### PR TITLE
Add meta data channel to base transmitter

### DIFF
--- a/include/smurf/core/transmitters/BaseTransmitter.h
+++ b/include/smurf/core/transmitters/BaseTransmitter.h
@@ -42,8 +42,9 @@ namespace smurf
             class BaseTransmitter;
             typedef std::shared_ptr<BaseTransmitter> BaseTransmitterPtr;
 
-            class BaseTransmitter : public ris::Slave
-            {
+            class BaseTransmitterChannel;
+
+            class BaseTransmitter: public std::enable_shared_from_this<smurf::core::transmitters::BaseTransmitter> {
             public:
                 BaseTransmitter();
                 ~BaseTransmitter() {};
@@ -57,14 +58,23 @@ namespace smurf
                 void       setDisable(bool d);
                 const bool getDisable() const;
 
+                // Get data channel
+                std::shared_ptr<smurf::core::transmitters::BaseTransmitterChannel> getDataChannel();
+                
+                // Get meta data channel
+                std::shared_ptr<smurf::core::transmitters::BaseTransmitterChannel> getMetaChannel();
+
                 // Clear all counter.
                 void clearCnt();
 
                 // Get the dropped packet counter
                 const std::size_t getPktDropCnt() const;
 
-                // Accept new frames
-                void acceptFrame(ris::FramePtr frame);
+                // Accept new data frames
+                void acceptDataFrame(ris::FramePtr frame);
+
+                // Accept new meta frames
+                void acceptMetaFrame(ris::FramePtr frame);
 
                 // This method is intended to be used to take SMuRF packet and send them to other
                 // system.
@@ -72,6 +82,11 @@ namespace smurf
                 // (which is a smart pointer to a read-only interface to a Smurf packer object) is passed.
                 // It must be overwritten by the user application
                 virtual void transmit(SmurfPacketROPtr sp) {};
+
+                // This method is intended to be used to take SMuRF meta data and send them to other
+                // system.
+                // It must be overwritten by the user application
+                virtual void metaTransmit(std::string) {};
 
             private:
                 bool                          disable;              // Disable flag
@@ -85,6 +100,10 @@ namespace smurf
                 std::thread                   pktTransmitterThread; // Thread where the SMuRF packet transmission will run
                 std::condition_variable       txCV;                 // Variable to notify the thread new data is ready
                 std::mutex                    txMutex;              // Mutex used for accessing the conditional variable
+
+                // Inteface channels
+                std::shared_ptr<smurf::core::transmitters::BaseTransmitterChannel> dataChannel;
+                std::shared_ptr<smurf::core::transmitters::BaseTransmitterChannel> metaChannel;
 
                 // Transmit method. Will run in the pktTransmitterThread thread.
                 // Here is where the method 'transmit' is called.

--- a/include/smurf/core/transmitters/BaseTransmitterChannel.h
+++ b/include/smurf/core/transmitters/BaseTransmitterChannel.h
@@ -1,0 +1,67 @@
+#ifndef _SMURF_CORE_TRANSMITTERS_BASETRANSMITTER_CHANNEL_H_
+#define _SMURF_CORE_TRANSMITTERS_BASETRANSMITTER_CHANNEL_H_
+
+/**
+ *-----------------------------------------------------------------------------
+ * Title         : SMuRF Data Base Transmitter Channel
+ * ----------------------------------------------------------------------------
+ * File          : BaseTransmitterChannel.h
+ * Created       : 2019-09-27
+ *-----------------------------------------------------------------------------
+ * Description :
+ *    SMuRF Data Base Transmitter Class, channel ineterface
+ *-----------------------------------------------------------------------------
+ * This file is part of the smurf software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+    * https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the smurf software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ *-----------------------------------------------------------------------------
+**/
+
+#include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
+#include <rogue/interfaces/stream/Slave.h>
+#include <rogue/GilRelease.h>
+
+namespace bp  = boost::python;
+namespace ris = rogue::interfaces::stream;
+
+namespace smurf
+{
+    namespace core
+    {
+        namespace transmitters
+        {
+            class BaseTransmitterChannel;
+            typedef std::shared_ptr<BaseTransmitterChannel> BaseTransmitterChannelPtr;
+
+            class BaseTransmitter;
+
+            class BaseTransmitterChannel : public ris::Slave
+            {
+            public:
+                BaseTransmitterChannel(std::shared_ptr<smurf::core::transmitters::BaseTransmitter> bt, uint32_t channel);
+                ~BaseTransmitterChannel() {};
+
+                static BaseTransmitterChannelPtr create(std::shared_ptr<smurf::core::transmitters::BaseTransmitter> bt, uint32_t channel);
+
+                static void setup_python();
+
+                // Accept new frames
+                void acceptFrame(ris::FramePtr frame);
+
+            private:
+
+                uint32_t channel_;
+
+                std::shared_ptr<smurf::core::transmitters::BaseTransmitter> bt_;
+
+            };
+        }
+    }
+}
+
+#endif

--- a/python/pysmurf/core/transmitters/_BaseTransmitter.py
+++ b/python/pysmurf/core/transmitters/_BaseTransmitter.py
@@ -52,7 +52,9 @@ class BaseTransmitter(pyrogue.Device):
             description='Clear all counters',
             function=self._transmitter.clearCnt))
 
