### PR TITLE
Setup stream group and add utility to define pysmurf groups

### DIFF
--- a/python/pysmurf/core/roots/CmbEth.py
+++ b/python/pysmurf/core/roots/CmbEth.py
@@ -27,6 +27,8 @@ import rogue.protocols.srp
 from   CryoDet._MicrowaveMuxBpEthGen2 import FpgaTopLevel
 import AmcCarrierCore.AppTop              as AppTop
 
+import pysmurf.core.utilities
+
 class CmbEth(AppTop.RootBase):
     def __init__(self, *,
                  ip_addr        = "",
@@ -45,7 +47,7 @@ class CmbEth(AppTop.RootBase):
                  txDevice       = None,
                  **kwargs):
 
-        pyrogue.Root.__init__(self, name="AMCc", initRead=True, pollEn=polling_en, **kwargs)
+        pyrogue.Root.__init__(self, name="AMCc", initRead=True, pollEn=polling_en, streamIncGroups='stream', **kwargs)
 
         # Add PySmurf Application Block
         self.add(pysmurf.core.devices.SmurfApplication())
@@ -205,6 +207,9 @@ class CmbEth(AppTop.RootBase):
 
     def start(self):
         pyrogue.Root.start(self)
+
+        # Setup groups        
+        pysmurf.core.utilities.setupGroups(self)
 
         # Show image build information
         try:

--- a/python/pysmurf/core/roots/CmbPcie.py
+++ b/python/pysmurf/core/roots/CmbPcie.py
@@ -27,6 +27,8 @@ import rogue.protocols.srp
 from   CryoDet._MicrowaveMuxBpEthGen2 import FpgaTopLevel
 import AmcCarrierCore.AppTop              as AppTop
 
+import pysmurf.core.utilities
+
 class CmbPcie(AppTop.RootBase):
     def __init__(self, *,
                  ip_addr        = "",
@@ -45,7 +47,7 @@ class CmbPcie(AppTop.RootBase):
                  txDevice       = None,
                  **kwargs):
 
-        pyrogue.Root.__init__(self, name="AMCc", initRead=True, pollEn=polling_en, **kwargs)
+        pyrogue.Root.__init__(self, name="AMCc", initRead=True, pollEn=polling_en, streamIncGroups='stream', **kwargs)
 
         # Add PySmurf Application Block
         self.add(pysmurf.core.devices.SmurfApplication())
@@ -202,6 +204,9 @@ class CmbPcie(AppTop.RootBase):
 
     def start(self):
         pyrogue.Root.start(self)
+
+        # Setup groups        
+        pysmurf.core.utilities.setupGroups(self)
 
         # Show image build information
         try:

--- a/python/pysmurf/core/utilities/_SetupGroups.py
+++ b/python/pysmurf/core/utilities/_SetupGroups.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#-----------------------------------------------------------------------------
+# Title      : PySMuRF Group Setup Utility
+#-----------------------------------------------------------------------------
+# File       : _SmurfPublisher.py
+# Created    : 2019-10-31
+#-----------------------------------------------------------------------------
+# Description:
+#    Setup groups for variables & devices
+#-----------------------------------------------------------------------------
+# This file is part of the smurf software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the smurf software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue
+import pysmurf
+import os
+
+VariableGroups = {'root.LocalTime':                            ['publish','stream'],
+                  'root.SmurfApplication.SomePySmurfVariable': ['publish','stream']}
+
+
+def setupGroups(root):
+    for k,v in VariableGroups.items():
+
+        # Get node
+        n = root.getNode(k)
+
+        # Add to groups
+        for g in v:
+            n.addToGroup(g)
+
+

--- a/python/pysmurf/core/utilities/__init__.py
+++ b/python/pysmurf/core/utilities/__init__.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+#-----------------------------------------------------------------------------
+# Title      : PySMuRF Python Package Directory File
+#-----------------------------------------------------------------------------
+# File       : __init__.py
+# Created    : 2019-09-30
+#-----------------------------------------------------------------------------
+# Description:
+#    Mark this directory as python package directory.
+#-----------------------------------------------------------------------------
+# This file is part of the smurf software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the smurf software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+from pysmurf.core.utilities._SetupGroups import setupGroups
+


### PR DESCRIPTION
Here I have defined the streaming group to be 'stream'. Any variable in this group will be streamed to the data file and to the OCS back end. I have also created a utility script to define the variable list group and update the variable group membership on the startup of the root object.