### PR TITLE
Update the processing of zip files

### DIFF
--- a/python/pysmurf/core/server_scripts/Common.py
+++ b/python/pysmurf/core/server_scripts/Common.py
@@ -198,6 +198,9 @@ def get_args():
                     print("Not found. Omitting it.")
                     args['config_file'] = None
 
+        else:
+            print("Invalid zip file. Omitting it.")
+
     return args
 
 def verify_ip(args):


### PR DESCRIPTION
The generated pyrogue zip files contain the python directory under a top level directory (with the name of the project). The code was written assuming that the python directory was at the top level instead. This PR fix it, and in order to be backward compatible accept both cases. 

Found during this test:
https://jira.slac.stanford.edu/browse/ESCRYODET-543