### PR TITLE
Add install and docs build steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # pysmurf
-The python control software for SMuRF. Includes scripts to do low level commands as well as higher level analysis.
+The python control software for SMuRF. Includes scripts to do low level
+commands as well as higher level analysis.
+
+## Installation
+To install pysmurf clone this repository and install using pip:
+
+```
+git clone https://github.com/slaclab/pysmurf.git
+cd pysmurf/
+pip3 install .
+```
+
+## Documentation
+Documentation is built using Sphinx, and follows the
+[Google Style Docstrings][1]. To build the documentation first install the
+pysmurf package, then run:
+
+```
+cd docs/
+make html
+```
+
+Output will be located in `_build/html`. You can view the compiled
+documentation by opening `_build/html/index.html` in the browser of your
+choice.
+
+[1]: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html


### PR DESCRIPTION
This resolves #100. It describes how to build the documentation and view it locally. There is also a note about installation, which is needed for Sphinx to be able to build properly. I know the `setup.py` for packaging pysmurf is relatively new (688c344454568259251fe52f8a4e2191e88750cb), but it seems based on #101 that the `pip install` might not be totally sufficient for proper installation. Additional installation info should be added if needed.

As for the documentation style -- looking briefly at some of the docstrings it looks like a majority of them are closest to the Google Style, so I've gone with that and linked to the example in the napoleon docs that I find to be a useful reference when writing docstrings.