### PR TITLE
Update smurf-rogue base image to version R2.5.1

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.5.0
+FROM tidair/smurf-rogue:R2.5.1
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src


### PR DESCRIPTION
This version include this [bug fix](https://github.com/slaclab/rogue/pull/602) in Rogue that was causing a deadlock as reported in [ESCRYODET-533](https://jira.slac.stanford.edu/browse/ESCRYODET-533)