### PR TITLE
Fixes issue 74 and first check in of a working RFSoC-SMuRF cfg

### DIFF
--- a/cfg_files/stanford/smurf-srv03/experiment_fp30_srv03_rfsoc.cfg
+++ b/cfg_files/stanford/smurf-srv03/experiment_fp30_srv03_rfsoc.cfg
@@ -1,0 +1,221 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		#https://confluence.slac.stanford.edu/display/SMuRF/0eea5630
+		#"refPhaseDelay" : 6,
+		#"refPhaseDelayFine" : 9,
+		#"lmsDelay" : 24,
+		# Measured for 5ee81820 by SWH on 7/11/19 with C02-01
+		# carrier + LB AMC C03-A01-03.
+		#"refPhaseDelay" : 8,
+		#"refPhaseDelayFine" : 41,		
+		# Measured for 071150b0 by SWH on 7/3/19 with C02-01
+		# carrier + LB AMC C03-A01-03.
+		#"refPhaseDelay" : 8,
+		#"refPhaseDelayFine" : 38,
+		# lmsDelay only gets set from the cfg if it's present
+		# ; otherwise it gets set to 4*refPhaseDelay.  It's
+		# supposed to be 4*refPhaseDelay, but in fw 071150b0,
+		# refPhaseDelay is 8, and 4*8=32, which exceeds 31,
+		# which is the maximum value lmsDelay can be set to in
+		# 071150b0.
+		#"lmsDelay" : 31,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		# Measured for a406a45 by SWH on 7/19/19
+		#"refPhaseDelay" : 8,
+		#"refPhaseDelayFine" : 42,
+		#"lmsDelay" : 31,
+		# Measured for 081ca90 by SWH on 7/19/19
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 110,
+		"lmsDelay" : 24,		
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 6,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask" : {
+},
+
+"amplifier": {
+	     "hemt_Vg" : 0.570,
+	     "bit_to_V_hemt" : 3.8592e-06,
+	     "hemt_Id_offset" : 0.16758,
+	     "LNA_Vg" : -0.7575,
+	     # 32 if using a C02 cryostat card.  Some C01s were
+	     # kludged to provide a 50k gate voltage for ASU 50K LNAs
+	     # in early testing.  For those, use 2.	     
+	     "dac_num_50k" : 32,
+	     "bit_to_V_50k" : 3.8592e-06,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24],
+        "12" : [25,26],
+        "13" : [27,28],
+        "14" : [29,30]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 25479,
+"high_low_current_ratio" : 12.50,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [3],
+
+"tune_band" : {
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.489,
+	"delta_freq": {
+		    "0" : 0.02
+        },		
+	"lms_freq": {
+		    "0" : 16500
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98
+	},	
+	"gradient_descent_gain": {
+		    "0" : 1e-5
+        },
+	"gradient_descent_averages": {
+		    "0" : 5
+        },
+	"eta_scan_averages": {
+		    "0" : 5
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "ext_ref"
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 4,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+# For remote commanding
+#"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/scratch/shawn/scripts/shawnhammer.sh
+++ b/scratch/shawn/scripts/shawnhammer.sh
@@ -27,14 +27,12 @@ start_atca_monitor=true
 parallel_setup=false
 cpwd=$PWD
 
-pysmurf=/home/cryo/docker/pysmurf/dspv3
+pysmurf=/home/cryo/docker/pysmurf/dev
 
 crate_id=3
-#slots_in_configure_order=(2 3 4)
-slots_in_configure_order=(5)
+slots_in_configure_order=(4)
 
-pysmurf_init_script=scratch/shawn/scripts/init_rflab.py
-#pysmurf_init_script=scratch/shawn/scripts/init_stanford.py
+pysmurf_init_script=scratch/shawn/scripts/init_stanford.py
 
 tmux_session_name=smurf
 

--- a/scratch/shawn/scripts/shawnhammerfunctions.sh
+++ b/scratch/shawn/scripts/shawnhammerfunctions.sh
@@ -112,7 +112,7 @@ config_pysmurf_serial () {
     slot_number=$1
     pysmurf_docker=$2
     
-    tmux send-keys -t ${tmux_session_name}:${slot_number} 'S = pysmurf.SmurfControl(epics_root=epics_prefix,cfg_file=config_file,setup=True,make_logfile=False,shelfmanager="'${shelfmanager}'")' C-m
+    tmux send-keys -t ${tmux_session_name}:${slot_number} 'S = pysmurf.SmurfControl(epics_root=epics_prefix,cfg_file=config_file,setup=True,make_logfile=False,shelf_manager="'${shelfmanager}'")' C-m
     
     # wait for setup to complete
     echo "-> Waiting for carrier setup (watching pysmurf docker ${pysmurf_docker})"


### PR DESCRIPTION
Fixes pysmurf issue #74, a bug in release [v3.1.1](https://github.com/slaclab/pysmurf/releases/tag/v3.1.1) which was causing shawnhammer to crash when it attempted to setup (due to a typo in the `shelf_manager` argument provided to the `setup(...)` call.  Also checking in the pysmurf RFSOC cfg that we used successfully to run the RFSOC implementation of SMuRF for the first time the week of 7/22/19 in the Stanford lab.