### PR TITLE
Validate the SmurfProcessor's filter

### DIFF
--- a/python/pysmurf/core/emulators/_DataFromFile.py
+++ b/python/pysmurf/core/emulators/_DataFromFile.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+#-----------------------------------------------------------------------------
+# Title      : PySMuRF DataFromFile
+#-----------------------------------------------------------------------------
+# File       : _StreamDataEmulator.py
+# Created    : 2019-11-15
+#-----------------------------------------------------------------------------
+# Description:
+#    Stream data from a file
+#-----------------------------------------------------------------------------
+# This file is part of the smurf software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the smurf software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import sys
+import time
+import rogue.interfaces.stream
+import pyrogue
+
+class DataFromFile(pyrogue.Device):
+    """
+    Class to stream data from a test file.
+    """
+    def __init__(self, name="DataFromFile", description="Data from file source", **kwargs):
+        pyrogue.Device.__init__(self, name=name, description=description, **kwargs)
+        self._data_master = DataMaster()
+
+        self.add(pyrogue.LocalVariable(
+            name='FileName',
+            description='Path to the data file',
+            mode='RW',
+            value='/tmp/fw/x.dat'))
+
+        self.add(pyrogue.LocalVariable(
+            name='FrameCnt',
+            description='Number of sent frames',
+            mode='RO',
+            value=0,
+            localGet = self._data_master.get_frame_cnt))
+
+        self.add(pyrogue.LocalCommand(
+            name='SendData',
+            description='Send data',
+            function=self._send_data))
+
+    def _send_data(self):
+        """
+        Method to send data from the specified text file.
+        """
+        file_name = self.FileName.get()
+        self._data_master.send_data(file_name=file_name)
+
+    def _getStreamMaster(self):
+        """
+        Method called by streamConnect, streamTap and streamConnectBiDir to access master.
+        """
+        return self._data_master
+
+
+
+class DataMaster(rogue.interfaces.stream.Master):
+    """
+    A Rogue master device, used to stream the data.
+    """
+    def __init__(self):
+        super().__init__()
+        self._frame_cnt=0
+
+    def get_frame_cnt(self):
+        """
+        Get the number of sent frames
+        """
+        return self._frame_cnt
+
+    def send_data(self, file_name):
+        """
+        Send all the data from a text file. The input data file,
+        must be a text file with data point on each line. The data
+        must be of type int16.
+        Each data point is read from the file, and then send on a
+        frame with the SMuRF header, with only the first channel
+        containing the data point.
+
+        Args:
+        -----
+        - file_name (str) : path to the input data file
+        """
+        if not file_name:
+            print("ERROR: Must define a data file first!")
+            return
+
+        try:
+            with open(file_name, 'r') as f:
+                for data in f:
+                    self.sendData(data=data)
+                    time.sleep(0.01)
+
+        except IOError:
+            print("Error trying to open {file_name}")
+
+
+    # Method for generating a frame
+    def sendData(self, data):
+        """
+        Send a Rogue Frame. The frame contains the SMuRF header and the
+        input data point in the first channel. The frame will contain only
+        one channel. The SMuRF header will be only partially filled, containing
+        only the number of channels, and a the frame counter words.
+
+        Args:
+        -----
+        - data (int) : input data (must be of type int16)
+        """
+
+        # Request a frame to hold 1 data point
+        frame = self._reqFrame(128+2, True)
+
+        # Write the number of channels
+        frame.write( bytearray((1).to_bytes(4, sys.byteorder)), 4)
+
+        # Write the frame counter into the header
+        frame.write( bytearray(self._frame_cnt.to_bytes(4, sys.byteorder)), 84)
+
+        # Write the data into the first channel
+        frame.write( bytearray(int(data).to_bytes(2, sys.byteorder, signed=True)), 128)
+
+        # Send the frame
+        self._sendFrame(frame)
+
+        # Update the frame counter
+        self._frame_cnt =  self._frame_cnt + 1

--- a/python/pysmurf/core/emulators/__init__.py
+++ b/python/pysmurf/core/emulators/__init__.py
@@ -19,3 +19,4 @@
 
 from pysmurf.core.emulators._StreamDataEmulator import StreamDataEmulator
 from pysmurf.core.emulators._StreamDataSource   import StreamDataSource
