### PR TITLE
Changed common argument parsing to use argparse

### DIFF
--- a/python/pysmurf/core/server_scripts/Common.py
+++ b/python/pysmurf/core/server_scripts/Common.py
@@ -132,32 +132,32 @@ def make_parser(parser=None):
     group = parser.add_argument_group('SMuRF Args')
 
     group.add_argument('--zip', '-z', dest='zip_file', default="",
-        help="Pyrogue zip file to be included in python path"
+        help="Pyrogue zip file to be included in python path."
     )
     group.add_argument('--addr', '-a', dest='ip_addr', default="",
-        help="FPGA IP address. Required when the communication is based off on Ethernet."
+        help="FPGA IP address. Required when the communication type is based on Ethernet."
     )
     group.add_argument('--defaults', '-d', dest='config_file',
         help="Default configuration file. If the path is relative, it refers to "
-             f"the zip file (i.e: file.zip/python/{top_rogue_package_name}/config/config_file.yml)."
+             f"the zip file (i.e: <file.zip>/python/{top_rogue_package_name}/config/<config_file.yml>)."
     )
     group.add_argument('--configure', '-c', action='store_true',
-        help="Load the default configuration at startup"
+        help="Load the default configuration at startup."
     )
     group.add_argument('--epics', '-e', dest='epics_prefix', default="",
-        help="Start an EPICS server with PV name prefix \"prefix\""
+        help="Start an EPICS server with PV name prefix \"prefix\"."
     )
     group.add_argument('--gui', '-g', action='store_true', dest='use_gui',
-        help="Starts the server with a gui"
+        help="Starts the server with a gui."
     )
     group.add_argument('--nopoll', '-n', action='store_false', dest='polling_en',
-        help="Disables all polling"
+        help="Disables all polling."
     )
     group.add_argument('--pcie-rssi-lane', '-l', type=int, choices=[0,1,2,3,4,5],
         help="PCIe RSSI lane. Only needed when using PCIe communication.", dest='pcie_rssi_lane'
     )
     group.add_argument('--dump-pvs', '-u', dest='pv_dump_file', default="",
-        help="Dump the PV list to \"file_name\". Must be used with -e"
+        help="Dump the PV list to \"file_name\". Must be used with -e."
     )
     group.add_argument('--disable-bay0', action='store_true',
         help="Disable the instantiation of devices for Bay 0."
@@ -171,11 +171,11 @@ def make_parser(parser=None):
     )
     group.add_argument('--pcie-dev-rssi', default="/dev/datadev_0",
         help="Set the PCIe card device name used for RSSI "
-             "(defaults to '/dev/datadev_0')"
+             "(defaults to '/dev/datadev_0')."
     )
     group.add_argument('--pcie-dev-data', default="/dev/datadev_1",
         help="Set the PCIe card device name used for data "
-             "(defaults to '/dev/datadev_1')"
+             "(defaults to '/dev/datadev_1')."
     )
 
     return parser

