### PR TITLE
Hb devel dspv2

### DIFF
--- a/base/smurf_control.py
+++ b/base/smurf_control.py
@@ -230,15 +230,15 @@ class SmurfControl(SmurfCommandMixin, SmurfUtilMixin, SmurfTuneMixin,
         self.fraction_full_scale = self.config.get('tune_band').get('fraction_full_scale')
         smurf_init_config = self.config.get('init')
         bands = smurf_init_config['bands']
+        # Load in tuning parameters, if present
+        tune_band_cfg=self.config.get('tune_band')
+        tune_band_keys=tune_band_cfg.keys()
         for b in bands:
             # Make band dictionaries
             self.freq_resp[b] = {}
             self.freq_resp[b]['lock_status'] = {}
-            self.lms_freq_hz[b] = 4000
+            self.lms_freq_hz[b] = tune_band_cfg['lms_freq'][str(b)]
 
-        # Load in tuning parameters, if present
-        tune_band_cfg=self.config.get('tune_band')
-        tune_band_keys=tune_band_cfg.keys()
         for cfg_var in ['gradient_descent_gain', 'gradient_descent_averages', 'eta_scan_averages']:
             if cfg_var in tune_band_keys:
                 setattr(self, cfg_var, {})

--- a/cfg_files/experiment_fp29_smurfsrv03_noExtRef_hbOnlyBay0.cfg
+++ b/cfg_files/experiment_fp29_smurfsrv03_noExtRef_hbOnlyBay0.cfg
@@ -1,0 +1,198 @@
+{
+"epics_root" : "test_epics",
+"init": {
+	"bands" : [2,3],
+	"dspEnable": 1,
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		"toneScale" : 2,
+		"analysisScale" : 3,
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"synthesisScale": 3,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"rfEnable": 1,
+		"bandCenterMHz": 5250,
+		"data_out_mux" : [6, 7],
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 11
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		"toneScale" : 2,
+		"analysisScale" : 3,
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"synthesisScale": 3,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"rfEnable": 1,
+		"bandCenterMHz": 5750,
+		"data_out_mux" : [8, 9],
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 11
+	}
+},
+
+"bad_mask" : {
+},
+
+"channel_assignment" : {
+		     "band_2" : "/usr/local/controls/Applications/smurf/pysmurf/pysmurf/scratch/shawn/channel_assignment_b2_teses.txt",
+		     "band_3" : "/usr/local/controls/Applications/smurf/pysmurf/pysmurf/scratch/shawn/channel_assignment_b3.txt"
+},
+
+"amplifier": {
+	     "hemt_Vg" : 0.60,
+	     "bit_to_V_hemt" : 1.92e-6,
+	     "hemt_Id_offset" : 1.00546875,
+	     "LNA_Vg" : -0.718,
+	     "dac_num_50k" : 2,
+	     "bit_to_V_50k" : 3.88e-6,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+"pic_to_bias_group": {
+	"9" : 8,
+	"11" : 10,
+	"13" : 12,
+	"15" : 14,
+	"14" : 15,
+	"12" : 13,
+	"10" : 11,
+	"8" : 9,
+	"7" : 6,
+	"5" : 4,
+	"3" : 2,
+	"1" : 0,
+	"6" : 7,
+	"4" : 5,
+	"2" : 3,
+	"0" : 1
+},
+
+"bias_group_to_pair" : {
+	"8" : [2,1],
+	"10": [4,3],
+	"12": [6,5],
+	"14": [8,7],
+	"15": [10,9],
+	"13": [12,11],
+	"11": [14,13],
+	"9": [16,15],
+	"6": [18,17],
+	"4": [20,19],
+	"2": [22,21],
+	"0": [24,23],
+	"7": [26,25],
+	"5": [28,27],
+	"3": [30,29],
+	"1": [32,31]
+},
+
+"band_to_chip" : {
+	"1" : [1, 2, 3, 4],
+	"2" : [5, 6, 7, 8],
+	"3" : [9, 10, 11, 12],
+	"4" : [13, 14, 15, 16]
+},
+
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 25479,
+"high_low_current_ratio" : 12.50,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [3],
+
+"tune_band" : {
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	"fraction_full_scale": 0.495,
+	"lms_freq": {
+		    "2" : 16660,
+		    "3" : 19500
+        },
+	"gradient_descent_gain": {
+		    "2" : 1e-5,
+		    "3" : 1e-5
+        },
+	"gradient_descent_averages": {
+		    "2" : 10,
+		    "3" : 10
+        },
+	"eta_scan_averages": {
+		    "2" : 10,
+		    "3" : 10
+        },
+	"default_tune": "/data/smurf_data/tune/1547959798_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"ramp_start_mode" : 0,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 4,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 0,
+	"data_frames" : 2000000,
+	"static_mask" : 0,
+	"num_averages" : 20
+	
+},
+
+"default_data_dir": "/data/smurf_data",
+"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/cfg_files/experiment_fp29_smurfsrv03_noExtRef_hbOnlyBay0.cfg
+++ b/cfg_files/experiment_fp29_smurfsrv03_noExtRef_hbOnlyBay0.cfg
@@ -144,10 +144,10 @@
 	"amp_cut" : 0.25,
 	"freq_max" : 250000000,
 	"freq_min" : -250000000,
-	"fraction_full_scale": 0.495,
+	"fraction_full_scale": 0.65,
 	"lms_freq": {
-		    "2" : 16660,
-		    "3" : 19500
+		    "2" : 8520,
+		    "3" : 8520
         },
 	"gradient_descent_gain": {
 		    "2" : 1e-5,
@@ -161,7 +161,7 @@
 		    "2" : 10,
 		    "3" : 10
         },
-	"default_tune": "/data/smurf_data/tune/1547959798_tune.npy"
+	"default_tune": "/data/smurf_data/tune/1555011900_tune.npy"
 },
 
 "flux_ramp" : {

--- a/debug/smurf_noise.py
+++ b/debug/smurf_noise.py
@@ -122,8 +122,10 @@ class SmurfNoiseMixin(SmurfBase):
                 ax[1].plot(f, Pxx)
                 if good_fit:
                     ax[1].plot(f_fit,Pxx_fit,linestyle = '--',label=r'$n=%.2f$' % (n))
-                    ax[1].plot(f_knee,2.*wl,linestyle = 'none',marker = 'o',label=r'$f_\mathrm{knee} = %.2f\,\mathrm{Hz}$' % (f_knee))
-                    ax[1].plot(f_fit,wl + np.zeros(len(f_fit)),linestyle = ':',label=r'$\mathrm{wl} = %.0f\,\mathrm{pA}/\sqrt{\mathrm{Hz}}$' % (wl))
+                    ax[1].plot(f_knee,2.*wl,linestyle = 'none',marker = 'o',
+                        label=r'$f_\mathrm{knee} = %.2f\,\mathrm{Hz}$' % (f_knee))
+                    ax[1].plot(f_fit,wl + np.zeros(len(f_fit)),linestyle = ':',
+                        label=r'$\mathrm{wl} = %.0f\,\mathrm{pA}/\sqrt{\mathrm{Hz}}$' % (wl))
                     ax[1].legend(loc='best')
                 ax[1].set_xlabel('Frequency [Hz]')
                 ax[1].set_xlim(f[1],f[-1])
@@ -330,12 +332,14 @@ class SmurfNoiseMixin(SmurfBase):
         if amplitudes is None:
             if step_size > 0:
                 step_size *= -1
-            amplitudes = np.arange(amplitude_high, amplitude_low-np.absolute(step_size), step_size)
+            amplitudes = np.arange(amplitude_high, 
+                amplitude_low-np.absolute(step_size), step_size)
 
         self.noise_vs(band=band,var='amplitude',var_range=amplitudes,
-                 meas_time=meas_time, analyze=analyze, channel=channel, nperseg=nperseg,
-                 detrend=detrend, fs=fs, show_plot=show_plot, make_timestream_plot=make_timestream_plot,
-                 gcp_mode=gcp_mode, psd_ylim=psd_ylim)
+                 meas_time=meas_time, analyze=analyze, channel=channel, 
+                 nperseg=nperseg, detrend=detrend, fs=fs, show_plot=show_plot, 
+                 make_timestream_plot=make_timestream_plot, gcp_mode=gcp_mode, 
+                 psd_ylim=psd_ylim)
 
     def noise_vs(self, band, var, var_range, 
                  meas_time=30, analyze=False, channel=None, nperseg=2**13,
@@ -393,10 +397,14 @@ class SmurfNoiseMixin(SmurfBase):
                 unit_override=''
                 xlabel_override='Tone amplitude [unit-less]'
                 self.log('Retuning at tone amplitude {}'.format(v))
-                self.set_amplitude_scale_array(band,np.array(self.get_amplitude_scale_array(band)*v/np.max(self.get_amplitude_scale_array(band)),dtype=int)) 
+                self.set_amplitude_scale_array(band,
+                    np.array(self.get_amplitude_scale_array(band)*v/
+                        np.max(self.get_amplitude_scale_array(band)),dtype=int)) 
                 self.run_serial_gradient_descent(band)
                 self.run_serial_eta_scan(band)
-                self.tracking_setup(band,lms_freq_hz=self.lms_freq_hz[band],save_plot=True, make_plot=True, channel=self.which_on(band),show_plot=False)
+                self.tracking_setup(band,lms_freq_hz=self.lms_freq_hz[band],
+                    save_plot=True, make_plot=True, channel=self.which_on(band),
+                    show_plot=False)
 
             self.log('Taking data')
             datafile = self.take_stream_data(meas_time,gcp_mode=gcp_mode)
@@ -420,12 +428,16 @@ class SmurfNoiseMixin(SmurfBase):
                                        data_timestamp=timestamp, 
                                        gcp_mode=gcp_mode,psd_ylim=psd_ylim,
                                        make_timestream_plot=make_timestream_plot,
-                                       xlabel_override=xlabel_override, unit_override=unit_override)
+                                       xlabel_override=xlabel_override, 
+                                       unit_override=unit_override)
 
     def get_datafiles_from_file(self,fn_datafiles):
         '''
-        For, e.g., noise_vs_bias, the list of datafiles is recorded in a txt file. This function
-        simply extracts those filenames and returns them as a list.
+        For, e.g., noise_vs_bias, the list of datafiles is recorded in a txt file. 
+        This function simply extracts those filenames and returns them as a list.
+
+        Args:
+        -----
         fn_datafiles (str): full path to txt containing names of data files
         Returns: datafiles (list): strings of data-file names.
         '''
