### PR TITLE
Expose and interface to define the VariableGroups from the top server

### DIFF
--- a/python/pysmurf/core/roots/CmbEth.py
+++ b/python/pysmurf/core/roots/CmbEth.py
@@ -36,6 +36,7 @@ class CmbEth(Common):
                  disable_bay1   = False,
                  txDevice       = None,
                  configure      = False,
+                 VariableGroups = None,
                  **kwargs):
 
 
@@ -78,5 +79,6 @@ class CmbEth(Common):
                               pv_dump_file   = pv_dump_file,
                               txDevice       = txDevice,
                               configure      = configure,
+                              VariableGroups = VariableGroups,
                               **kwargs)
 

--- a/python/pysmurf/core/roots/CmbPcie.py
+++ b/python/pysmurf/core/roots/CmbPcie.py
@@ -39,6 +39,7 @@ class CmbPcie(Common):
                  disable_bay1   = False,
                  txDevice       = None,
                  configure      = False,
+                 VariableGroups = None,
                  **kwargs):
 
         # TDEST 0 routed to streamr0 (SRPv3)
@@ -73,5 +74,6 @@ class CmbPcie(Common):
                               pv_dump_file   = pv_dump_file,
                               txDevice       = txDevice,
                               configure      = configure,
+                              VariableGroups = VariableGroups,
                               **kwargs)
 

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -37,6 +37,7 @@ class Common(pyrogue.Root):
                  stream_pv_size = 2**19,    # Not sub-classed
                  stream_pv_type = 'Int16',  # Not sub-classed
                  configure      = False,
+                 VariableGroups = None,
                  **kwargs):
 
         pyrogue.Root.__init__(self, name="AMCc", initRead=True, pollEn=polling_en, streamIncGroups='stream', **kwargs)
@@ -131,6 +132,9 @@ class Common(pyrogue.Root):
         # once the root is started.
         self._configure = configure
 
+        # Variable groups
+        self._VariableGroups = VariableGroups
+
         # Add epics interface
         self._epics = None
         if epics_prefix:
@@ -186,7 +190,7 @@ class Common(pyrogue.Root):
         pyrogue.Root.start(self)
 
         # Setup groups
-        pysmurf.core.utilities.setupGroups(self)
+        pysmurf.core.utilities.setupGroups(self, self._VariableGroups)
 
         # Show image build information
         try:

--- a/python/pysmurf/core/server_scripts/_VariableGroupExample.py
+++ b/python/pysmurf/core/server_scripts/_VariableGroupExample.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : Variable Group Definition Example
+#-----------------------------------------------------------------------------
+# File       : cmb_eth.py
+# Created    : 2017-06-20
+#-----------------------------------------------------------------------------
+# Description:
+# Example of how to define a VariableGroups dictionary.
+#-----------------------------------------------------------------------------
+# This file is part of the pysmurf software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+# Below is a dictionary with the key being the path to a Rogue Device or Variable
+# The 'groups' entry provides a list of groups to add the Device/Variable to. If the
+# path points to a device, the group will be added recursively to all devices and
+# variables deeper in the path.
+# The 'pollInterval' entry provides an optional value which will be used to update
+# the polling interface if the path points to a variable. The poll interval value
+# is in seconds. Use None to leave interval unchanged, 0 to disable polling.
+
+VariableGroups = {
+    'root.RogueVersion'     : {'groups' : ['publish','stream'], 'pollInterval': None},
+    'root.RogueDirectory'   : {'groups' : ['publish','stream'], 'pollInterval': None},
+    'root.SmurfApplication' : {'groups' : ['publish','stream'], 'pollInterval': None},
+    'root.SmurfProcessor'   : {'groups' : ['publish','stream'], 'pollInterval': None},
+    }

--- a/python/pysmurf/core/utilities/_SetupGroups.py
+++ b/python/pysmurf/core/utilities/_SetupGroups.py
@@ -21,39 +21,47 @@ import pyrogue
 import pysmurf
 import os
 