+from pysmurf.core.emulators._DataFromFile       import DataFromFile

--- a/python/pysmurf/core/transmitters/_DataToFile.py
+++ b/python/pysmurf/core/transmitters/_DataToFile.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+#-----------------------------------------------------------------------------
+# Title      : PySMuRF DataToFile
+#-----------------------------------------------------------------------------
+# File       : _StreamDataEmulator.py
+# Created    : 2019-11-15
+#-----------------------------------------------------------------------------
+# Description:
+#    Receive a stream and write the data to disk
+#-----------------------------------------------------------------------------
+# This file is part of the smurf software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the smurf software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import sys
+import rogue.interfaces.stream
+import pyrogue
+
+class DataToFile(pyrogue.Device):
+    """
+    Class to write data to a file
+    """
+    def __init__(self, name="DataToFile", description="Data to file writer", **kwargs):
+        pyrogue.Device.__init__(self, name=name, description=description, **kwargs)
+        self._data_slave = DataSlave()
+        self._meta_slave = MetaSlave()
+
+        self.add(pyrogue.LocalVariable(
+            name='FileName',
+            description='Path to the data file',
+            mode='RW',
+            value='/tmp/fw/y.dat'))
+
+        self.add(pyrogue.LocalCommand(
+            name='WriteData',
+            description='Write data to disk',
+            function=self._write_data))
+
+    def _write_data(self):
+        """
+        Method to write the data to the specified text file.
+        """
+        file_name = self.FileName.get()
+        self._data_slave.write_data(file_name=file_name)
+
+    def getDataChannel(self):
+        """
+        Method called by streamConnect, streamTap and streamConnectBiDir to access slave.
+        This is method is called to request the data channel.
+        """
+        return self._data_slave
+
+    def getMetaChannel(self):
+        """
+        Method called by streamConnect, streamTap and streamConnectBiDir to access slave.
+        This is method is called to request the metadata channel.
+        """
+        return self._meta_slave
+
+class DataSlave(rogue.interfaces.stream.Slave):
+    """
+    A Rogue slave device, used receive a stream of data and write it to disk.
+    """
+    def __init__(self):
+        super().__init__()
+        self._data = []
+
+    def write_data(self, file_name):
+        """
+        Method to write the data buffer to a text file. Writes the
+        content of the data buffer (self._data) to the output file,
+        one data point on each line as text.
+
+        Args:
+        -----
+        - file_name (str) : path to the output data file.
+        """
+        if not file_name:
+            print("ERROR: Must define a data file first!")
+            return
+
+        try:
+            with open(file_name, 'w') as f:
+                for datum in self._data:
+                    f.write(f'{str(datum)}\n')
+
+
+        except IOError:
+            print("Error trying to open {file_name}")
+
+    def _acceptFrame(self, frame):
+        """
+        Args:
+        Receive a frame with SMuRF data. The first channel is appended
+        to the data buffer.
+
+        -----
+        frame (rogue.interfaces.stream.Frame) : a frame with SMuRF data.
+        """
+        with frame.lock():
+            data = bytearray(4)
+
+            frame.read(data, 128)
+            self._data.append(int.from_bytes(bytes(data), byteorder=sys.byteorder, signed=True))
+
+            #try:
+            #    with open(self._file_name, 'a+') as f:
+            #        f.write(f'{str(data_int)}\n')
+            #except IOError:
+            #    pass
+
+
+class MetaSlave(rogue.interfaces.stream.Slave):
+    """
+    A Rogue slave device, used to connect to the metadata channel.
+    """
+    def __init__(self):
+        super().__init__()
+
+    def _acceptFrame(self, frame):
+        """
+        Receive a frame with metadata. The frame is discarded.
+
+        Args:
+        -----
+        frame (rogue.interfaces.stream.Frame) : a frame with metadata
+        """
+        pass

--- a/python/pysmurf/core/transmitters/__init__.py
+++ b/python/pysmurf/core/transmitters/__init__.py
@@ -18,3 +18,4 @@
 #-----------------------------------------------------------------------------
 
 from pysmurf.core.transmitters._BaseTransmitter import *
+from pysmurf.core.transmitters._DataToFile      import DataToFile

