### PR TITLE
Build pysmurf in "RelWithDebInfo" mode to have debug symbols 

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.4.1
+FROM tidair/smurf-rogue:R2.5.0
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -16,7 +16,7 @@ RUN git clone https://github.com/slaclab/pysmurf.git -b ${branch}
 WORKDIR pysmurf
 RUN mkdir build
 WORKDIR build
-RUN cmake -DCMAKE_BUILD_TYPE=Release .. && make -j4
+RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .. && make -j4
 ENV PYTHONPATH /usr/local/src/pysmurf/lib:${PYTHONPATH}
 ENV PYTHONPATH /usr/local/src/pysmurf/python:${PYTHONPATH}
 ENV SMURF_DIR /usr/local/src/pysmurf


### PR DESCRIPTION
The smurf-rogue base image was also updated to R2.5.0 in which Rogue is built in the same "RelWithDebInfo" mode as well.

https://jira.slac.stanford.edu/browse/ESCRYODET-519