-    # Method called by streamConnect, streamTap and streamConnectBiDir to access slave
-    def _getStreamSlave(self):
-        return self._transmitter
+    def getDataChannel(self):
+        return self._transmitter.getDataChannel()
+
+    def getMetaChannel(self):
+        return self._transmitter.getMetaChannel()
 

--- a/src/smurf/core/transmitters/BaseTransmitter.cpp
+++ b/src/smurf/core/transmitters/BaseTransmitter.cpp
@@ -136,6 +136,8 @@ void sct::BaseTransmitter::acceptMetaFrame(ris::FramePtr frame)
 {
     rogue::GilRelease noGil;
     ris::FrameLockPtr fLock = frame->lock();
+
+    if ( frame->bufferCount() != 1 ) return;
     
     std::string cfg(reinterpret_cast<char const*>(frame->beginRead().ptr()), frame->getPayload());
     fLock->unlock();

--- a/src/smurf/core/transmitters/BaseTransmitter.cpp
+++ b/src/smurf/core/transmitters/BaseTransmitter.cpp
@@ -21,13 +21,13 @@
 #include <boost/python.hpp>
 #include "smurf/core/common/Timer.h"
 #include "smurf/core/transmitters/BaseTransmitter.h"
+#include "smurf/core/transmitters/BaseTransmitterChannel.h"
 
 namespace bp  = boost::python;
 namespace sct = smurf::core::transmitters;
 
 sct::BaseTransmitter::BaseTransmitter()
 :
-    ris::Slave(),
     disable(false),
     pktDropCnt(0),
     pktBuffer(2),
@@ -40,6 +40,9 @@ sct::BaseTransmitter::BaseTransmitter()
 {
     if( pthread_setname_np( pktTransmitterThread.native_handle(), "SmurfPacketTx" ) )
         perror( "pthread_setname_np failed for the SmurfPacketTx thread" );
+
+    dataChannel = sct::BaseTransmitterChannel::create(shared_from_this(),0);
+    metaChannel = sct::BaseTransmitterChannel::create(shared_from_this(),1);
 }
 
 sct::BaseTransmitterPtr sct::BaseTransmitter::create()
@@ -51,15 +54,25 @@ void sct::BaseTransmitter::setup_python()
 {
     bp::class_< sct::BaseTransmitter,
                 sct::BaseTransmitterPtr,
-                bp::bases<ris::Slave>,
                 boost::noncopyable >
                 ("BaseTransmitter",bp::init<>())
-        .def("setDisable",    &BaseTransmitter::setDisable)
-        .def("getDisable",    &BaseTransmitter::getDisable)
-        .def("clearCnt",      &BaseTransmitter::clearCnt)
-        .def("getPktDropCnt", &BaseTransmitter::getPktDropCnt)
+        .def("setDisable",     &BaseTransmitter::setDisable)
+        .def("getDisable",     &BaseTransmitter::getDisable)
+        .def("clearCnt",       &BaseTransmitter::clearCnt)
+        .def("getPktDropCnt",  &BaseTransmitter::getPktDropCnt)
+        .def("getDataChannel", &BaseTransmitter::getDataChannel)
+        .def("getMetaChannel", &BaseTransmitter::getMetaChannel)
     ;
-    bp::implicitly_convertible< sct::BaseTransmitterPtr, ris::SlavePtr >();
+}
+
+// Get data channel
+sct::BaseTransmitterChannelPtr sct::BaseTransmitter::getDataChannel() {
+   return dataChannel;
+}
+
+// Get meta data channel
+sct::BaseTransmitterChannelPtr sct::BaseTransmitter::getMetaChannel() {
+   return dataChannel;
 }
 
 void sct::BaseTransmitter::setDisable(bool d)
@@ -82,7 +95,7 @@ const std::size_t sct::BaseTransmitter::getPktDropCnt() const
     return pktDropCnt;
 }
 
