### PR TITLE
Update smurf-rogue image to version R2.3.1

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.3.0
+FROM tidair/smurf-rogue:R2.3.1
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src


### PR DESCRIPTION
This new version has a rogue patch that was causing the root's close() methods to hang, as described here: https://jira.slac.stanford.edu/browse/ESCRYODET-471