--- a/src/smurf/core/processors/SmurfProcessor.cpp
+++ b/src/smurf/core/processors/SmurfProcessor.cpp
@@ -509,7 +509,8 @@ void scp::SmurfProcessor::acceptFrame(ris::FramePtr frame)
                 break;
 
             // Get the mapped value from the framweBuffer and cast it
-            currentData.at(i) = static_cast<unwrap_t>(*(inIt + m * sizeof(fw_t)));
+            // Reinterpret the bytes from the frameBuffer to 'fw_t' values. And the cast that value to 'unwrap_t' values
+            currentData.at(i) = static_cast<unwrap_t>(*(reinterpret_cast<fw_t*>(&(*( inIt + m * sizeof(fw_t) )))));
 
             // Unwrap the value is the unwrapper is not disabled.
             // If it is disabled, don't do anything to the data

--- a/tests/validate_filter.py
+++ b/tests/validate_filter.py
@@ -184,6 +184,7 @@ if __name__ == "__main__":
     rmse = np.sqrt(np.square(np.subtract(y,y_smurf)).mean())
     print(f'RMSE = {rmse}')
 
+    # Verify that the 2 results are identical
     if rmse != 0:
         raise AssertionError(f'RMSE value {rmse} is not zero')
 

--- a/tests/validate_filter.py
+++ b/tests/validate_filter.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : SmurfProcessor's Filter Validation Script
+#-----------------------------------------------------------------------------
+# File       : cmb_eth.py
+# Created    : 2017-06-20
+#-----------------------------------------------------------------------------
+# Description:
+# Script to validate the behavior of the SmurfProcessor's filter
+#-----------------------------------------------------------------------------
+# This file is part of the pysmurf software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import sys
+import scipy.signal as signal
+import numpy as np
+import argparse
+
+import pyrogue
+import pysmurf
+import pysmurf.core.devices
+import pysmurf.core.transmitters
+import pysmurf.core.server_scripts.Common as common
+
+# Input arguments
+parser = argparse.ArgumentParser(description='Test the SmurfProcessor Filter.')
+# Filter order
+parser.add_argument('--filter_order',
+        type=int,
+        default=4,
+        help='Filter order')
+
+# Filter frequency
+parser.add_argument('--filter_freq',
+        type=int,
+        default=2*63/4000,
+        help='Filter order')
+
+# Number of generated points
+parser.add_argument('--input_size',
+        type=int,
+        default=1000,
+        help='Number of point to generate')
+
+# Output directory
+parser.add_argument('--out_dir',
+        type=str,
+        default='/tmp',
+        help='Directory to write the output data')
+
+
+class LocalRoot(pyrogue.Root):
+    """
+    Local root device. It contains the SmurfProcessor, connected to
+    a DataFromFile data source, and using the DataToFile transmitter.
+    It will generate frame with the data from an input text file,
+    send those frames through the SmurfProcessor, and write the results
+    to an output text file.
+    """
+    def __init__(self, **kwargs):
+        pyrogue.Root.__init__(self, name="AMCc", initRead=True, pollEn=True, **kwargs)
+
+        # Use the DataFromFile as a stream data source
+        self._streaming_stream =  pysmurf.core.emulators.DataFromFile()
+        self.add(self._streaming_stream)
+
+        # Add the SmurfProcessor, using the DataToFile transmitter
+        # to write the results to a text file
+        self._smurf_processor = pysmurf.core.devices.SmurfProcessor(
+            name="SmurfProcessor",
+            description="Process the SMuRF Streaming Data Stream",
+            root=self,
+            txDevice=pysmurf.core.transmitters.DataToFile())
+        self.add(self._smurf_processor)
+
+        # Connect the DataFromFile data source to the SmurfProcessor
+        pyrogue.streamConnect(self._streaming_stream, self._smurf_processor)
+
+# Main body
+if __name__ == "__main__":
+
+    # Parse input arguments
+    args = parser.parse_args()
+    filter_order = args.filter_order
+    filter_freq = args.filter_freq
+    input_size = args.input_size
+    input_data_file = f'{args.out_dir}/x.dat'
+    python_filtered_file = f'{args.out_dir}/y_python.dat'
+    smurf_filtered_file = f'{args.out_dir}/y_smurf.dat'
+
+    # Generate filter coefficients
+    print(f'Generating filer parameters for freq {filter_freq}, order {filter_order}... ', end='')
+    b,a = signal.butter(filter_order, filter_freq)
+    print('Done!')
+    print('Filter coefficients:')
+    print(f'  a = {a}')
+    print(f'  b = {b}')
+
+    # Generate random data, as int16
+    print(f'Generation random number, {input_size} points... ', end='')
+    x1 =  np.random.randn(input_size)
+    x2 = x1 / np.abs(x1).max() * 2**15
+    x = x2.astype('int16')
+    print('Done')
+
+    # Filter the data
+    print('Filtering data...', end='')
+    y1, _ = signal.lfilter(b, a, x, zi=signal.lfilter_zi(b, a)*[0])
+    y = y1.astype('int16')
+    print('Done')
+
+    # Save the input data to disk
+    print(f'Writing random generated data to "{input_data_file}"... ', end='')
+    np.savetxt(input_data_file, x, fmt='%i')
+    print('Done')
+
+    # Save the output data to disk
+    print(f'Writing filtered data to "{python_filtered_file}"... ', end='')
+    np.savetxt(python_filtered_file, y, fmt='%i')
+    print('Done')
+
+    # Send the input data through the SmurfProcessor, disabling the unwrapper and
+    # downsampling, and setting the filer with the generated coefficients.
+    print('Starting the SmurfProcessor, and filter the same data with it... ', end='')
+    with LocalRoot() as root:
+        # Disable the unwrapper
+        print('  Disabling data unwrapping... ', end='')
+        root.SmurfProcessor.Unwrapper.Disable.set(True)
+        print('Done')
+
+        # Disable the downsampler
+        print('  Disabling data downsampling... ', end='')
+        root.SmurfProcessor.Downsampler.Disable.set(True)
+        print('Done')
+
+        # Set the filter parameters according to our simulation
+        print('  Setting filter parameters... ', end='')
+        root.SmurfProcessor.Filter.A.set(a.tolist())
+        root.SmurfProcessor.Filter.B.set(b.tolist())
+        root.SmurfProcessor.Filter.Order.set(4)
+        print('Done')
+
+        # Print current filter settings
+        print('  Filter set to:')
+        print(f'    order = {root.SmurfProcessor.Filter.Order.get()}')
+        print(f'    A     = {root.SmurfProcessor.Filter.A.get()}')
+        print(f'    B     = {root.SmurfProcessor.Filter.B.get()}')
+
+        # Set the input data file
+        print(f'  Setting input data file to "{input_data_file}"... ', end='')
+        root.DataFromFile.FileName.set(input_data_file)
+        print('Done.')
+
+        # Set the output data file
+        print(f'  Setting output data file to "{smurf_filtered_file}"... ', end='')
+        root.SmurfProcessor.DataToFile.FileName.set(smurf_filtered_file)
+        print('Done.')
+
+        # Start sending the data trough the processor
+        print('  Sending data through the SmurfProcessor... ', end='')
+        root.DataFromFile.SendData.call()
+        print('Done.')
+
+        print(f'    Number of frame sent = {root.DataFromFile.FrameCnt.get()}')
+
+        # Write the results
+        print('  Writing results... ', end='')
+        root.SmurfProcessor.DataToFile.WriteData.call()
+        print('Done.')
+
+
+    # Load the results obtained using the smurf processor
+    print('Reading results... ', end='')
+    y_smurf = np.loadtxt(smurf_filtered_file, dtype='int16')
+    print('Done.')
+
+    # Calculate the RMSE between the 2 filter's output
+    rmse = np.sqrt(np.square(np.subtract(y,y_smurf)).mean())
+    print(f'RMSE = {rmse}')
+
+    if rmse != 0:
+        raise AssertionError(f'RMSE value {rmse} is not zero')
+
+
+    print('SmurfProcessor filter test passed!')


### PR DESCRIPTION
There was a bug in the SmurfProcessor code, before the filter, which was processing the data in an incorrect way. 
The filter itself was implemented correctly. 
I added a validation script that generates random data, filters it using `scipy.signal.lfilter`, then sends the same data trough the SmurfProcessor with only the filter enabled, and with the same filter parameters used for the `scipy.signal.lfilter` filter and then compares the two results. It calculates the RMSE and verify that it is 0.

https://jira.slac.stanford.edu/browse/ESCRYODET-479