### PR TITLE
Use stream connect instead of setSlave

### DIFF
--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -154,7 +154,7 @@ class Common(pyrogue.Root):
                         fifo_size = stream_pv_size * 4
 
                     self._stream_fifos.append(rogue.interfaces.stream.Fifo(1000, fifo_size, True)) # changes
-                    self._stream_fifos[i]._setSlave(self._stream_slaves[i])
+                    pyrogue.streamConnect(self._stream_fifos[i],self._stream_slaves[i])
                     pyrogue.streamTap(self._ddr_streams[i], self._stream_fifos[i])
 
 

--- a/server_scripts/emulate_local.py
+++ b/server_scripts/emulate_local.py
@@ -53,6 +53,8 @@ if __name__ == "__main__":
                          disable_bay0   = False,
                          disable_bay1   = False) as root:
 
+        root.saveVariableList("varlist.txt")
+
         # Start the GUI
         import pyrogue.gui
         print("Starting GUI...\n")


### PR DESCRIPTION
Replaces a call to fifo.setSlave() with streamConnect() to prepare for an updated rogue version which removes setSlave().