@@ -437,8 +449,12 @@ class SmurfNoiseMixin(SmurfBase):
 
     def get_biases_from_file(self,fn_biases,dtype=float):
         '''
-        For, e.g., noise_vs_bias, the list of commanded bias voltages is recorded in a txt file.
-        This function simply extracts those values and returns them as a list.
+        For, e.g., noise_vs_bias, the list of commanded bias voltages is 
+        recorded in a txt file. This function simply extracts those values and 
+        returns them as a list.
+
+        Args:
+        -----
         fn_biases (str): full path to txt containing list of bias voltages
         Returns biases (list): floats of commanded bias voltages
         '''
@@ -580,7 +596,8 @@ class SmurfNoiseMixin(SmurfBase):
         if iv_data_filename is not None and band is not None:
             iv_band_data = self.get_iv_data(iv_data_filename,band,
                                            high_current_mode=high_current_mode)
-            self.log('IV data given. Estimating NEP. Skipping noise analysis for channels without responsivity estimates.')
+            self.log('IV data given. Estimating NEP. Skipping noise analysis'
+                ' for channels without responsivity estimates.')
             est_NEP = True
         else:
             est_NEP = False

--- a/debug/smurf_noise.py
+++ b/debug/smurf_noise.py
@@ -96,7 +96,8 @@ class SmurfNoiseMixin(SmurfBase):
                     f_knees[ch]=f_knee
                     n_list.append(n)
                     good_fit = True    
