### PR TITLE
Disable streamEnable on stream_data_off

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -778,8 +778,8 @@ class SmurfUtilMixin(SmurfBase):
         Turns off streaming data.
         """
         self.close_data_file(write_log=write_log)
+        self.set_stream_enable(0, write_log=write_log, wait_after=.15)
 
-        
     def read_stream_data(self, datafile, channel=None,
                          n_samp=None, array_size=None):
         """


### PR DESCRIPTION
This PR just disables streaming when `stream_data_off` is called. This is to prevent data from being sent to the smurf-streamer when users don't want to be streaming data.