--- a/python/pysmurf/core/server_scripts/Common.py
+++ b/python/pysmurf/core/server_scripts/Common.py
@@ -135,11 +135,11 @@ def make_parser(parser=None):
         help="Pyrogue zip file to be included in python path"
     )
     group.add_argument('--addr', '-a', dest='ip_addr', default="",
-        help="FPGA IP address. Required when the communication iss based off on Ethernet."
+        help="FPGA IP address. Required when the communication is based off on Ethernet."
     )
     group.add_argument('--defaults', '-d', dest='config_file',
         help="Default configuration file. If the path is relative, it refers to "
-             "the zip file (i.e: file.zip/config/config_file.yml)."
+             f"the zip file (i.e: file.zip/python/{top_rogue_package_name}/config/config_file.yml)."
     )
     group.add_argument('--configure', '-c', action='store_true',
         help="Load the default configuration at startup"
@@ -153,8 +153,8 @@ def make_parser(parser=None):
     group.add_argument('--nopoll', '-n', action='store_false', dest='polling_en',
         help="Disables all polling"
     )
-    group.add_argument('--pcie-rssi-link', '-l', type=int, choices=[0,1,2,3,4,5],
-        help="PCIe RSSI lane.", dest='pcie_rssi_lane'
+    group.add_argument('--pcie-rssi-lane', '-l', type=int, choices=[0,1,2,3,4,5],
+        help="PCIe RSSI lane. Only needed when using PCIe communication.", dest='pcie_rssi_lane'
     )
     group.add_argument('--dump-pvs', '-u', dest='pv_dump_file', default="",
         help="Dump the PV list to \"file_name\". Must be used with -e"
@@ -167,7 +167,7 @@ def make_parser(parser=None):
     )
     group.add_argument('--windows-title', '-w', default="",
         help="Sets the GUI windows title. Defaults to name of this script. "
-             "This value will be ignored when running in server mode"
+             "This value will be ignored when running in server mode."
     )
     group.add_argument('--pcie-dev-rssi', default="/dev/datadev_0",
         help="Set the PCIe card device name used for RSSI "

--- a/python/pysmurf/core/server_scripts/Common.py
+++ b/python/pysmurf/core/server_scripts/Common.py
@@ -18,130 +18,35 @@
 #-----------------------------------------------------------------------------
 
 import sys
-import getopt
 import pyrogue
 import socket
 import subprocess
 import os
 import zipfile
+import argparse
 
-# Print the usage message
-def usage(name):
-    print("Usage: {}".format(name))
-    print("        [-z|--zip file] [-a|--addr IP_address] [-g|--gui]")
-    print("        [-e|--epics prefix] [-n|--nopoll] [-l|--pcie-rssi-lane index]")
-    print("        [-d|--defaults config_file] [-u|--dump-pvs file_name]")
-    print("        [--disable-bay0] [--disable-bay1] [-w|--windows-title title]")
-    print("        [--pcie-dev-rssi pice_device] [--pcie-dev-data pice_device]")
-    print("        [-c||--configure] [-h|--help]")
-    print("")
-    print("    -h|--help                   : Show this message")
-    print("    -z|--zip file               : Pyrogue zip file to be included in"\
-        "the python path.")
-    print("    -a|--addr IP_address        : FPGA IP address. Required when"\
-        "the communication type is based on Ethernet.")
-    print("    -d|--defaults config_file   : Default configuration file. If the path is"\
-        "relative, it refers to the zip file (i.e: file.zip/config/config_file.yml).")
-    print("    -c|--configure              : Load the default configuration at startup.")
-    print("    -e|--epics prefix           : Start an EPICS server with",\
-        "PV name prefix \"prefix\"")
-    print("    -g|--gui                    : Start the server with a GUI.")
-    print("    -n|--nopoll                 : Disable all polling")
-    print("    -l|--pcie-rssi-lane index   : PCIe RSSI lane (only needed with"\
-        "PCIe). Supported values are 0 to 5")
-    print("    -u|--dump-pvs file_name     : Dump the PV list to \"file_name\".",\
-        "(Must be used with -e)")
-    print("    --disable-bay0              : Disable the instantiation of the"\
-        "devices for Bay0")
-    print("    --disable-bay1              : Disable the instantiation of the"\
-        "devices for Bay1")
-    print("    -w|--windows-title title    : Set the GUI windows title. If not"\
-        "specified, the default windows title will be the name of this script."\
-        "This value will be ignored when running in server mode.")
-    print("    --pcie-dev-rssi pice_device : Set the PCIe card device name"\
-        "used for RSSI (defaults to '/dev/datadev_0')")
-    print("    --pcie-dev-data pice_device : Set the PCIe card device name"\
-        "used for data (defaults to '/dev/datadev_1')")
-    print("")
-    print("Examples:")
-    print("    {} -a IP_address              :".format(name),\
-        " Start a local rogue server, with GUI, without an EPICS servers")
-    print("    {} -a IP_address -e prefix    :".format(name),\
-        " Start a local rogue server, with GUI, with and EPICS server")
-    print("    {} -a IP_address -e prefix -s :".format(name),\
-        " Start a local rogue server, without GUI, with an EPICS servers")
-    print("")
 
-# Parse the args
 def get_args():
+    """
+        Parses and processes args, returning the modified arguments as a dict. 
+        This is to maintain backwards compatibility with the old of parsing
+        arguments.
+    """
+    parser = make_parser()
+    args = parser.parse_args()
+    process_args(args)
+    return vars(args)
 
-    # Defaults
-    args = {'zip_file' : "",
-            'ip_addr' : "",
-            'epics_prefix' : "",
-            'config_file' : None,
-            'use_gui' : False,
-            'polling_en' : True,
-            'pcie_rssi_lane' : None,
-            'pv_dump_file' : "",
-            'pcie_dev_rssi' : "/dev/datadev_0",
-            'pcie_dev_data' : "/dev/datadev_1",
-            'disable_bay0' : False,
-            'disable_bay1' : False,
-            'windows_title' : "",
-            'configure' : False }
 
-    # Read Arguments
-    try:
-        opts, _ = getopt.getopt(sys.argv[1:],
-            "hz:a:ge:d:nb:f:l:u:w:c",
-            ["help", "zip=", "addr=", "gui", "epics=", "defaults=", "nopoll",
-            "pcie-rssi-link=", "dump-pvs=",
-            "disable-bay0", "disable-bay1", "windows-title=", "pcie-dev-rssi=",
-            "pcie-dev-data=","configure"])
-
-    except getopt.GetoptError as e:
-        print("ERROR while parsing input arguments:")
-        print(e)
-        print("")
-        sys.exit()
-
-    for opt, arg in opts:
-        if opt in ("-h", "--help"):
-            usage(sys.argv[0])
-            sys.exit()
-        elif opt in ("-z", "--zip"):
-            args['zip_file'] = arg
-        elif opt in ("-a", "--addr"):        # IP Address
-            args['ip_addr'] = arg
-        elif opt in ("-g", "--gui"):         # Use a GUI
-            args['use_gui'] = True
-        elif opt in ("-e", "--epics"):       # EPICS prefix
-            args['epics_prefix'] = arg
-        elif opt in ("-n", "--nopoll"):      # Disable all polling
-            args['polling_en'] = False
-        elif opt in ("-d", "--defaults"):   # Default configuration file
-            args['config_file'] = arg
-        elif opt in ("-l", "--pcie-rssi-link"):       # PCIe RSSI Link
-            args['pcie_rssi_lane'] = int(arg)
-        elif opt in ("-u", "--dump-pvs"):   # Dump PV file
-            args['pv_dump_file'] = arg
-        elif opt in ("--disable-bay0"):
-            args['disable_bay0'] = True
-        elif opt in ("--disable-bay1"):
-            args['disable_bay1'] = True
-        elif opt in ("-w", "--windows-title"):
-            args['windows_title'] = arg
-        elif opt in ("--pcie-dev-rssi"):
-            args['pcie_dev_rssi'] = arg
-        elif opt in ("--pcie-dev-data"):
-            args['pcie_dev_data'] = arg
-        elif opt in ["-c", "--configure"]:
-            args['configure'] = True
+def process_args(args):
+    """
+        Processes args from argparse. Unzips zip_file and finds/sets the
+        args.config_file
+    """
 
     # Verify if the zip file was specified
-    if args['zip_file']:
-        zip_file_name = args['zip_file']
+    if args.zip_file:
+        zip_file_name = args.zip_file
 
         # Verify if the zip file exist and if it is valid
         if os.path.exists(zip_file_name) and zipfile.is_zipfile(zip_file_name):
@@ -187,10 +92,10 @@ def get_args():
 
             # If the default configuration file was given using a relative path,
             # it is refereed to the zip file, so build its full path.
-            if args['config_file'] and args['config_file'][0] != '/':
+            if args.config_file and args.config_file[0] != '/':
                 # The configuration file will be in a directory called 'config' parallel to
                 # the 'python' directory
-                config_file = top_name + "config/" + args['config_file']
+                config_file = top_name + "config/" + args.config_file
 
                 print("Default configuration was defined with a relative path.")
                 print(f"Looking if the zip file contains: {config_file}")
@@ -199,24 +104,34 @@ def get_args():
                 if config_file in file_list:
                     # If found, build the full path to it, including the path to the zip file
                     print("Found!")
-                    args['config_file'] = zip_file_name + "/" + config_file
+                    args.config_file = zip_file_name + "/" + config_file
                 else:
                     # if not found, then clear the argument as it is invalid.
                     print("Not found. Omitting it.")
-                    args['config_file'] = None
+                    args.config_file = None
 
         else:
             print("Invalid zip file. Omitting it.")
 
     return args
 
+
 def verify_ip(args):
+
+    if isinstance(args, argparse.Namespace):
+        args = vars(args)
+
     try:
         socket.inet_pton(socket.AF_INET, args['ip_addr'])
     except socket.error:
         sys.exit("ERROR: Invalid IP Address.")
 
+
 def ping_fpga(args):
+
+    if isinstance(args, argparse.Namespace):
+        args = vars(args)
+
     print("")
     print("Trying to ping the FPGA...")
     try:
@@ -227,3 +142,67 @@ def ping_fpga(args):
     except subprocess.CalledProcessError:
        sys.exit("    ERROR: FPGA can't be reached!")
 
+
+def make_parser(parser=None):
+    """
+        Creates argparse parser containing smurf command-line options
+        
+        Args: 
+            parser (optional, argparse.ArgumentParser): 
+                Existing parser to add arguments to. If not specified a new one
+                will be created and returned.
+    """
+
+    if parser is None:
+        parser = argparse.ArgumentParser()
+
+    group = parser.add_argument_group('SMuRF Args') 
+
+    group.add_argument('--zip', '-z', dest='zip_file', default="",
+        help="Pyrogue zip file to be included in python path"
+    )
+    group.add_argument('--addr', '-a', dest='ip_addr', default="",
+        help="FPGA IP address. Required when the communication iss based off on Ethernet."
+    )
+    group.add_argument('--defaults', '-d', dest='config_file',
+        help="Default configuration file. If the path is relative, it refers to "
+             "the zip file (i.e: file.zip/config/config_file.yml)."
+    )
+    group.add_argument('--configure', '-c', action='store_true',
+        help="Load the default configuration at startup"
+    )
+    group.add_argument('--epics', '-e', dest='epics_prefix', default="",
+        help="Start an EPICS server with PV name prefix \"prefix\""
+    )
+    group.add_argument('--gui', '-g', action='store_true', dest='use_gui',
+        help="Starts the server with a gui"
+    )
+    group.add_argument('--nopoll', '-n', action='store_false', dest='polling_en',
+        help="Disables all polling"
+    )
+    group.add_argument('--pcie-rssi-link', '-l', type=int, choices=[0,1,2,3,4,5],
+        help="PCIe RSSI lane.", dest='pcie_rssi_lane'
+    )
+    group.add_argument('--dump-pvs', '-u', dest='pv_dump_file', default="",
+        help="Dump the PV list to \"file_name\". Must be used with -e"
+    )
+    group.add_argument('--disable-bay0', action='store_true',
+        help="Disable the instantiation of devices for Bay 0."
+    )
+    group.add_argument('--disable-bay1', action='store_true',
+        help="Disable the instantiation of devices for Bay 1"
+    )
+    group.add_argument('--windows-title', '-w', default="",
+        help="Sets the GUI windows title. Defaults to name of this script. "
+             "This value will be ignored when running in server mode"
+    )
+    group.add_argument('--pcie-dev-rssi', default="/dev/datadev_0",
+        help="Set the PCIe card device name used for RSSI "
+             "(defaults to '/dev/datadev_0')"
+    )
+    group.add_argument('--pcie-dev-data', default="/dev/datadev_1",
+        help="Set the PCIe card device name used for data "
+             "(defaults to '/dev/datadev_1')"
+    )
+
+    return parser

--- a/python/pysmurf/core/server_scripts/Common.py
+++ b/python/pysmurf/core/server_scripts/Common.py
@@ -139,13 +139,13 @@ def make_parser(parser=None):
     )
     group.add_argument('--defaults', '-d', dest='config_file',
         help="Default configuration file. If the path is relative, it refers to "
-             f"the zip file (i.e: <file.zip>/python/{top_rogue_package_name}/config/<config_file.yml>)."
+             f"the zip file (i.e: <ZIP_FILE>/python/{top_rogue_package_name}/config/<CONFIG_FILE>)."
     )
     group.add_argument('--configure', '-c', action='store_true',
         help="Load the default configuration at startup."
     )
     group.add_argument('--epics', '-e', dest='epics_prefix', default="",
-        help="Start an EPICS server with PV name prefix \"prefix\"."
+        help="Start an EPICS server with PV name prefix \"EPICS_PREFIX\"."
     )
     group.add_argument('--gui', '-g', action='store_true', dest='use_gui',
         help="Starts the server with a gui."
@@ -157,7 +157,7 @@ def make_parser(parser=None):
         help="PCIe RSSI lane. Only needed when using PCIe communication.", dest='pcie_rssi_lane'
     )
     group.add_argument('--dump-pvs', '-u', dest='pv_dump_file', default="",
-        help="Dump the PV list to \"file_name\". Must be used with -e."
+        help="Dump the PV list to \"DUMP_FILE\". Must be used with -e."
     )
     group.add_argument('--disable-bay0', action='store_true',
         help="Disable the instantiation of devices for Bay 0."


### PR DESCRIPTION
This PR changes the common argument parsing method from get_opt to argparse, so that it is more versatile and can be used by SO streaming scripts. The argument parsing is split into `make_parser` which returns a parser with all of the smurf arguments added to it, and `process_args`, which takes an args namespace and does the processing.

I left in the `get_args` function, and made it parse and process the args, and return the argument namespace as a dict, so it should still work with existing code that used that function, but I haven't tested it yet.

I have tested it with my scripts, and I'm able to do things like add my own arguments to the parser before parsing, and pre-processing the command line arguments before passing them to the parser.

Let me know if there are any changes you think I should make!