-# Below is a dictionary with the key being the path to a Rogue Device or Variable
-# The 'groups' entry provides a list of groups to add the Device/Variable to. If the
-# path points to a device, the group will be added recursively to all devices and
-# variables deeper in the path.
-# The 'pollInterval' entry provides an optional value which will be used to update
-# the polling interface if the path points to a variable. The poll interval value
-# is in seconds. Use None to leave interval unchanged, 0 to disable polling.
+def setupGroups(root, VariableGroups):
+    """
+    Set variable groups.
 
-VariableGroups = {
-    'root.RogueVersion'     : {'groups' : ['publish','stream'], 'pollInterval': None},
-    'root.RogueDirectory'   : {'groups' : ['publish','stream'], 'pollInterval': None},
-    'root.SmurfApplication' : {'groups' : ['publish','stream'], 'pollInterval': None},
-    'root.SmurfProcessor'   : {'groups' : ['publish','stream'], 'pollInterval': None},
-    }
+    Args:
+    -----
+    VariableGroups (dict) : each entry must have the form
+                            '<Rogue device or Variable>' :
+                                {'groups' : [<list of groups>],
+                                 'pollInterval': <poll interval> }
 
+                            The 'groups' entry provides a list of groups to add the Device/Variable to.
+                            If the path points to a device, the group will be added recursively to all
+                            devices and variables deeper in the path.
+                            The 'pollInterval' entry provides an optional value which will be used to update
+                            the polling interface if the path points to a variable. The poll interval value
+                            is in seconds. Use None to leave interval unchanged, 0 to disable polling.
+                            If this argument is 'None' then nothing will be done.
 
-def setupGroups(root):
-    for k,v in VariableGroups.items():
+    Ret:
+    -----
+    None
+    """
 
-        # Get node
-        n = root.getNode(k)
+    if VariableGroups:
+        for k,v in VariableGroups.items():
 
-        # Did we find the node?
-        if n is not None:
+            # Get node
+            n = root.getNode(k)
 
-            # Add to each group
-            for grp in v['groups']:
-                n.addToGroup(grp)
+            # Did we find the node?
+            if n is not None:
 
-            # Update poll interval if provided.
-            if v['pollInterval'] is not None and n.isinstance(pyrogue.BaseVariable):
-                n.pollInterval = v['pollInterval']
+                # Add to each group
+                for grp in v['groups']:
+                    n.addToGroup(grp)
 
-        else:
-            print(f"setupGroups: Warning: {k} not found!")
+                # Update poll interval if provided.
+                if v['pollInterval'] is not None and n.isinstance(pyrogue.BaseVariable):
+                    n.pollInterval = v['pollInterval']
+
+            else:
+                print(f"setupGroups: Warning: {k} not found!")
 

--- a/server_scripts/cmb_eth.py
+++ b/server_scripts/cmb_eth.py
@@ -40,6 +40,10 @@ if __name__ == "__main__":
     common.verify_ip(args)
     common.ping_fpga(args)
 
+    # Define variable groups (we use the provided example definition)
+    # We can disable it by defining "VariableGroups = None" instead.
+    from pysmurf.core.server_scripts._VariableGroupExample import VariableGroups
+
     # The PCIeCard object will take care of setting up the PCIe card (if present)
     with pysmurf.core.devices.PcieCard( lane      = args['pcie_rssi_lane'],
                                         comm_type = "eth-rssi-interleaved",
@@ -54,7 +58,8 @@ if __name__ == "__main__":
                      pv_dump_file   = args['pv_dump_file'],
                      disable_bay0   = args['disable_bay0'],
                      disable_bay1   = args['disable_bay1'],
-                     configure      = args['configure']) as root:
+                     configure      = args['configure'],
+                     VariableGroups = VariableGroups) as root:
 
             if args['use_gui']:
                 # Start the GUI

--- a/server_scripts/cmb_pcie.py
+++ b/server_scripts/cmb_pcie.py
@@ -37,6 +37,10 @@ if __name__ == "__main__":
     if args['ip_addr']:
         common.verify_ip(args)
 
+    # Define variable groups (we use the provided example definition)
+    # We can disable it by defining "VariableGroups = None" instead.
+    from pysmurf.core.server_scripts._VariableGroupExample import VariableGroups
+
     # The PCIeCard object will take care of setting up the PCIe card (if present)
     with pysmurf.core.devices.PcieCard( lane      = args['pcie_rssi_lane'],
                                         comm_type = "pcie-rssi-interleaved",
@@ -53,7 +57,8 @@ if __name__ == "__main__":
                       pcie_rssi_lane = args['pcie_rssi_lane'],
                       pcie_dev_rssi  = args['pcie_dev_rssi'],
                       pcie_dev_data  = args['pcie_dev_data'],
-                      configure      = args['configure']) as root:
+                      configure      = args['configure'],
+                      VariableGroups = VariableGroups) as root:
 
             if args['use_gui']:
                 # Start the GUI


### PR DESCRIPTION
startup script. And move the current definition to a separate file
as an example.