### PR TITLE
Updating master with latest improvements to dspv2 from Pton MMBv1pp HB testing

### DIFF
--- a/base/smurf_config.py
+++ b/base/smurf_config.py
@@ -26,8 +26,23 @@ class SmurfConfig:
               update (bool): Whether or not to update the configuration.
         """
         if update:
+            comment_char='#'
             with open(self.filename) as config_file:
-                loaded_config = json.load(config_file)
+                no_comments=[]
+                for idx, line in enumerate(config_file):
+                    if line.lstrip().startswith(comment_char):
+                        # line starts with comment character - remove it
+                        continue
+                    elif comment_char in line:
+                        # there's a comment character on this line.
+                        # ignore it and everything that follows
+                        line=line.split('#')[0]
+                        no_comments.append(line)
+                    else:
+                        # will pass on to json parser
+                        no_comments.append(line)
+                        
+                loaded_config = json.loads('\n'.join(no_comments))
             
             # put in some logic here to make sure parameters in experiment file match 
             # the parameters we're looking for

--- a/cfg_files/pton/experiment_pc004_smurfsrv08_noExtRef.cfg
+++ b/cfg_files/pton/experiment_pc004_smurfsrv08_noExtRef.cfg
@@ -143,10 +143,10 @@
 	"amp_cut" : 0.25,
 	"freq_max" : 250000000,
 	"freq_min" : -250000000,
-	"fraction_full_scale": 0.495,
+	"fraction_full_scale": 0.500,
 	"lms_freq": {
-		    "2" : 16660,
-		    "3" : 19500
+		    "2" : 15951,
+		    "3" : 15951
         },
 	"gradient_descent_gain": {
 		    "2" : 1e-5,

--- a/cfg_files/pton/experiment_pc004_smurfsrv08_noExtRef.cfg
+++ b/cfg_files/pton/experiment_pc004_smurfsrv08_noExtRef.cfg
@@ -1,0 +1,196 @@
+{
+"epics_root" : "test_epics",
+"init": {
+	"bands" : [2,3],
+	"dspEnable": 1,
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 7,
+		"refPhaseDelayFine" : 105,
+		"toneScale" : 2,
+		"analysisScale" : 3,
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"synthesisScale": 3,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"rfEnable": 1,
+		"bandCenterMHz": 5250,
+		"data_out_mux" : [6, 7],
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 11
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 7,
+		"refPhaseDelayFine" : 105,
+		"toneScale" : 2,
+		"analysisScale" : 3,
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"synthesisScale": 3,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"rfEnable": 1,
+		"bandCenterMHz": 5750,
+		"data_out_mux" : [8, 9],
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 11
+	}
+},
+
+"bad_mask" : {
+},
+
+"channel_assignment" : {
+		     "band_2" : "/usr/local/controls/Applications/smurf/pysmurf/pysmurf/scratch/shawn/channel_assignment_b2_teses.txt",
+		     "band_3" : "/usr/local/controls/Applications/smurf/pysmurf/pysmurf/scratch/shawn/channel_assignment_b3.txt"
+},
+
+"amplifier": {
+	     "hemt_Vg" : -1.1,
+	     "bit_to_V_hemt" : 3.84e-6,
+	     "hemt_Id_offset" : 0.1611328,
+	     "LNA_Vg" : -0.630,
+	     "dac_num_50k" : 32,
+	     "bit_to_V_50k" : 3.88e-6,
+	     "hemt_gate_min_voltage" : -1.25,
+	     "hemt_gate_max_voltage" : 0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+"pic_to_bias_group": {
+        "0" : 0,
+	"1" : 1,
+	"2" : 2,
+	"3" : 3,
+	"4" : 4,
+	"5" : 5,
+	"6" : 6,
+	"7" : 7,
+	"8" : 8,
+	"9" : 9,
+	"10" : 10,
+	"11" : 11,
+	"12" : 12,
+	"13" : 13,
+	"14" : 14,
+	"15" : 15
+},
+
+"bias_group_to_pair" : {
+	"0" : [1,2],
+	"1" : [3,4],
+	"2" : [5,6],
+	"3" : [7,8],
+	"4" : [9,10],
+	"5" : [11,12],
+	"6" : [13,14],
+	"7" : [15,16],
+	"8" : [17,18],
+	"9" : [19,20],
+	"10" : [21,22],
+	"11" : [23,24],
+	"12" : [25,26],
+	"13" : [27,28],
+	"14" : [29,30]
+},
+
+"band_to_chip" : {
+	"1" : [1, 2, 3, 4],
+	"2" : [5, 6, 7, 8],
+	"3" : [9, 10, 11, 12],
+	"4" : [13, 14, 15, 16]
+},
+
+
+"R_sh" : 750e-6,
+"bias_line_resistance" : 15200.0,
+"high_low_current_ratio" : 6.08,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [3],
+
+"tune_band" : {
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	"fraction_full_scale": 0.495,
+	"lms_freq": {
+		    "2" : 16660,
+		    "3" : 19500
+        },
+	"gradient_descent_gain": {
+		    "2" : 1e-5,
+		    "3" : 1e-5
+        },
+	"gradient_descent_averages": {
+		    "2" : 10,
+		    "3" : 10
+        },
+	"eta_scan_averages": {
+		    "2" : 10,
+		    "3" : 10
+        },
+	"default_tune": "/data/smurf_data/tune/1547959798_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"ramp_start_mode" : 0,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 4,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 2000000,
+	"static_mask" : 0,
+	"num_averages" : 20
+},
+
+"default_data_dir": "/data/smurf_data",
+"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/scratch/shawn/band_filling_test.py
+++ b/scratch/shawn/band_filling_test.py
@@ -1,0 +1,28 @@
+# Runlike this exec(open("band_filling_test.py").read())
+# to use the pysmurf S object you've already initialized
+import time
+import numpy as np
+
+bands=[2,3]
+amplitude=12 
+wait=True 
+wait_time_sec=0.1
+ 
+for band in bands:
+    S.set_att_uc(band,0)
+    #S.set_dsp_enable(band,1) 
+    #S.set_tone_scale(band,2) 
+    #S.set_analysis_scale(band,3) 
+    #S.set_synthesis_scale(band,2) 
+    channels=[] 
+ 
+    #for sb in np.arange(64,116):
+    for sb in np.arange(12,116):     
+        channels.append(S.get_channels_in_subband(band,sb)[0]) 
+ 
+    for ch in channels: 
+        print(ch) 
+        S.set_center_frequency_mhz_channel(band,ch,0.1*np.random.rand(1)) 
+        S.set_amplitude_scale_channel(band,ch,amplitude) 
+        if wait: 
+            time.sleep(wait_time_sec)

--- a/scratch/shawn/init_pton.py
+++ b/scratch/shawn/init_pton.py
@@ -1,0 +1,11 @@
+import pysmurf
+import matplotlib.pylab as plt
+import numpy as np
+
+# the s2 means this is the slot 2 server.
+epics_prefix = 'smurf_server_s2'
+# point to your config file here
+config_file='/data/pysmurf_cfg/experiment_pc004_smurfsrv08_noExtRef.cfg'
+
+# don't initialize by default
+S = pysmurf.SmurfControl(epics_root=epics_prefix,cfg_file=config_file,setup=False,make_logfile=False) 

--- a/scratch/shawn/measureFluxRampFvsV.py
+++ b/scratch/shawn/measureFluxRampFvsV.py
@@ -1,3 +1,6 @@
+# Runlike this exec(open("measureFluxRampFvsV.py").read())
+# that way it will use your pysmurf S object.
+
 import pysmurf
 import numpy as np
 import time
@@ -6,26 +9,39 @@ import sys
 ## instead of takedebugdata try relaunch PyRogue, then loopFilterOutputArray, which is 
 ## the integral tracking term with lmsEnable[1..3]=0
 
-S = pysmurf.SmurfControl(make_logfile=False,setup=False,epics_root='smurf_server_s5',cfg_file='/home/cryo/docker/pysmurf/hb-devel-dspv2/pysmurf/cfg_files/experiment_fp29_smurfsrv03_noExtRef_hbOnlyBay0.cfg')
+#S = pysmurf.SmurfControl(make_logfile=False,setup=False,epics_root='smurf_server_s2',cfg_file='/data/pysmurf_cfg/experiment_fp29_smurfsrv03_noExtRef_lbOnlyBay0.cfg')
+
+import os
+fn_raw_data = os.path.join('./', '%s_fr_sweep_data.npy'%(S.get_timestamp()))
 
 #######
-hbInBay0=True
+#amplitudes_and_uc_atts=[(8,30),(9,30),(10,30),(11,30),(12,30),(12,24),(12,18),(12,12),(12,6),(12,0)]
+#amplitudes_and_uc_atts=[(8,30),(10,30),(12,30),(12,18),(12,6),(12,0)]
+#amplitudes_and_uc_atts=[(8,30),(10,30),(12,30),(12,18),(12,6),(12,0)]
+amplitudes_and_uc_atts=[(None,None)]
+#amplitudes_and_uc_atts=[(8,30)]
+#amplitudes=[9,10,11,12,13,14]
+# [(None,None)] means don't change the amplitude or uc_att, but still retunes
+#amplitudes=[9]
+
+# needs to be nonzero, or won't track flux ramp well,
+# particularly when stepping flux ramp by large amounts
+lmsGain=6
+hbInBay0=False
+relock=False 
 bands=[2,3]
-Npts=3
 bias=None
-wait_time=.05
+# no longer averaging as much or waiting as long between points in newer fw which has df filter
+wait_time=0.125
+Npts=3
 #bias_low=-0.432
 #bias_high=0.432
-bias_low=-0.65
-bias_high=0.65
-Nsteps=1000
+bias_low=-0.60
+bias_high=0.60
+Nsteps=500
+#Nsteps=25
 bias_step=np.abs(bias_high-bias_low)/float(Nsteps)
-show_plot=False
-make_plot=True
-save_plot=True 
 channels=None
-gcp_mode=True
-grid_on=False
 #much slower than using loopFilterOutputArray,
 #and creates a bunch of files
 use_take_debug_data=False
@@ -39,9 +55,10 @@ print(channels[band])
 
 if bias is None:
     bias = np.arange(bias_low, bias_high, bias_step)
-
+    
 # final output data dictionary
 raw_data = {}
+raw_data['bias'] = bias
 print(channels[band])
 bands_with_channels_on=[]
 for band in bands:
@@ -52,7 +69,7 @@ for band in bands:
         S.set_lms_enable1(band, 0)
         S.set_lms_enable2(band, 0)
         S.set_lms_enable3(band, 0)
-        S.set_lms_gain(band, 0)
+        S.set_lms_gain(band, lmsGain)
 
         raw_data[band]={}
 
@@ -60,23 +77,59 @@ for band in bands:
 
 bands=bands_with_channels_on
 
-amplitudes=[9,10,11,12,13,14,15]
-for amplitude in amplitudes:
+for (amplitude,uc_att) in amplitudes_and_uc_atts:
 
+    sys.stdout.write('\rSetting flux ramp bias to 0 V\033[K before tune'.format(bias_low))
+    S.set_fixed_flux_ramp_bias(0.)
+
+    # make sure we tune at bias low
+    #sys.stdout.write('\rSetting flux ramp bias low at {:4.3f} V\033[K'.format(bias_low))
+    #S.set_fixed_flux_ramp_bias(bias_low,do_config=True)
+    #time.sleep(wait_time)
+    
     ### begin retune on all bands with tones
     for band in bands:
-        S.log('Retuning at tone amplitude {}'.format(amplitude))
-        S.set_amplitude_scale_array(band,np.array(S.get_amplitude_scale_array(band)*amplitude/np.max(S.get_amplitude_scale_array(band)),dtype=int))
+        S.log('Retuning at tone amplitude {} and UC attenuator {}'.format(amplitude,uc_att))
+        if relock:
+            S.relock(band)
+        if amplitude is not None:
+            S.set_amplitude_scale_array(band,np.array(S.get_amplitude_scale_array(band)*amplitude/np.max(S.get_amplitude_scale_array(band)),dtype=int))
+        if uc_att is not None:
+            S.set_att_uc(band,uc_att)
         S.run_serial_gradient_descent(band)
         S.run_serial_eta_scan(band)
-        raw_data[band][amplitude]={}
+
+        # toggle feedback if functionality exists in this version of pysmurf
+        time.sleep(5)
+        if 'toggle_feedback' in dir(S):
+            S.toggle_feedback(band)
+        
+        raw_data[band][(amplitude,uc_att)]={}
         
     ### end retune
-    S.log('Starting to take flux ramp with amplitude={}.'.format(amplitude), S.LOG_USER)
 
+    ##
+    ## THIS DOESN'T WORK AND I DON'T UNDERSTAND WHY NOT
+    small_steps_to_starting_bias=None
+    if bias_low<0:
+        small_steps_to_starting_bias=np.arange(bias_low,0,bias_step)[::-1]
+    else:
+        small_steps_to_starting_bias=np.arange(0,bias_low,bias_step)
+    
+    # step from zero (where we tuned) down to starting bias
+    S.log('Slowly shift flux ramp voltage to place where we begin.'.format(amplitude,uc_att), S.LOG_USER)    
+    for b in small_steps_to_starting_bias:
+        sys.stdout.write('\rFlux ramp bias at {:4.3f} V\033[K'.format(b))
+        sys.stdout.flush()
+        S.set_fixed_flux_ramp_bias(b,do_config=False)
+        time.sleep(wait_time)        
+
+    ## make sure we start at bias_low
     sys.stdout.write('\rSetting flux ramp bias low at {:4.3f} V\033[K'.format(bias_low))
-    S.set_fixed_flux_ramp_bias(bias_low)
+    S.set_fixed_flux_ramp_bias(bias_low,do_config=False)
     time.sleep(wait_time)
+    
+    S.log('Starting to take flux ramp with amplitude={} and uc_att={}.'.format(amplitude,uc_att), S.LOG_USER)    
 
     fs={}
     for band in bands:
@@ -85,7 +138,7 @@ for amplitude in amplitudes:
     for b in bias:
         sys.stdout.write('\rFlux ramp bias at {:4.3f} V\033[K'.format(b))
         sys.stdout.flush()
-        S.set_fixed_flux_ramp_bias(b)
+        S.set_fixed_flux_ramp_bias(b,do_config=False)
         time.sleep(wait_time)
 
         for band in bands:
@@ -102,32 +155,30 @@ for amplitude in amplitudes:
 
     sys.stdout.write('\n')
 
-    S.log('Done taking flux ramp with amplitude={}.'.format(amplitude), S.LOG_USER)
+    S.log('Done taking flux ramp with amplitude={} and uc_att={}.'.format(amplitude,uc_att), S.LOG_USER)
 
     for band in bands:
 
         fres=[S.channel_to_freq(band, ch) for ch in channels[band]]
-        raw_data[band][amplitude]['fres']=np.array(fres) + (2e3 if hbInBay0 else 0)
-        raw_data[band][amplitude]['channels']=channels[band]
+        raw_data[band][(amplitude,uc_att)]['fres']=np.array(fres) + (2e3 if hbInBay0 else 0)
+        raw_data[band][(amplitude,uc_att)]['channels']=channels[band]
 
         if use_take_debug_data:
             #stack
             fovsfr=np.dstack(fs[band])[0]
             [sbs,sbc]=S.get_subband_centers(band)
             fvsfr=fovsfr[channels[band]]+[sbc[np.where(np.array(sbs)==S.get_subband_from_channel(band,ch))[0]]+S.get_band_center_mhz(band) for ch in channels[band]]
-            raw_data[band][amplitude]['fvsfr']=fvsfr + (2e3 if hbInBay0 else 0)
+            raw_data[band][(amplitude,uc_att)]['fvsfr']=fvsfr + (2e3 if hbInBay0 else 0)
         else:
             #stack
             lfovsfr=np.dstack(fs[band])[0]
-            raw_data[band][amplitude]['lfovsfr']=lfovsfr
-            raw_data[band][amplitude]['fvsfr']=np.array([arr/4.+fres for (arr,fres) in zip(lfovsfr,fres)]) + (2e3 if hbInBay0 else 0)
+            raw_data[band][(amplitude,uc_att)]['lfovsfr']=lfovsfr
+            raw_data[band][(amplitude,uc_att)]['fvsfr']=np.array([arr/4.+fres for (arr,fres) in zip(lfovsfr,fres)]) + (2e3 if hbInBay0 else 0)
 
-raw_data['bias'] = bias
-
+    # save dataset for each iteration, just to make sure it gets
+    # written to disk
+    np.save(fn_raw_data, raw_data)
+            
 # done - zero and unset
-S.set_fixed_flux_ramp_bias(0)
+S.set_fixed_flux_ramp_bias(0,do_config=False)
 S.unset_fixed_flux_ramp_bias()
-
-import os
-fn_raw_data = os.path.join('./', '%s_fr_sweep_data.npy'%(S.get_timestamp()))
-np.save(fn_raw_data, raw_data)

--- a/util/smurf_util.py
+++ b/util/smurf_util.py
@@ -910,6 +910,53 @@ class SmurfUtilMixin(SmurfBase):
         amps = self.get_amplitude_scale_array(band)
         return np.ravel(np.where(amps != 0))
 
+    def toggle_feedback(self, band, **kwargs):
+        '''
+        Toggles feedbackEnable (->0->1) and lmsEnables1-3 (->0->1) for
+        this band.  Only toggles back to 1 if it was 1 when asked to
+        toggle, otherwise leaves it zero.
+
+        Args:
+        -----
+        band (int) : The band whose feedback to toggle.
+        '''
+
+        # current vals?
+        old_feedback_enable=self.get_feedback_enable(band)      
+        old_lms_enable1=self.get_lms_enable1(band)        
+        old_lms_enable2=self.get_lms_enable2(band)          
+        old_lms_enable3=self.get_lms_enable3(band)
+
+        self.log('Before toggling feedback on band {}, feedbackEnable={}, lmsEnable1={}, lmsEnable2={}, and lmsEnable3={}.'.format(band, old_feedback_enable, old_lms_enable1, old_lms_enable2, old_lms_enable3), 
+                 self.LOG_USER)        
+        
+        # -> 0
+        self.log('Setting feedbackEnable=lmsEnable1=lmsEnable2=lmsEnable3=0 (in that order).',
+                 self.LOG_USER)                
+        self.set_feedback_enable(band,0)
+        self.set_lms_enable1(band,0)
+        self.set_lms_enable2(band,0)
+        self.set_lms_enable3(band,0)          
+
+        # -> 1
+        logstr='Set '
+        if old_feedback_enable:
+            self.set_feedback_enable(band,1)
+            logstr+='feedbackEnable='
+        if old_lms_enable1:
+            self.set_lms_enable1(band,1)
+            logstr+='lmsEnable1='
+        if old_lms_enable2:
+            self.set_lms_enable2(band,1)
+            logstr+='lmsEnable2='            
+        if old_lms_enable3:
+            self.set_lms_enable3(band,1)
+            logstr+='lmsEnable3='            
+            
+        logstr+='1 (in that order).'
+        self.log(logstr,
+                 self.LOG_USER)                        
+
     def band_off(self, band, **kwargs):
         '''
         Turns off all tones in a band

--- a/util/smurf_util.py
+++ b/util/smurf_util.py
@@ -416,6 +416,9 @@ class SmurfUtilMixin(SmurfBase):
                 self.log('Writing PyRogue configuration to file : {}'.format(config_filename), 
                      self.LOG_USER)
                 self.write_config(config_filename)
+                # When deployed first HB to Princeton, caputs just following this
+                # were timing out ; adding wait.
+                time.sleep(5.)
 
             self.log('Writing to file : {}'.format(data_filename), 
                 self.LOG_USER)


### PR DESCRIPTION
Improvements to dspv2 pysmurf from Princeton running with a HB AMC on MMBv1pp.  
Including:

- Added ability to add comments to pysmurf cfg.
- Updates to Pton configs and startup scripts (for using dspv2 with a HB AMC).
- Added ability to estimate the phi0 rate (using meas_lms_freq in tracking_setup).
- Added toggle feedback function from dspv3 ; toggling feedback added as an option to track_and_check.
- Fix for flux_mod2 so that the carrier rate is only estimated from assigned channels.
- Improvements to flux_mod2.