### PR TITLE
Bug fix: validate_filter.py was using a hard-code filter order of 4

### DIFF
--- a/tests/validate_filter.py
+++ b/tests/validate_filter.py
@@ -143,7 +143,7 @@ if __name__ == "__main__":
         print('  Setting filter parameters... ', end='')
         root.SmurfProcessor.Filter.A.set(a.tolist())
         root.SmurfProcessor.Filter.B.set(b.tolist())
-        root.SmurfProcessor.Filter.Order.set(4)
+        root.SmurfProcessor.Filter.Order.set(filter_order)
         print('Done')
 
         # Print current filter settings


### PR DESCRIPTION
When setting the SMuRF processor filter. Use the filter_order variable instead now.