-                self.log('%i. Band %i, ch. %i:' % (c+1,band,ch) + ' white-noise level = {:.2f}'.format(wl) +
+                self.log('%i. Band %i, ch. %i:' % (c+1,band,ch) + 
+                    ' white-noise level = {:.2f}'.format(wl) +
                         ' pA/rtHz, n = {:.2f}'.format(n) + 
                         ', f_knee = {:.2f} Hz'.format(f_knee))
             except Exception as e:
@@ -736,7 +737,8 @@ class SmurfNoiseMixin(SmurfBase):
                     idxs_est = np.logical_and(f>=freq_min,f<=freq_max)
                     noise_est = np.mean(Pxx[idxs_est])
                     self.log('ch. {}, bias = {:.2f}'.format(ch,b) + 
-                             ', mean current noise between {:.3e} and {:.3e} Hz = {:.2f} pA/rtHz'.format(freq_min,freq_max,noise_est))
+                             ', mean current noise between ' + 
+                             '{:.3e} and {:.3e} Hz = {:.2f} pA/rtHz'.format(freq_min,freq_max,noise_est))
                 else:
                     noise_est = wl
                 noise_est_list.append(noise_est)
@@ -773,7 +775,8 @@ class SmurfNoiseMixin(SmurfBase):
                         R_frac_max = R[nb_idx]/R_n
                         for ax in [ax_NEIwl,ax_NEPwl,ax_SI]:
                             if ax == ax_SI:
-                                label_Rfrac = r'{:.2f}-{:.2f}'.format(R_frac_min,R_frac_max) + r'$R_\mathrm{N}$'
+                                label_Rfrac = r'{:.2f}-{:.2f}'.format(R_frac_min,R_frac_max) + \
+                                    r'$R_\mathrm{N}$'
                             else:
                                 label_Rfrac = None
                             ax.axvspan(iv_bias[sc_idx],iv_bias[nb_idx],
@@ -826,7 +829,8 @@ class SmurfNoiseMixin(SmurfBase):
             if est_NEP:
                 ax_NEPwl.set_ylabel(r'NEP %s [$\mathrm{aW}/\sqrt{\mathrm{Hz}}$]' % \
                                    (ylabel_summary))
-                ax_SI.set_ylabel(r'Estimated responsivity with $\beta = 0$ [$\mu\mathrm{V}^{-1}$]')
+                ax_SI.set_ylabel(r'Estimated responsivity with $\beta' + 
+                    r' = 0$ [$\mu\mathrm{V}^{-1}$]')
                 
                 bottom_NEP = 0.95*min(NEP_est_list)
                 top_NEP_desired = 1.05*max(NEP_est_list)
@@ -865,7 +869,9 @@ class SmurfNoiseMixin(SmurfBase):
                 file_name_string = str(bias_group) + '_'
 
                 
-            fig.suptitle(basename + ' Band {}, Group {} Channel {:03} - {:.2f} MHz'.format(band,fig_title_string,ch, res_freq))
+            fig.suptitle(basename + 
+                ' Band {}, Group {}'.format(band,fig_title_string) + 
+                ' Channel {:03} - {:.2f} MHz'.format(ch, res_freq))
             #fig.subplots_adjust(top=0.1)
             plt.tight_layout()
             #plt.tight_layout(rect=[0.,0.03,1.,0.97])
@@ -874,8 +880,8 @@ class SmurfNoiseMixin(SmurfBase):
                 plt.show()
 
             if save_plot:
-                plot_name = 'noise_vs_bias_band{}_g{}ch{:03}.png'.format(band,file_name_string,
-                    ch)
+                plot_name = 'noise_vs_bias_band{}_g{}ch{:03}.png'.format(band,
+                    file_name_string, ch)
                 if data_timestamp is not None:
                     plot_name = '{}_'.format(data_timestamp) + plot_name
                 else:
@@ -936,7 +942,8 @@ class SmurfNoiseMixin(SmurfBase):
         plt.yscale('log')
         plt.ylabel(r'NEI %s [$\mathrm{pA}/\sqrt{\mathrm{Hz}}$]' % (ylabel_summary))
         plt.ylim(10**bin_min,10**bin_max)
-        plt.title(basename + ': Band {}, Group {}, {} channels'.format(band,fig_title_string.strip(','),n_analyzed))
+        plt.title(basename + 
+            ': Band {}, Group {}, {} channels'.format(band,fig_title_string.strip(','),n_analyzed))
         xtick_labels = []
         for b in bias:
             xtick_labels.append('{}'.format(b))
@@ -972,16 +979,19 @@ class SmurfNoiseMixin(SmurfBase):
             hist_NEP_mat = np.zeros((len(bins_NEP_hist)-1,len(bias)))
             NEP_est_median_list = []
             for i in range(len(bias)):
-                hist_NEP_mat[:,i],_ = np.histogram(NEP_est_data_bias[i],bins=bins_NEP_hist)
+                hist_NEP_mat[:,i],_ = np.histogram(NEP_est_data_bias[i],
+                    bins=bins_NEP_hist)
                 NEP_est_median_list.append(np.median(NEP_est_data_bias[i]))
-            X_NEP_hist,Y_NEP_hist = np.meshgrid(np.arange(len(bias),-1,-1),bins_NEP_hist)
+            X_NEP_hist,Y_NEP_hist = np.meshgrid(np.arange(len(bias),-1,-1),
+                bins_NEP_hist)
             plt.pcolor(X_NEP_hist,Y_NEP_hist,hist_NEP_mat)
             cbar_NEP = plt.colorbar()
             cbar_NEP.set_label('Number of channels')
             plt.yscale('log')
             plt.ylabel(r'NEP %s [$\mathrm{aW}/\sqrt{\mathrm{Hz}}$]' % (ylabel_summary))
             plt.ylim(10**bin_NEP_min,10**bin_NEP_max)
-            plt.title(basename + ': Band {}, Group {}, {} channels'.format(band,fig_title_string.strip(','),n_analyzed))
+            plt.title(basename + 
+                ': Band {}, Group {}, {} channels'.format(band,fig_title_string.strip(','),n_analyzed))
             plt.xticks(xtick_locs,xtick_labels)
             plt.xlabel('Commanded bias voltage [V]')
             plt.plot(xtick_locs,NEP_est_median_list,linestyle='--',marker='o',
@@ -1136,18 +1146,29 @@ class SmurfNoiseMixin(SmurfBase):
         return wl_diff
 
 
-    def NET_CMB(self,NEI,V_b,R_tes,opt_eff,f_center=150e9,bw=32e9,R_sh=None,high_current_mode=False):
+    def NET_CMB(self, NEI, V_b, R_tes, opt_eff, f_center=150e9, bw=32e9,
+        R_sh=None, high_current_mode=False):
         '''
-        Converts current spectral noise density to NET in uK rt(s). Assumes NEI is white-noise level.
+        Converts current spectral noise density to NET in uK rt(s). Assumes NEI 
+        is white-noise level.
 
+        Args
+        ----
         NEI (float): current spectral density in pA/rtHz
         V_b (float): commanded bias voltage in V
         R_tes (float): resistance of TES at bias point in Ohm
         opt_eff (float): optical efficiency (in the range 0-1)
+
+        Opt Args:
+        ---------
         f_center (float): center optical frequency of detector in Hz, e.g., 150 GHz for E4c
         bw (float): effective optical bandwidth of detector in Hz, e.g., 32 GHz for E4c
         R_sh (float): shunt resistance in Ohm; defaults to stored config figure
         high_current_mode (bool): whether the bias voltage was set in high-current mode
+
+        Ret:
+        ----
+        NET (float) : The noise equivalent temperature in units of uKrts
         '''
         NEI *= 1e-12 # bring NEI to SI units, i.e., A/rt(Hz)
         if high_current_mode:
@@ -1160,6 +1181,7 @@ class SmurfNoiseMixin(SmurfBase):
         T_CMB = 2.7
         dPdT = opt_eff*tools.dPdT_singleMode(f_center,bw,T_CMB)
         NET_SI = NEP/(dPdT*np.sqrt(2.)) # NET in SI units, i.e., K rt(s)
+
         return NET_SI/1e-6 # NET in uK rt(s)
 
     def analyze_noise_vs_tone(self, tone, datafile, channel=None, band=None,
@@ -1331,7 +1353,8 @@ class SmurfNoiseMixin(SmurfBase):
                 fig_title_string = str(bias_group) + ','
                 file_name_string = str(bias_group) + '_'
 
-            ax[0].set_title(basename + ' Band {}, Group {} Channel {:03} - {:.2f} MHz'.format(band,fig_title_string,ch, res_freq))
+            ax[0].set_title(basename + 
+                ' Band {}, Group {} Channel {:03} - {:.2f} MHz'.format(band,fig_title_string,ch, res_freq))
             plt.tight_layout(rect=[0.,0.03,1.,1.0])
 
             if show_plot:

--- a/scratch/shawn/init_dev.py
+++ b/scratch/shawn/init_dev.py
@@ -2,7 +2,7 @@ import pysmurf
 import matplotlib.pylab as plt
 import numpy as np
 
-epics_prefix = 'smurf_server'                                                                                  
+epics_prefix = 'smurf_server_s5' 
 config_file='/data/pysmurf_cfg/experiment_fp29_smurfsrv03_noExtRef_hbOnlyBay0.cfg'
 
 S = pysmurf.SmurfControl(epics_root=epics_prefix,cfg_file=config_file,setup=False,make_logfile=False) 

--- a/scratch/shawn/init_dev.py
+++ b/scratch/shawn/init_dev.py
@@ -1,0 +1,8 @@
+import pysmurf
+import matplotlib.pylab as plt
+import numpy as np
+
+epics_prefix = 'smurf_server'                                                                                  
+config_file='/data/pysmurf_cfg/experiment_fp29_smurfsrv03_noExtRef_hbOnlyBay0.cfg'
+
+S = pysmurf.SmurfControl(epics_root=epics_prefix,cfg_file=config_file,setup=False,make_logfile=False) 

--- a/scratch/shawn/measureFluxRampFvsV.py
+++ b/scratch/shawn/measureFluxRampFvsV.py
@@ -6,18 +6,20 @@ import sys
 ## instead of takedebugdata try relaunch PyRogue, then loopFilterOutputArray, which is 
 ## the integral tracking term with lmsEnable[1..3]=0
 
-S = pysmurf.SmurfControl(make_logfile=False,setup=False,epics_root='smurf_server',cfg_file='/data/pysmurf_cfg/experiment_fp29_smurfsrv03_noExtRef_hbOnlyBay0.cfg')
+S = pysmurf.SmurfControl(make_logfile=False,setup=False,epics_root='smurf_server_s5',cfg_file='/home/cryo/docker/pysmurf/hb-devel-dspv2/pysmurf/cfg_files/experiment_fp29_smurfsrv03_noExtRef_hbOnlyBay0.cfg')
 
 #######
-band=2
+hbInBay0=True
+bands=[2,3]
 Npts=3
 bias=None
 wait_time=.05
 #bias_low=-0.432
 #bias_high=0.432
-bias_low=-0.325*2
-bias_high=0.325*2
-bias_step=.0015
+bias_low=-0.65
+bias_high=0.65
+Nsteps=1000
+bias_step=np.abs(bias_high-bias_low)/float(Nsteps)
 show_plot=False
 make_plot=True
 save_plot=True 
@@ -30,153 +32,102 @@ use_take_debug_data=False
 
 # Look for good channels
 if channels is None:
-    channels = S.which_on(band)
+    channels = {}
+    for band in bands:
+        channels[band] = S.which_on(band)
+print(channels[band])
 
 if bias is None:
     bias = np.arange(bias_low, bias_high, bias_step)
 
-S.set_lms_enable1(band, 0)
-S.set_lms_enable2(band, 0)
-S.set_lms_enable3(band, 0)
+# final output data dictionary
+raw_data = {}
+print(channels[band])
+bands_with_channels_on=[]
+for band in bands:
+    print(band,channels[band])
+    if len(channels[band])>0:
+        S.log('{} channels on in band {}, configuring band for simple, integral tracking'.format(len(channels[band]),band))
+        S.log('-> Setting lmsEnable[1-3] and lmsGain to 0 for band {}.'.format(band), S.LOG_USER)
+        S.set_lms_enable1(band, 0)
+        S.set_lms_enable2(band, 0)
+        S.set_lms_enable3(band, 0)
+        S.set_lms_gain(band, 0)
 
-S.log('Turning lmsGain to 0.', S.LOG_USER)
-lms_gain = S.get_lms_gain(band)
-S.set_lms_gain(band, 0)
+        raw_data[band]={}
 
-S.log('Staring to take flux ramp.', S.LOG_USER)
+        bands_with_channels_on.append(band)
 
-sys.stdout.write('\rSetting flux ramp bias low at {:4.3f} V\033[K'.format(bias_low))
-S.set_fixed_flux_ramp_bias(bias_low)
-time.sleep(wait_time)
+bands=bands_with_channels_on
 
-fs=[]
-for b in bias:
-    sys.stdout.write('\rFlux ramp bias at {:4.3f} V\033[K'.format(b))
-    sys.stdout.flush()
-    S.set_fixed_flux_ramp_bias(b)
+amplitudes=[9,10,11,12,13,14,15]
+for amplitude in amplitudes:
+
+    ### begin retune on all bands with tones
+    for band in bands:
+        S.log('Retuning at tone amplitude {}'.format(amplitude))
+        S.set_amplitude_scale_array(band,np.array(S.get_amplitude_scale_array(band)*amplitude/np.max(S.get_amplitude_scale_array(band)),dtype=int))
+        S.run_serial_gradient_descent(band)
+        S.run_serial_eta_scan(band)
+        raw_data[band][amplitude]={}
+        
+    ### end retune
+    S.log('Starting to take flux ramp with amplitude={}.'.format(amplitude), S.LOG_USER)
+
+    sys.stdout.write('\rSetting flux ramp bias low at {:4.3f} V\033[K'.format(bias_low))
+    S.set_fixed_flux_ramp_bias(bias_low)
     time.sleep(wait_time)
 
-    if use_take_debug_data:
-        f,df,sync=S.take_debug_data(band,IQstream=False,single_channel_readout=0)
-        fsampmean=np.mean(f,axis=0)
-        fs.append(fsampmean)
-    else:
-        fsamp=np.zeros(shape=(Npts,len(channels)))
-        for i in range(Npts):
-            fsamp[i,:]=S.get_loop_filter_output_array(band)[channels]
-        fsampmean=np.mean(fsamp,axis=0)
-        fs.append(fsampmean)
+    fs={}
+    for band in bands:
+        fs[band]=[]
 
-sys.stdout.write('\n')
+    for b in bias:
+        sys.stdout.write('\rFlux ramp bias at {:4.3f} V\033[K'.format(b))
+        sys.stdout.flush()
+        S.set_fixed_flux_ramp_bias(b)
+        time.sleep(wait_time)
+
+        for band in bands:
+            if use_take_debug_data:
+                f,df,sync=S.take_debug_data(band,IQstream=False,single_channel_readout=0)
+                fsampmean=np.mean(f,axis=0)
+                fs[band].append(fsampmean)
+            else:
+                fsamp=np.zeros(shape=(Npts,len(channels[band])))
+                for i in range(Npts):
+                    fsamp[i,:]=S.get_loop_filter_output_array(band)[channels[band]]
+                fsampmean=np.mean(fsamp,axis=0)
+                fs[band].append(fsampmean)
+
+    sys.stdout.write('\n')
+
+    S.log('Done taking flux ramp with amplitude={}.'.format(amplitude), S.LOG_USER)
+
+    for band in bands:
+
+        fres=[S.channel_to_freq(band, ch) for ch in channels[band]]
+        raw_data[band][amplitude]['fres']=np.array(fres) + (2e3 if hbInBay0 else 0)
+        raw_data[band][amplitude]['channels']=channels[band]
+
+        if use_take_debug_data:
+            #stack
+            fovsfr=np.dstack(fs[band])[0]
+            [sbs,sbc]=S.get_subband_centers(band)
+            fvsfr=fovsfr[channels[band]]+[sbc[np.where(np.array(sbs)==S.get_subband_from_channel(band,ch))[0]]+S.get_band_center_mhz(band) for ch in channels[band]]
+            raw_data[band][amplitude]['fvsfr']=fvsfr + (2e3 if hbInBay0 else 0)
+        else:
+            #stack
+            lfovsfr=np.dstack(fs[band])[0]
+            raw_data[band][amplitude]['lfovsfr']=lfovsfr
+            raw_data[band][amplitude]['fvsfr']=np.array([arr/4.+fres for (arr,fres) in zip(lfovsfr,fres)]) + (2e3 if hbInBay0 else 0)
+
+raw_data['bias'] = bias
 
 # done - zero and unset
 S.set_fixed_flux_ramp_bias(0)
 S.unset_fixed_flux_ramp_bias()
 
-raw_data = {}
-
-fres=[S.channel_to_freq(band, ch) for ch in channels]
-raw_data['fres']=fres
-raw_data['channels']=channels
-
-if use_take_debug_data:
-    #stack
-    fovsfr=np.dstack(fs)[0]
-    [sbs,sbc]=S.get_subband_centers(band)
-    fvsfr=fovsfr[channels]+[sbc[np.where(np.array(sbs)==S.get_subband_from_channel(band,ch))[0]]+S.get_band_center_mhz(band) for ch in channels]
-    raw_data['fvsfr']=fvsfr
-else:
-    #stack
-    lfovsfr=np.dstack(fs)[0]
-    raw_data['lfovsfr']=lfovsfr
-    raw_data['fvsfr']=np.array([arr/4.+fres for (arr,fres) in zip(lfovsfr,fres)])
-
-raw_data['bias'] = bias
-raw_data['band'] = band
-
 import os
 fn_raw_data = os.path.join('./', '%s_fr_sweep_data.npy'%(S.get_timestamp()))
 np.save(fn_raw_data, raw_data)
-
-###
-import matplotlib.pylab as plt
-# if loading from file *.item(); e.g.;
-#d=np.load('1543444743_fr_sweep_data.npy')
-#raw_data=d.item()
-def plot(chans,raw_data):
-    for ch in chans:
-        chf=raw_data['fvsfr'][np.where(raw_data['channels']==ch)[0][0]]
-        chf=chf-np.mean(chf)
-        plt.plot(raw_data['bias'],chf,label='ch%d'%ch)
-    plt.xlabel('fraction fullscale (one-sided)')
-    plt.ylabel('Foff (MHz)')
-    plt.legend()
-    plt.show()
-###
-
-sys.exit(1)
-
-plot([385],raw_data)
-
-## try to analyze
-def fourier(x, *a):
-    ret = a[3] + a[2] * np.sin(np.pi / a[1] * (x - a[0] ) )
-    for deg in range(4, len(a)):
-        ret += a[deg] * np.sin((deg+1) * np.pi / a[1] * (x - a[0]) )
-    return ret
-
-from scipy import signal
-from scipy.optimize import curve_fit
-def analyze(ch,raw_data):
-    chf=raw_data['fvsfr'][np.where(raw_data['channels']==ch)[0][0]]
-    bias=raw_data['bias']
-    
-    #peakind = signal.find_peaks_cwt(chf, np.linspace(0.05,0.4,4))
-
-    biasspan=np.max(bias)-np.min(bias)
-    fspan=np.max(chf)-np.min(chf)
-    fmean=np.mean(chf)
-    meanschf=chf-fmean
-    peakind=signal.find_peaks(meanschf,threshold=0,distance=20)[0]
-
-    Fres=S.channel_to_freq(raw_data['band'],ch)
-    if len(peakind)==0:
-        return
-    try:
-        qest=np.abs(bias[peakind[1]]-bias[peakind[0]])/2.
-        phest=np.max(np.diff(bias[peakind]))
-    except:
-        plt.plot(bias,chf,label='ch%d data'%(ch))    
-        plt.title('ch%d -- FAILED'%(ch))
-        print('ch%d FAILED!'%ch)
-        plt.legend()
-        plt.show()
-        return
-
-    Fres=S.channel_to_freq(raw_data['band'],ch)
-    print('%d\t%0.3f\t%0.4f\t%0.4f\n'%(ch,Fres,phest,fspan))
-    of=open('phest.dat','a+')
-    of.write('%d\t%0.3f\t%0.4f\n'%(ch,Fres,phest))
-    of.close()
-
-    plt.plot(bias,chf,label='ch%d data'%(ch))    
-    plt.scatter(bias[peakind],chf[peakind],label='maxes')
-
-    plt.title('ch%d  Fres=%0.3f  phest=%0.4f%%'%(ch,Fres,phest))
-
-#    # fit first harmonic
-#    p0=[qest+phest/2,qest,fspan/2,fmean]
-#    param_bounds=([0,        biasspan/20., -np.inf,-np.inf],
-#                  [2.*np.pi,     biasspan,  np.inf, np.inf])
-#    popt, pcov = curve_fit(fourier, bias, chf, p0, bounds=param_bounds)
-#
-#    plt.plot(bias,fourier(bias,*p0),'g--',label='1st harmonic guess')
-#    plt.plot(bias,fourier(bias,*popt),label='fit')
-#    
-    plt.legend()
-    plt.savefig('ch%d.png'%ch)
-
-#for ch in raw_data['channels']:                                    
-#    analyze(ch,raw_data)                                              
-#    plt.waitforbuttonpress()                                          
-#    plt.clf() 

--- a/scratch/shawn/measureFluxRampFvsV.py
+++ b/scratch/shawn/measureFluxRampFvsV.py
@@ -6,7 +6,7 @@ import sys
 ## instead of takedebugdata try relaunch PyRogue, then loopFilterOutputArray, which is 
 ## the integral tracking term with lmsEnable[1..3]=0
 
-S = pysmurf.SmurfControl(make_logfile=False,setup=False,epics_root='test_epics2',cfg_file='/usr/local/controls/Applications/smurf/pysmurf/pysmurf/cfg_files/experiment_fp29_smurfsrv04.cfg')
+S = pysmurf.SmurfControl(make_logfile=False,setup=False,epics_root='smurf_server',cfg_file='/data/pysmurf_cfg/experiment_fp29_smurfsrv03_noExtRef_hbOnlyBay0.cfg')
 
 #######
 band=2
@@ -15,8 +15,8 @@ bias=None
 wait_time=.05
 #bias_low=-0.432
 #bias_high=0.432
-bias_low=-0.45
-bias_high=0.45
+bias_low=-0.325*2
+bias_high=0.325*2
 bias_step=.0015
 show_plot=False
 make_plot=True

--- a/scratch/shawn/pole/measureFluxRampFvsV_atPole.py
+++ b/scratch/shawn/pole/measureFluxRampFvsV_atPole.py
@@ -1,0 +1,136 @@
+import matplotlib
+matplotlib.use('Agg')
+
+import pysmurf
+import numpy as np
+import time
+import sys
+
+## instead of takedebugdata try relaunch PyRogue, then loopFilterOutputArray, which is 
+## the integral tracking term with lmsEnable[1..3]=0
+
+S = pysmurf.SmurfControl(make_logfile=False,setup=False,epics_root='smurf_server_s5',cfg_file='/home/cryo/docker/pysmurf/hb-devel-dspv2/pysmurf/cfg_files/experiment_fp29_smurfsrv03_noExtRef_hbOnlyBay0.cfg')
+
+#######
+hbInBay0=False
+bands=[2,3]
+Npts=3
+bias=None
+#wait_time=.05
+wait_time=1.
+#bias_low=-0.432
+#bias_high=0.432
+bias_low=-0.8
+bias_high=0.8
+Nsteps=250
+#Nsteps=25
+bias_step=np.abs(bias_high-bias_low)/float(Nsteps)
+channels=None
+#much slower than using loopFilterOutputArray,
+#and creates a bunch of files
+use_take_debug_data=False
+
+# Look for good channels
+if channels is None:
+    channels = {}
+    for band in bands:
+        channels[band] = S.which_on(band)
+print(channels[band])
+
+if bias is None:
+    bias = np.arange(bias_low, bias_high, bias_step)
+
+# final output data dictionary
+raw_data = {}
+print(channels[band])
+bands_with_channels_on=[]
+for band in bands:
+    print(band,channels[band])
+    if len(channels[band])>0:
+        S.log('{} channels on in band {}, configuring band for simple, integral tracking'.format(len(channels[band]),band))
+        S.log('-> Setting lmsEnable[1-3] and lmsGain to 0 for band {}.'.format(band), S.LOG_USER)
+        S.set_lms_enable1(band, 0)
+        S.set_lms_enable2(band, 0)
+        S.set_lms_enable3(band, 0)
+        S.set_lms_gain(band, 0)
+
+        raw_data[band]={}
+
+        bands_with_channels_on.append(band)
+
+bands=bands_with_channels_on
+
+#amplitudes=[9,10,11,12,13,14,15]
+# [None] means don't change the amplitude, but still retunes
+amplitudes=[None]
+for amplitude in amplitudes:
+
+    ### begin retune on all bands with tones
+    for band in bands:
+        S.log('Retuning at tone amplitude {}'.format(amplitude))
+        if amplitude is not None:
+            S.set_amplitude_scale_array(band,np.array(S.get_amplitude_scale_array(band)*amplitude/np.max(S.get_amplitude_scale_array(band)),dtype=int))
+        S.run_serial_gradient_descent(band)
+        S.run_serial_eta_scan(band)
+        raw_data[band][amplitude]={}
+        
+    ### end retune
+    S.log('Starting to take flux ramp with amplitude={}.'.format(amplitude), S.LOG_USER)
+
+    sys.stdout.write('\rSetting flux ramp bias low at {:4.3f} V\033[K'.format(bias_low))
+    S.set_fixed_flux_ramp_bias(bias_low)
+    time.sleep(wait_time)
+
+    fs={}
+    for band in bands:
+        fs[band]=[]
+
+    for b in bias:
+        sys.stdout.write('\rFlux ramp bias at {:4.3f} V\033[K'.format(b))
+        sys.stdout.flush()
+        S.set_fixed_flux_ramp_bias(b)
+        time.sleep(wait_time)
+
+        for band in bands:
+            if use_take_debug_data:
+                f,df,sync=S.take_debug_data(band,IQstream=False,single_channel_readout=0)
+                fsampmean=np.mean(f,axis=0)
+                fs[band].append(fsampmean)
+            else:
+                fsamp=np.zeros(shape=(Npts,len(channels[band])))
+                for i in range(Npts):
+                    fsamp[i,:]=S.get_loop_filter_output_array(band)[channels[band]]
+                fsampmean=np.mean(fsamp,axis=0)
+                fs[band].append(fsampmean)
+
+    sys.stdout.write('\n')
+
+    S.log('Done taking flux ramp with amplitude={}.'.format(amplitude), S.LOG_USER)
+
+    for band in bands:
+
+        fres=[S.channel_to_freq(band, ch) for ch in channels[band]]
+        raw_data[band][amplitude]['fres']=np.array(fres) + (2e3 if hbInBay0 else 0)
+        raw_data[band][amplitude]['channels']=channels[band]
+
+        if use_take_debug_data:
+            #stack
+            fovsfr=np.dstack(fs[band])[0]
+            [sbs,sbc]=S.get_subband_centers(band)
+            fvsfr=fovsfr[channels[band]]+[sbc[np.where(np.array(sbs)==S.get_subband_from_channel(band,ch))[0]]+S.get_band_center_mhz(band) for ch in channels[band]]
+            raw_data[band][amplitude]['fvsfr']=fvsfr + (2e3 if hbInBay0 else 0)
+        else:
+            #stack
+            lfovsfr=np.dstack(fs[band])[0]
+            raw_data[band][amplitude]['lfovsfr']=lfovsfr
+            raw_data[band][amplitude]['fvsfr']=np.array([arr/4.+fres for (arr,fres) in zip(lfovsfr,fres)]) + (2e3 if hbInBay0 else 0)
+
+raw_data['bias'] = bias
+
+# done - zero and unset
+S.set_fixed_flux_ramp_bias(0)
+S.unset_fixed_flux_ramp_bias()
+
+import os
+fn_raw_data = os.path.join('./', '%s_fr_sweep_data.npy'%(S.get_timestamp()))
+np.save(fn_raw_data, raw_data)

--- a/tune/smurf_tune.py
+++ b/tune/smurf_tune.py
@@ -685,7 +685,7 @@ class SmurfTuneMixin(SmurfBase):
         else:
             plt.ioff()
 
-        timestamp = self.freq_resp[band]['timestamp']
+        timestamp = self.freq_resp[band]['find_freq']['timestamp'][0]
 
         fig, ax = plt.subplots(2,2, figsize=(10,6))
 

--- a/util/smurf_util.py
+++ b/util/smurf_util.py
@@ -917,7 +917,7 @@ class SmurfUtilMixin(SmurfBase):
 
     def channel_off(self, band, channel, **kwargs):
         """
-        Turns off tones for a single channel
+        Turns off the tone for a single channel by setting the amplitude to zero and disabling feedback.
         """
         self.log('Turning off band {} channel {}'.format(band, channel), 
             self.LOG_USER)


### PR DESCRIPTION
Shawn was working in this version with the HB on the NIST 7-8 GHz box we had installed in Frankenpolar in run 29.  For folks with access to the Frankenpolar pages in the SLAC SMuRF confluence, the best set of measurements to date taken with this branch are summarized here;

https://confluence.slac.stanford.edu/pages/viewpage.action?pageId=246770396

Nothing really substantial here, just some clean up and added documentation.  A quick summary of some notable things added in this branch;

- Configuration file cfg_files/experiment_fp29_smurfsrv03_noExtRef_hbOnlyBay0.cfg is the best one for running with the HB AMC on the NIST 7-8 GHz box in FP29.
- Big improvements to Shawn's SQUID curve measurement script - now supports taking data on multiple bands simultaneously, taking it vs amplitude with fast retuning, etc.
- Fixed bug where lms_freq_hz in config file was being ignored (and was hard-coded to 4 kHz).  This wasn't a problem as long as you explicitly specified it in any function you used that requires the lms_freq, but if you ever forgot it was a pretty confusing bug.
- Added some clarification to the documentation to the channel_off function to make it clear what it actually does.
- Got noise_vs_amplitude basically working, and fixed most (but not all) of its plot labels.