### PR TITLE
Update smurf-rogue base image to version R2.4.0

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.3.1
+FROM tidair/smurf-rogue:R2.4.0
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src


### PR DESCRIPTION
https://jira.slac.stanford.edu/browse/ESCRYODET-497