### PR TITLE
Bug fix: Move declaration of the std::thread to after the declaration 

### DIFF
--- a/include/smurf/core/processors/SmurfProcessor.h
+++ b/include/smurf/core/processors/SmurfProcessor.h
@@ -145,10 +145,10 @@ namespace smurf
                 std::vector<filter_t>    dataCopy;              // A copy of the data to be send
                 bool                     txDataReady;           // Flag to indicate new data is ready t be sent
                 std::atomic<bool>        runTxThread;           // Flag used to stop the thread
-                std::thread              pktTransmitterThread;  // Thread to send the data to the next slave
                 std::condition_variable  txCV;                  // Variable to notify the thread new data is ready
                 std::mutex               txMutex;               // Mutex used for accessing the conditional variable
                 std::mutex               outDataMutex;          // Mutex used to access the data in the transition method
+                std::thread              pktTransmitterThread;  // Thread to send the data to the next slave
 
                 //** METHOD **//
                 void                    pktTansmitter();        // Send frame to the next slave

--- a/include/smurf/core/transmitters/DualDataBuffer.h
+++ b/include/smurf/core/transmitters/DualDataBuffer.h
@@ -83,9 +83,9 @@ namespace smurf
                 std::size_t             dataCnt;      // Number of data elements in the buffer
                 bool                    txDataReady;  // Flag to indicate new data is ready t be sent
                 std::atomic<bool>       runTxThread;  // Flag used to stop the thread
-                std::thread             txThread;     // Thread where the SMuRF packet transmission will run
                 std::condition_variable txCV;         // Variable to notify the thread new data is ready
                 std::mutex              txMutex;      // Mutex used for accessing the conditional variable
+                std::thread             txThread;     // Thread where the SMuRF packet transmission will run
 
                 // Transmit method. Will run in the 'txThread' thread.
                 // Here is where the txFunc callback function will be called.


### PR DESCRIPTION
of the mutex they use, so that the mutex already exist when they are used. 

https://jira.slac.stanford.edu/browse/ESCRYODET-526