### PR TITLE
Fix packaging and add readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,21 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt
+    - method: pip
+      path: .

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ To install pysmurf clone this repository and install using pip:
 ```
 git clone https://github.com/slaclab/pysmurf.git
 cd pysmurf/
+pip3 install -r requirements.txt
 pip3 install .
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # pysmurf
+
+[![Documentation Status](https://readthedocs.org/projects/pysmurf/badge/?version=latest)](https://pysmurf.readthedocs.io/en/latest/?badge=latest)
+
 The python control software for SMuRF. Includes scripts to do low level
 commands as well as higher level analysis.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+scipy
+pyepics

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
-from setuptools import setup, Extension
+from setuptools import setup, find_packages
 
 import versioneer
 
-setup (name = 'pysmurf',
-       description='The python control software for SMuRF',
-       package_dir={'pysmurf': 'pysmurf'},
-       packages=['pysmurf'],
-       version=versioneer.get_version(),
-       cmdclass=versioneer.get_cmdclass())
+setup(name='pysmurf',
+      description='The python control software for SMuRF',
+      package_dir={'pysmurf': 'pysmurf'},
+      packages=find_packages(),
+      version=versioneer.get_version(),
+      cmdclass=versioneer.get_cmdclass())


### PR DESCRIPTION
The `setup.py` file didn't specify submodules within the pysmurf package. This PR updates setup.py to dynamically find these submodules.

@laurensaunders discovered that the docs wouldn't build properly given the instructions due to both the packaging issue and the lack of a `requirements.txt`. Here we also add this requirements file to specify package dependencies, and include a line in the installation instructions.

Finally, I had talked to @swh76 about setting up the documentation on readthedocs. This links to the docs using a badge at the top of the README, and adds a configuration file for the builds there. It'd be great to get a webhook setup so they autobuild on new commits, I'll be in touch with a repo admin about doing that. Happy to add someone as a maintainer on the readthedocs website as well.

A preview of the test built documentation on rtd: https://pysmurf.readthedocs.io/en/packaging-fix-w-rtd/index.html