### PR TITLE
Fix pysmurf package state

### DIFF
--- a/python/pysmurf/__init__.py
+++ b/python/pysmurf/__init__.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+#-----------------------------------------------------------------------------
+# Title      : PySMuRF Python Package Directory File
+#-----------------------------------------------------------------------------
+# File       : __init__.py
+# Created    : 2019-09-30
+#-----------------------------------------------------------------------------
+# Description:
+#    Mark this directory as python package directory.
+#-----------------------------------------------------------------------------
+# This file is part of the smurf software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the smurf software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------

--- a/python/pysmurf/core/devices/_SmurfApplication.py
+++ b/python/pysmurf/core/devices/_SmurfApplication.py
@@ -37,10 +37,8 @@ class SmurfApplication(pyrogue.Device):
         self.add(pyrogue.LocalVariable(
             name='SmurfDirectory',
             description='Path to SMURF Python Files',
-            mode='RO',
-            value=''))
-            # TO DO: pysmurf doesn't have a '__file__' attribute
-            #value=os.path.dirname(pysmurf.__file__)))
+            value=os.path.dirname(pysmurf.__file__),
+            mode='RO'))
 
         self.add(pyrogue.LocalVariable(
             name='SomePySmurfVariable',


### PR DESCRIPTION
Add __init__.py to pysmurf sub-dir so that it operates as a proper python package. 

Also restore pysmurf directory variable. 