### PR TITLE
Fix automatic documentation builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
 pyepics
+matplotlib


### PR DESCRIPTION
Builds on readthedocs were failing silently due to maptlotlib not being in `requirements.txt`. This just adds it, fixing the documentation builds.