-void sct::BaseTransmitter::acceptFrame(ris::FramePtr frame)
+void sct::BaseTransmitter::acceptDataFrame(ris::FramePtr frame)
 {
     rogue::GilRelease noGil;
 
@@ -117,6 +130,17 @@ void sct::BaseTransmitter::acceptFrame(ris::FramePtr frame)
         // Increase the dropped packet counter
         ++pktDropCnt;
     }
+}
+
+void sct::BaseTransmitter::acceptMetaFrame(ris::FramePtr frame)
+{
+    rogue::GilRelease noGil;
+    ris::FrameLockPtr fLock = frame->lock();
+    
+    std::string cfg(reinterpret_cast<char const*>(frame->beginRead().ptr()), frame->getPayload());
+    fLock->unlock();
+
+    metaTransmit(cfg);
 }
 
 void sct::BaseTransmitter::pktTansmitter()

--- a/src/smurf/core/transmitters/BaseTransmitterChannel.cpp
+++ b/src/smurf/core/transmitters/BaseTransmitterChannel.cpp
@@ -1,0 +1,54 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title         : SMuRF Data Base Transmitter Channel
+ * ----------------------------------------------------------------------------
+ * File          : BaseTransmitterChannel.cpp
+ * Created       : 2019-09-27
+ *-----------------------------------------------------------------------------
+ * Description :
+ *   SMuRF Data Base Transmitter Class, channel interface
+ *-----------------------------------------------------------------------------
+ * This file is part of the smurf software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+    * https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the smurf software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ *-----------------------------------------------------------------------------
+**/
+
+#include <boost/python.hpp>
+#include "smurf/core/transmitters/BaseTransmitterChannel.h"
+#include "smurf/core/transmitters/BaseTransmitter.h"
+
+namespace bp  = boost::python;
+namespace sct = smurf::core::transmitters;
+
+sct::BaseTransmitterChannel::BaseTransmitterChannel(sct::BaseTransmitterPtr bt, uint32_t channel) 
+{
+    channel_ = channel;
+    bt_ = bt;
+}
+
+sct::BaseTransmitterChannelPtr sct::BaseTransmitterChannel::create(sct::BaseTransmitterPtr bt, uint32_t channel)
+{
+    return std::make_shared<BaseTransmitterChannel>(bt,channel);
+}
+
+void sct::BaseTransmitterChannel::setup_python()
+{
+    bp::class_< sct::BaseTransmitterChannel,
+                sct::BaseTransmitterChannelPtr,
+                bp::bases<ris::Slave>,
+                boost::noncopyable >
+                ("BaseTransmitterChannel",bp::no_init);
+   bp::implicitly_convertible<sct::BaseTransmitterChannelPtr, ris::SlavePtr>();
+}
+
+void sct::BaseTransmitterChannel::acceptFrame(ris::FramePtr frame)
+{
+   if ( channel_ == 0 ) bt_->acceptDataFrame(frame);
+   else if ( channel_ == 1 ) bt_->acceptMetaFrame(frame);
+}
+

--- a/src/smurf/core/transmitters/CMakeLists.txt
+++ b/src/smurf/core/transmitters/CMakeLists.txt
@@ -14,4 +14,5 @@
 # ----------------------------------------------------------------------------
 
 target_sources(smurf PRIVATE "${CMAKE_CURRENT_LIST_DIR}/BaseTransmitter.cpp")
+target_sources(smurf PRIVATE "${CMAKE_CURRENT_LIST_DIR}/BaseTransmitterChannel.cpp")
 target_sources(smurf PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")

--- a/src/smurf/core/transmitters/module.cpp
+++ b/src/smurf/core/transmitters/module.cpp
@@ -21,6 +21,7 @@
 #include <boost/python.hpp>
 #include "smurf/core/transmitters/module.h"
 #include "smurf/core/transmitters/BaseTransmitter.h"
+#include "smurf/core/transmitters/BaseTransmitterChannel.h"
 
 namespace bp  = boost::python;
 namespace sct = smurf::core::transmitters;
@@ -37,5 +38,6 @@ void sct::setup_module()
     bp::scope io_scope = module;
 
     sct::BaseTransmitter::setup_python();
+    sct::BaseTransmitterChannel::setup_python();
 }
 


### PR DESCRIPTION
This PR channelizes the BaseTransmitter slave interface into separate data and meta data channels.