### PR TITLE
Adding ability to append to plot filenames for all plotmaking functio…

### DIFF
--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -145,8 +145,7 @@ class SmurfIVMixin(SmurfBase):
 
     def partial_load_curve_all(self, bias_high_array, bias_low_array=None, 
         wait_time=0.1, bias_step=0.1, show_plot=False, analyze=True,  
-        make_plot=True, save_plot=True, plotname_append='', 
-		channels=None, overbias_voltage=None,
+        make_plot=True, save_plot=True, channels=None, overbias_voltage=None,
         overbias_wait=1.0, phase_excursion_min=1.):
         """
         Take a partial load curve on all bias groups. Function will step 
@@ -154,12 +153,10 @@ class SmurfIVMixin(SmurfBase):
         relay (ie, will stay in high current mode if already there). Will 
         hold at the bias_low point at the end, so different bias groups 
         may have different length ramps. 
-
         Args:
         -----
         bias_high_array (float array): (n_bias_groups,) array of voltage biases, in
           bias group order
-
         Opt Args:
         -----
         bias_low_array (float array): (n_bias_groups,) array of voltage biases, in 
@@ -172,7 +169,6 @@ class SmurfIVMixin(SmurfBase):
         make_plot (bool): whether to generate plots. Default True. 
         analyze (bool): whether to analyze the data. Default True.
         save_plot (bool): whether to save generated plots. Default True.
-		plotname_append (string): Appended to the default plot filename. Default is ''.
         channels (int array): which channels to analyze. Default to anything
           that exceeds phase_excursion_min
         overbias_voltage (float): value in V at which to overbias. If None, 
@@ -258,8 +254,7 @@ class SmurfIVMixin(SmurfBase):
 
         if analyze:
             self.analyze_plc_from_file(fn_plc_raw_data, make_plot=make_plot,
-                show_plot=show_plot, save_plot=save_plot, 
-				plotname_append=plotname_append, R_sh=self.R_sh,
+                show_plot=show_plot, save_plot=save_plot, R_sh=self.R_sh,
                 high_current_mode=self.high_current_mode_bool,
                 phase_excursion_min=phase_excursion_min, channels=channels)
 
@@ -801,23 +796,20 @@ class SmurfIVMixin(SmurfBase):
         return iv_dict
 
     def analyze_plc_from_file(self, fn_plc_raw_data, make_plot=True, show_plot=False, 
-        save_plot=True, plotname_append='', R_sh=None, 
-		high_current_mode=None, phase_excursion_min=1., channels=None):
+        save_plot=True, R_sh=None, high_current_mode=None, phase_excursion_min=1., 
+        channels=None):
         """
         Function to analyze a partial load curve from its raw file. Basically 
         the same as the slow_iv analysis but without fitting the superconducting
         branch.
-
         Args:
         -----
         fn_plc_raw_data (str): *_plc_raw_data.npy file to analyze
-
         Opt Args:
         -----
         make_plot (bool): Defaults True. This is slow.
         show_plot (bool): Defaults False.
         save_plot (bool): Defaults True.
-		plotname_append (string): Appended to the default plot filename. Default is ''.
         R_sh (float): shunt resistance; defaults to the value in the config file
         high_current_mode (bool): Whether to perform analysis assuming that commanded 
           voltages were in high current mode. Defaults to the value in the config file.
@@ -884,7 +876,7 @@ class SmurfIVMixin(SmurfBase):
                         bg_str = bg_str + str(bg)
 
                     plot_name = basename + \
-                        'plc_stream_b{}_g{}_ch{:03}{}.png'.format(b, bg_str, ch, plotname_append)
+                        'plc_stream_b{}_g{}_ch{:03}.png'.format(b, bg_str, ch)
                     path = os.path.join(plot_dir, plot_name)
                     plt.savefig(path, bbox_inches='tight', dpi=300)
                     self.pub.register_file(path, 'plc_stream', plot=True)
@@ -897,11 +889,9 @@ class SmurfIVMixin(SmurfBase):
         """
         Estimate optical efficiency between two sets of load curves. Returns 
           per-channel plots and a histogram.
-
         Args:
         iv_fn_hot (str): timestamp/filename of load curve taken at higher temp
         iv_fn_cold (str): timestamp/filename of load curve taken at cooler temp
-
         Opt Args:
         t_hot (float): temperature in K of hotter load curve. Defaults to 293.
         t_cold (float): temperature in K of cooler load curve. Defaults to 77.
@@ -983,8 +973,7 @@ class SmurfIVMixin(SmurfBase):
             ax_pr.grid()
             
             # Plot name
-            plot_name = basename_hot + '_' + basename_cold + f'_optEff_g{group}_ch{ch:03}'+ \
-				plotname_append+'.png'
+            plot_name = basename_hot + '_' + basename_cold + f'_optEff_g{group}_ch{ch:03}.png'
             plot_filename = os.path.join(plot_dir, plot_name)
             self.log('Saving optical-efficiency plot to {}'.format(plot_filename))
             plt.savefig(plot_filename, bbox_inches='tight', dpi=300)
@@ -1000,11 +989,9 @@ class SmurfIVMixin(SmurfBase):
         dPdT_median = np.median(dPdT_list)
         plt.title(f'Group {group}, median = {dPdT_median:.3f} pW/K '+
             f'({n_outliers} outliers not plotted)')
-        plot_name = basename_hot + '_' + basename_cold + '_dPdT_hist_g{}{}.png'.format(group,plotname_append)
+        plot_name = basename_hot + '_' + basename_cold + '_dPdT_hist_g{}.png'.format(group)
         hist_filename = os.path.join(plot_dir,plot_name)
         self.log('Saving optical-efficiency histogram to {}'.format(hist_filename))
         plt.savefig(hist_filename, bbox_inches='tight', dpi=300)
         self.pub.register_file(hist_filename, 'opt_efficiency', plot=True)
         plt.close()
-
-

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -26,7 +26,8 @@ class SmurfIVMixin(SmurfBase):
     def slow_iv_all(self, bias_groups=None, wait_time=.1, bias=None, 
                     bias_high=1.5, bias_low=0, bias_step=.005, 
                     show_plot=False, overbias_wait=2., cool_wait=30,
-                    make_plot=True, save_plot=True, channels=None, band=None,
+                    make_plot=True, save_plot=True, plotname_append='', 
+					channels=None, band=None,
                     high_current_mode=True, overbias_voltage=8., 
                     grid_on=True, phase_excursion_min=3.):
         """
@@ -51,6 +52,7 @@ class SmurfIVMixin(SmurfBase):
             overbiasing before taking the IV.
         make_plot (bool) : Whether to make plots. Default True
         save_plot (bool) : Whether to save the plot. Default True.
+		plotname_append (string): Appended to the default plot filename. Default is ''.
         channels (int array) : A list of channels to make plots
         band (int array) : The bands to analyze
         high_current_mode (bool) : The current mode to take the IV in.
@@ -137,13 +139,14 @@ class SmurfIVMixin(SmurfBase):
 
         R_sh=self.R_sh
         self.analyze_slow_iv_from_file(fn_iv_raw_data, make_plot=make_plot,
-            show_plot=show_plot, save_plot=save_plot, R_sh=R_sh,
-            grid_on=grid_on,
+            show_plot=show_plot, save_plot=save_plot, 
+			plotname_append=plotname_append, R_sh=R_sh, grid_on=grid_on,
             phase_excursion_min=phase_excursion_min,chs=channels,band=band)
 
     def partial_load_curve_all(self, bias_high_array, bias_low_array=None, 
         wait_time=0.1, bias_step=0.1, show_plot=False, analyze=True,  
-        make_plot=True, save_plot=True, channels=None, overbias_voltage=None,
+        make_plot=True, save_plot=True, plotname_append='', 
+		channels=None, overbias_voltage=None,
         overbias_wait=1.0, phase_excursion_min=1.):
         """
         Take a partial load curve on all bias groups. Function will step 
@@ -169,6 +172,7 @@ class SmurfIVMixin(SmurfBase):
         make_plot (bool): whether to generate plots. Default True. 
         analyze (bool): whether to analyze the data. Default True.
         save_plot (bool): whether to save generated plots. Default True.
+		plotname_append (string): Appended to the default plot filename. Default is ''.
         channels (int array): which channels to analyze. Default to anything
           that exceeds phase_excursion_min
         overbias_voltage (float): value in V at which to overbias. If None, 
@@ -254,13 +258,15 @@ class SmurfIVMixin(SmurfBase):
 
         if analyze:
             self.analyze_plc_from_file(fn_plc_raw_data, make_plot=make_plot,
-                show_plot=show_plot, save_plot=save_plot, R_sh=self.R_sh,
+                show_plot=show_plot, save_plot=save_plot, 
+				plotname_append=plotname_append, R_sh=self.R_sh,
                 high_current_mode=self.high_current_mode_bool,
                 phase_excursion_min=phase_excursion_min, channels=channels)
 
 
     def analyze_slow_iv_from_file(self, fn_iv_raw_data, make_plot=True,
-                                  show_plot=False, save_plot=True, R_sh=None, 
+                                  show_plot=False, save_plot=True, 
+								  plotname_append='', R_sh=None, 
                                   phase_excursion_min=3., grid_on=False, 
                                   R_op_target=0.007,
                                   chs=None, band=None):
@@ -277,6 +283,7 @@ class SmurfIVMixin(SmurfBase):
         make_plot (bool): Defaults True. Usually this is the slowest part.
         show_plot (bool): Defaults False.
         save_plot (bool): Defaults True.
+		plotname_append (string): Appended to the default plot filename. Default is ''.
         phase_excursion_min (float): abs(max - min) of phase in radians. Analysis 
           ignores any channels without this phase excursion. Default 3.
         grid_on (bool): Whether to draw the grid on the PR plot. Defaults False
@@ -361,7 +368,7 @@ class SmurfIVMixin(SmurfBase):
 
 
                 plot_name = basename + \
-                    '_IV_stream_b{}_g{}_ch{:03}.png'.format(b, bg_str, ch)
+                    '_IV_stream_b{}_g{}_ch{:03}{}.png'.format(b, bg_str, ch, plotname_append)
                 if save_plot:
                     plot_fn = os.path.join(plot_dir, plot_name)
                     plt.savefig(plot_fn, bbox_inches='tight', dpi=300)
@@ -371,7 +378,8 @@ class SmurfIVMixin(SmurfBase):
 
             iv_dict = self.analyze_slow_iv(bias, phase, 
                 basename=basename, band=b, channel=ch, make_plot=make_plot, 
-                show_plot=show_plot, save_plot=save_plot, plot_dir=plot_dir,
+                show_plot=show_plot, save_plot=save_plot, 
+				plotname_append=plotname_append,  plot_dir=plot_dir,
                 R_sh = R_sh, high_current_mode = high_current_mode,
                 grid_on=grid_on,R_op_target=R_op_target)
             r = iv_dict['R']
@@ -475,7 +483,7 @@ class SmurfIVMixin(SmurfBase):
             # Title
             plt.suptitle('{}, band {}, group{}'.format(basename,\
                                              np.unique(band),bias_group))
-            iv_hist_filename = os.path.join(plot_dir, f'{basename}_IV_hist.png')
+            iv_hist_filename = os.path.join(plot_dir, f'{basename}_IV_hist{plotname_append}.png')
 
             # Save the figure
             plt.savefig(iv_hist_filename,bbox_inches='tight')
@@ -486,9 +494,9 @@ class SmurfIVMixin(SmurfBase):
                 plt.close()
 
     def analyze_slow_iv(self, v_bias, resp, make_plot=True, show_plot=False,
-        save_plot=True, basename=None, band=None, channel=None, R_sh=None,
-        plot_dir=None, high_current_mode=False, bias_group = None,
-        grid_on=False,R_op_target=0.007, **kwargs):
+        save_plot=True, plotname_append='', basename=None, band=None, 
+		channel=None, R_sh=None, plot_dir=None, high_current_mode=False, 
+		bias_group = None, grid_on=False,R_op_target=0.007, **kwargs):
         """
         Analyzes the IV curve taken with slow_iv()
 
@@ -663,7 +671,7 @@ class SmurfIVMixin(SmurfBase):
                 title += ', {:.2f} MHz'.format(self.channel_to_freq(band, channel))
             title += r', $R_\mathrm{sh}$ = ' + '${:.2f}$ '.format(R_sh*1.0E3) + \
                 r'$\mathrm{m}\Omega$'
-            plot_name = basename + '_' + plot_name
+            plot_name = basename + '_' + plot_name + plotname_append
             title = basename + ' ' + title
             plot_name += '.png'
 
@@ -793,8 +801,8 @@ class SmurfIVMixin(SmurfBase):
         return iv_dict
 
     def analyze_plc_from_file(self, fn_plc_raw_data, make_plot=True, show_plot=False, 
-        save_plot=True, R_sh=None, high_current_mode=None, phase_excursion_min=1., 
-        channels=None):
+        save_plot=True, plotname_append='', R_sh=None, 
+		high_current_mode=None, phase_excursion_min=1., channels=None):
         """
         Function to analyze a partial load curve from its raw file. Basically 
         the same as the slow_iv analysis but without fitting the superconducting
@@ -809,6 +817,7 @@ class SmurfIVMixin(SmurfBase):
         make_plot (bool): Defaults True. This is slow.
         show_plot (bool): Defaults False.
         save_plot (bool): Defaults True.
+		plotname_append (string): Appended to the default plot filename. Default is ''.
         R_sh (float): shunt resistance; defaults to the value in the config file
         high_current_mode (bool): Whether to perform analysis assuming that commanded 
           voltages were in high current mode. Defaults to the value in the config file.
@@ -875,7 +884,7 @@ class SmurfIVMixin(SmurfBase):
                         bg_str = bg_str + str(bg)
 
                     plot_name = basename + \
-                        'plc_stream_b{}_g{}_ch{:03}.png'.format(b, bg_str, ch)
+                        'plc_stream_b{}_g{}_ch{:03}{}.png'.format(b, bg_str, ch, plotname_append)
                     path = os.path.join(plot_dir, plot_name)
                     plt.savefig(path, bbox_inches='tight', dpi=300)
                     self.pub.register_file(path, 'plc_stream', plot=True)
@@ -974,7 +983,8 @@ class SmurfIVMixin(SmurfBase):
             ax_pr.grid()
             
             # Plot name
-            plot_name = basename_hot + '_' + basename_cold + f'_optEff_g{group}_ch{ch:03}.png'
+            plot_name = basename_hot + '_' + basename_cold + f'_optEff_g{group}_ch{ch:03}'+ \
+				plotname_append+'.png'
             plot_filename = os.path.join(plot_dir, plot_name)
             self.log('Saving optical-efficiency plot to {}'.format(plot_filename))
             plt.savefig(plot_filename, bbox_inches='tight', dpi=300)
@@ -990,7 +1000,7 @@ class SmurfIVMixin(SmurfBase):
         dPdT_median = np.median(dPdT_list)
         plt.title(f'Group {group}, median = {dPdT_median:.3f} pW/K '+
             f'({n_outliers} outliers not plotted)')
-        plot_name = basename_hot + '_' + basename_cold + '_dPdT_hist_g{}.png'.format(group)
+        plot_name = basename_hot + '_' + basename_cold + '_dPdT_hist_g{}{}.png'.format(group,plotname_append)
         hist_filename = os.path.join(plot_dir,plot_name)
         self.log('Saving optical-efficiency histogram to {}'.format(hist_filename))
         plt.savefig(hist_filename, bbox_inches='tight', dpi=300)

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -26,16 +26,13 @@ class SmurfIVMixin(SmurfBase):
     def slow_iv_all(self, bias_groups=None, wait_time=.1, bias=None, 
                     bias_high=1.5, bias_low=0, bias_step=.005, 
                     show_plot=False, overbias_wait=2., cool_wait=30,
-                    make_plot=True, save_plot=True, plotname_append='', 
-					channels=None, band=None,
+                    make_plot=True, save_plot=True, channels=None, band=None,
                     high_current_mode=True, overbias_voltage=8., 
                     grid_on=True, phase_excursion_min=3.):
         """
         Steps the TES bias down slowly. Starts at bias_high to bias_low with
         step size bias_step. Waits wait_time between changing steps.
-
         If this analyzes the data, the outputs are stored to output_dir.
-
         Opt Args:
         ---------
         bias_groups (np array): which bias groups to take the IV on. defaults
@@ -52,7 +49,6 @@ class SmurfIVMixin(SmurfBase):
             overbiasing before taking the IV.
         make_plot (bool) : Whether to make plots. Default True
         save_plot (bool) : Whether to save the plot. Default True.
-		plotname_append (string): Appended to the default plot filename. Default is ''.
         channels (int array) : A list of channels to make plots
         band (int array) : The bands to analyze
         high_current_mode (bool) : The current mode to take the IV in.
@@ -139,8 +135,8 @@ class SmurfIVMixin(SmurfBase):
 
         R_sh=self.R_sh
         self.analyze_slow_iv_from_file(fn_iv_raw_data, make_plot=make_plot,
-            show_plot=show_plot, save_plot=save_plot, 
-			plotname_append=plotname_append, R_sh=R_sh, grid_on=grid_on,
+            show_plot=show_plot, save_plot=save_plot, R_sh=R_sh,
+            grid_on=grid_on,
             phase_excursion_min=phase_excursion_min,chs=channels,band=band)
 
     def partial_load_curve_all(self, bias_high_array, bias_low_array=None, 
@@ -260,25 +256,21 @@ class SmurfIVMixin(SmurfBase):
 
 
     def analyze_slow_iv_from_file(self, fn_iv_raw_data, make_plot=True,
-                                  show_plot=False, save_plot=True, 
-								  plotname_append='', R_sh=None, 
+                                  show_plot=False, save_plot=True, R_sh=None, 
                                   phase_excursion_min=3., grid_on=False, 
                                   R_op_target=0.007,
                                   chs=None, band=None):
         """
         Function to analyze a load curve from its raw file. Can be used to 
           analyze IV's/generate plots separately from issuing commands.
-
         Args:
         -----
         fn_iv_raw_data (str): *_iv_raw_data.npy file to analyze
-
         Opt Args:
         ---------
         make_plot (bool): Defaults True. Usually this is the slowest part.
         show_plot (bool): Defaults False.
         save_plot (bool): Defaults True.
-		plotname_append (string): Appended to the default plot filename. Default is ''.
         phase_excursion_min (float): abs(max - min) of phase in radians. Analysis 
           ignores any channels without this phase excursion. Default 3.
         grid_on (bool): Whether to draw the grid on the PR plot. Defaults False
@@ -363,7 +355,7 @@ class SmurfIVMixin(SmurfBase):
 
 
                 plot_name = basename + \
-                    '_IV_stream_b{}_g{}_ch{:03}{}.png'.format(b, bg_str, ch, plotname_append)
+                    '_IV_stream_b{}_g{}_ch{:03}.png'.format(b, bg_str, ch)
                 if save_plot:
                     plot_fn = os.path.join(plot_dir, plot_name)
                     plt.savefig(plot_fn, bbox_inches='tight', dpi=300)
@@ -373,8 +365,7 @@ class SmurfIVMixin(SmurfBase):
 
             iv_dict = self.analyze_slow_iv(bias, phase, 
                 basename=basename, band=b, channel=ch, make_plot=make_plot, 
-                show_plot=show_plot, save_plot=save_plot, 
-				plotname_append=plotname_append,  plot_dir=plot_dir,
+                show_plot=show_plot, save_plot=save_plot, plot_dir=plot_dir,
                 R_sh = R_sh, high_current_mode = high_current_mode,
                 grid_on=grid_on,R_op_target=R_op_target)
             r = iv_dict['R']
@@ -478,7 +469,7 @@ class SmurfIVMixin(SmurfBase):
             # Title
             plt.suptitle('{}, band {}, group{}'.format(basename,\
                                              np.unique(band),bias_group))
-            iv_hist_filename = os.path.join(plot_dir, f'{basename}_IV_hist{plotname_append}.png')
+            iv_hist_filename = os.path.join(plot_dir, f'{basename}_IV_hist.png')
 
             # Save the figure
             plt.savefig(iv_hist_filename,bbox_inches='tight')
@@ -489,18 +480,16 @@ class SmurfIVMixin(SmurfBase):
                 plt.close()
 
     def analyze_slow_iv(self, v_bias, resp, make_plot=True, show_plot=False,
-        save_plot=True, plotname_append='', basename=None, band=None, 
-		channel=None, R_sh=None, plot_dir=None, high_current_mode=False, 
-		bias_group = None, grid_on=False,R_op_target=0.007, **kwargs):
+        save_plot=True, basename=None, band=None, channel=None, R_sh=None,
+        plot_dir=None, high_current_mode=False, bias_group = None,
+        grid_on=False,R_op_target=0.007, **kwargs):
         """
         Analyzes the IV curve taken with slow_iv()
-
         Args:
         -----
         v_bias (float array): The commanded bias in voltage. Length n_steps
         resp (float array): The TES phase response in radians. Of length 
                             n_pts (not the same as n_steps
-
         Returns:
         --------
         R (float array): 
@@ -666,7 +655,7 @@ class SmurfIVMixin(SmurfBase):
                 title += ', {:.2f} MHz'.format(self.channel_to_freq(band, channel))
             title += r', $R_\mathrm{sh}$ = ' + '${:.2f}$ '.format(R_sh*1.0E3) + \
                 r'$\mathrm{m}\Omega$'
-            plot_name = basename + '_' + plot_name + plotname_append
+            plot_name = basename + '_' + plot_name
             title = basename + ' ' + title
             plot_name += '.png'
 

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -27,7 +27,7 @@ class SmurfIVMixin(SmurfBase):
                     bias_high=1.5, bias_low=0, bias_step=.005, 
                     show_plot=False, overbias_wait=2., cool_wait=30,
                     make_plot=True, save_plot=True, plotname_append='',
-					channels=None, band=None,
+                    channels=None, band=None,
                     high_current_mode=True, overbias_voltage=8., 
                     grid_on=True, phase_excursion_min=3.):
         """
@@ -50,7 +50,7 @@ class SmurfIVMixin(SmurfBase):
             overbiasing before taking the IV.
         make_plot (bool) : Whether to make plots. Default True
         save_plot (bool) : Whether to save the plot. Default True.
-		plotname_append (string): Appended to the default plot filename. Default ''.
+        plotname_append (string): Appended to the default plot filename. Default ''.
         channels (int array) : A list of channels to make plots
         band (int array) : The bands to analyze
         high_current_mode (bool) : The current mode to take the IV in.
@@ -138,7 +138,7 @@ class SmurfIVMixin(SmurfBase):
         R_sh=self.R_sh
         self.analyze_slow_iv_from_file(fn_iv_raw_data, make_plot=make_plot,
             show_plot=show_plot, save_plot=save_plot, 
-			plotname_append=plotname_append, R_sh=R_sh, grid_on=grid_on, 
+            plotname_append=plotname_append, R_sh=R_sh, grid_on=grid_on, 
             phase_excursion_min=phase_excursion_min,chs=channels,band=band)
 
     def partial_load_curve_all(self, bias_high_array, bias_low_array=None, 
@@ -259,7 +259,7 @@ class SmurfIVMixin(SmurfBase):
 
     def analyze_slow_iv_from_file(self, fn_iv_raw_data, make_plot=True,
                                   show_plot=False, save_plot=True, 
-								  plotname_append='', R_sh=None, 
+                                  plotname_append='', R_sh=None, 
                                   phase_excursion_min=3., grid_on=False, 
                                   R_op_target=0.007,
                                   chs=None, band=None):
@@ -274,7 +274,7 @@ class SmurfIVMixin(SmurfBase):
         make_plot (bool): Defaults True. Usually this is the slowest part.
         show_plot (bool): Defaults False.
         save_plot (bool): Defaults True.
-		plotname_append (string): Appended to the default plot filename. Default ''.
+        plotname_append (string): Appended to the default plot filename. Default ''.
         phase_excursion_min (float): abs(max - min) of phase in radians. Analysis 
           ignores any channels without this phase excursion. Default 3.
         grid_on (bool): Whether to draw the grid on the PR plot. Defaults False
@@ -359,7 +359,8 @@ class SmurfIVMixin(SmurfBase):
 
 
                 plot_name = basename + \
-                    '_IV_stream_b{}_g{}_ch{:03}.png'.format(b, bg_str, ch)
+                    '_IV_stream_b{}_g{}_ch{:03}{}.png'.format(b, bg_str, ch, 
+                                                              plotname_append)
                 if save_plot:
                     plot_fn = os.path.join(plot_dir, plot_name)
                     plt.savefig(plot_fn, bbox_inches='tight', dpi=300)
@@ -370,7 +371,7 @@ class SmurfIVMixin(SmurfBase):
             iv_dict = self.analyze_slow_iv(bias, phase, 
                 basename=basename, band=b, channel=ch, make_plot=make_plot, 
                 show_plot=show_plot, save_plot=save_plot, 
-				plotname_append=plotname_append, plot_dir=plot_dir,
+                plotname_append=plotname_append, plot_dir=plot_dir,
                 R_sh = R_sh, high_current_mode = high_current_mode,
                 grid_on=grid_on,R_op_target=R_op_target)
             r = iv_dict['R']
@@ -486,7 +487,7 @@ class SmurfIVMixin(SmurfBase):
 
     def analyze_slow_iv(self, v_bias, resp, make_plot=True, show_plot=False,
         save_plot=True, plotname_append='', basename=None, band=None, channel=None, 
-		R_sh=None, plot_dir=None, high_current_mode=False, bias_group = None,
+        R_sh=None, plot_dir=None, high_current_mode=False, bias_group = None,
         grid_on=False,R_op_target=0.007, **kwargs):
         """
         Analyzes the IV curve taken with slow_iv()

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -26,7 +26,8 @@ class SmurfIVMixin(SmurfBase):
     def slow_iv_all(self, bias_groups=None, wait_time=.1, bias=None, 
                     bias_high=1.5, bias_low=0, bias_step=.005, 
                     show_plot=False, overbias_wait=2., cool_wait=30,
-                    make_plot=True, save_plot=True, channels=None, band=None,
+                    make_plot=True, save_plot=True, plotname_append='',
+					channels=None, band=None,
                     high_current_mode=True, overbias_voltage=8., 
                     grid_on=True, phase_excursion_min=3.):
         """
@@ -49,6 +50,7 @@ class SmurfIVMixin(SmurfBase):
             overbiasing before taking the IV.
         make_plot (bool) : Whether to make plots. Default True
         save_plot (bool) : Whether to save the plot. Default True.
+		plotname_append (string): Appended to the default plot filename. Default ''.
         channels (int array) : A list of channels to make plots
         band (int array) : The bands to analyze
         high_current_mode (bool) : The current mode to take the IV in.
@@ -135,8 +137,8 @@ class SmurfIVMixin(SmurfBase):
 
         R_sh=self.R_sh
         self.analyze_slow_iv_from_file(fn_iv_raw_data, make_plot=make_plot,
-            show_plot=show_plot, save_plot=save_plot, R_sh=R_sh,
-            grid_on=grid_on,
+            show_plot=show_plot, save_plot=save_plot, 
+			plotname_append=plotname_append, R_sh=R_sh, grid_on=grid_on, 
             phase_excursion_min=phase_excursion_min,chs=channels,band=band)
 
     def partial_load_curve_all(self, bias_high_array, bias_low_array=None, 
@@ -256,7 +258,8 @@ class SmurfIVMixin(SmurfBase):
 
 
     def analyze_slow_iv_from_file(self, fn_iv_raw_data, make_plot=True,
-                                  show_plot=False, save_plot=True, R_sh=None, 
+                                  show_plot=False, save_plot=True, 
+								  plotname_append='', R_sh=None, 
                                   phase_excursion_min=3., grid_on=False, 
                                   R_op_target=0.007,
                                   chs=None, band=None):
@@ -271,6 +274,7 @@ class SmurfIVMixin(SmurfBase):
         make_plot (bool): Defaults True. Usually this is the slowest part.
         show_plot (bool): Defaults False.
         save_plot (bool): Defaults True.
+		plotname_append (string): Appended to the default plot filename. Default ''.
         phase_excursion_min (float): abs(max - min) of phase in radians. Analysis 
           ignores any channels without this phase excursion. Default 3.
         grid_on (bool): Whether to draw the grid on the PR plot. Defaults False
@@ -365,7 +369,8 @@ class SmurfIVMixin(SmurfBase):
 
             iv_dict = self.analyze_slow_iv(bias, phase, 
                 basename=basename, band=b, channel=ch, make_plot=make_plot, 
-                show_plot=show_plot, save_plot=save_plot, plot_dir=plot_dir,
+                show_plot=show_plot, save_plot=save_plot, 
+				plotname_append=plotname_append, plot_dir=plot_dir,
                 R_sh = R_sh, high_current_mode = high_current_mode,
                 grid_on=grid_on,R_op_target=R_op_target)
             r = iv_dict['R']
@@ -469,7 +474,7 @@ class SmurfIVMixin(SmurfBase):
             # Title
             plt.suptitle('{}, band {}, group{}'.format(basename,\
                                              np.unique(band),bias_group))
-            iv_hist_filename = os.path.join(plot_dir, f'{basename}_IV_hist.png')
+            iv_hist_filename = os.path.join(plot_dir, f'{basename}_IV_hist{plotname_append}.png')
 
             # Save the figure
             plt.savefig(iv_hist_filename,bbox_inches='tight')
@@ -480,8 +485,8 @@ class SmurfIVMixin(SmurfBase):
                 plt.close()
 
     def analyze_slow_iv(self, v_bias, resp, make_plot=True, show_plot=False,
-        save_plot=True, basename=None, band=None, channel=None, R_sh=None,
-        plot_dir=None, high_current_mode=False, bias_group = None,
+        save_plot=True, plotname_append='', basename=None, band=None, channel=None, 
+		R_sh=None, plot_dir=None, high_current_mode=False, bias_group = None,
         grid_on=False,R_op_target=0.007, **kwargs):
         """
         Analyzes the IV curve taken with slow_iv()
@@ -657,7 +662,7 @@ class SmurfIVMixin(SmurfBase):
                 r'$\mathrm{m}\Omega$'
             plot_name = basename + '_' + plot_name
             title = basename + ' ' + title
-            plot_name += '.png'
+            plot_name += plotname_append + '.png'
 
             fig.suptitle(title)
 

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -30,7 +30,7 @@ class SmurfNoiseMixin(SmurfBase):
         channel=None, nperseg=2**12, 
         detrend='constant', fs=None, low_freq=np.array([.1, 1.]), 
         high_freq=np.array([1., 10.]), make_channel_plot=True,
-        make_summary_plot=True, save_data=False, show_plot=False,
+        make_summary_plot=True, save_data=False, plotname_append='', show_plot=False,
         grid_on=False, datafile=None, downsample_factor=None,
         write_log=True):
 
@@ -62,6 +62,7 @@ class SmurfNoiseMixin(SmurfBase):
             is True.
         save_data (bool): Whether to save the band averaged data as a text file.
             Default is False.
+		plotname_append (string): Appended to the default plot filename. Default is ''.
         show_plot (bool): Show the plot on the screen. Default False.
         datefile (str): if data has already been taken, can point to a file to 
             bypass data taking and just analyze.
@@ -211,7 +212,8 @@ class SmurfNoiseMixin(SmurfBase):
                 fig.tight_layout()
 
                 plot_name = basename + \
-                            f'_noise_timestream_b{b}_ch{ch:03}.png'
+                            f'_noise_timestream_b{b}_ch{ch:03}' + \
+							plotname_append + '.png'
                 fig.savefig(os.path.join(self.plot_dir, plot_name), 
                     bbox_inches='tight')
 
@@ -239,7 +241,7 @@ class SmurfNoiseMixin(SmurfBase):
                 ax.set_xlabel(r'Mean noise [$\mathrm{pA}/\sqrt{\mathrm{Hz}}$]')
 
                 plot_name = basename + \
-                    '{}_{}_noise_hist.png'.format(l, h)
+                    '{}_{}_noise_hist{}.png'.format(l, h, plotname_append)
                 plt.savefig(os.path.join(self.plot_dir, plot_name), 
                     bbox_inches='tight')
                 if show_plot:
@@ -276,7 +278,7 @@ class SmurfNoiseMixin(SmurfBase):
                 plt.tight_layout()
                 fig.subplots_adjust(top = 0.9)
                 noise_params_hist_fname = basename + \
-                    '_b{}_noise_params.png'.format(b)
+                    '_b{}_noise_params{}.png'.format(b, plotname_append)
                 plt.savefig(os.path.join(self.plot_dir,
                     noise_params_hist_fname),
                     bbox_inches='tight')
@@ -352,7 +354,7 @@ class SmurfNoiseMixin(SmurfBase):
                       step_size=0.25, bias=None, high_current_mode=True, 
                       overbias_voltage=9., meas_time=30., analyze=False, 
                       channel=None, nperseg=2**13, detrend='constant', 
-                      fs=None, show_plot=False, cool_wait=30.,
+                      fs=None, plotname_append='', show_plot=False, cool_wait=30.,
                       psd_ylim=(10.,1000.),make_timestream_plot=False,
                       only_overbias_once=False):
         """
@@ -383,6 +385,7 @@ class SmurfNoiseMixin(SmurfBase):
         detrend (str): Whether to detrend the data before taking the PSD.
             Default is to remove a constant.
         fs (float): The sample frequency.
+		plotname_append (string): Appended to the default plot filename. Default is ''.
         show_plot: Whether to show analysis plots. Defaults to False.
         only_overbias_once (bool): Whether or not to overbias right
             before each TES bias step
@@ -396,7 +399,8 @@ class SmurfNoiseMixin(SmurfBase):
                       var_range=bias, meas_time=meas_time,
                       analyze=analyze, channel=channel,
                       nperseg=nperseg, detrend=detrend, fs=fs,
-                      show_plot=show_plot, psd_ylim=psd_ylim,
+                      plotname_append=plotname_append, 
+					  show_plot=show_plot, psd_ylim=psd_ylim,
                       overbias_voltage=overbias_voltage,
                       cool_wait=cool_wait,high_current_mode=high_current_mode,
                       make_timestream_plot=make_timestream_plot,
@@ -405,7 +409,7 @@ class SmurfNoiseMixin(SmurfBase):
     def noise_vs_amplitude(self, band, amplitude_high=11, amplitude_low=9, step_size=1,
                            amplitudes=None,
                            meas_time=30., analyze=False, channel=None, nperseg=2**13,
-                           detrend='constant', fs=None, show_plot = False,
+                           detrend='constant', fs=None, plotname_append='', show_plot=False,
                            make_timestream_plot=False, 
                            psd_ylim = None):
         """
@@ -421,13 +425,14 @@ class SmurfNoiseMixin(SmurfBase):
 
         self.noise_vs(band=band,var='amplitude',var_range=amplitudes,
                  meas_time=meas_time, analyze=analyze, channel=channel, 
-                 nperseg=nperseg, detrend=detrend, fs=fs, show_plot=show_plot, 
+                 nperseg=nperseg, detrend=detrend, fs=fs, 
+				 plotname_append=plotname_append, show_plot=show_plot, 
                  make_timestream_plot=make_timestream_plot,  
                  psd_ylim=psd_ylim)
 
     def noise_vs(self, band, var, var_range, meas_time=30,
                  analyze=False, channel=None, nperseg=2**13,
-                 detrend='constant', fs=None, show_plot=False,
+                 detrend='constant', fs=None, plotname_append='', show_plot=False,
                  psd_ylim=None, make_timestream_plot=False,
                  only_overbias_once=False, **kwargs):
 
@@ -497,7 +502,7 @@ class SmurfNoiseMixin(SmurfBase):
                 self.run_serial_gradient_descent(band)
                 self.run_serial_eta_scan(band)
                 self.tracking_setup(band,lms_freq_hz=self.lms_freq_hz[band],
-                    save_plot=True, make_plot=True, channel=self.which_on(band),
+                    save_plot=True, plotname_append=plotname_append, make_plot=True, channel=self.which_on(band),
                     show_plot=False)
 
             self.log('Taking data')
@@ -521,7 +526,8 @@ class SmurfNoiseMixin(SmurfBase):
                                        band=band, 
                                        bias_group = kwargs['bias_group'], 
                                        nperseg=nperseg, detrend=detrend, fs=fs, 
-                                       save_plot=True, show_plot=show_plot, 
+                                       save_plot=True, plotname_append=plotname_append, 
+									   show_plot=show_plot, 
                                        data_timestamp=timestamp ,psd_ylim=psd_ylim,
                                        make_timestream_plot=make_timestream_plot,
                                        xlabel_override=xlabel_override, 
@@ -622,7 +628,7 @@ class SmurfNoiseMixin(SmurfBase):
 
     def analyze_noise_vs_bias(self, bias, datafile, channel=None, band=None,
         nperseg=2**13, detrend='constant', fs=None, save_plot=True, 
-        show_plot=False, make_timestream_plot=False, data_timestamp=None,
+        plotname_append='', show_plot=False, make_timestream_plot=False, data_timestamp=None,
         psd_ylim=(10.,1000.), bias_group=None, smooth_len=15,
         show_legend=True, freq_range_summary=None, R_sh=None,
         high_current_mode=True, iv_data_filename=None, NEP_ylim=(10.,1000.),
@@ -648,6 +654,7 @@ class SmurfNoiseMixin(SmurfBase):
         detrend (str): Passed to scipy.signal.welch.
         fs (float): Passed to scipy.signal.welch. The sample rate.
         save_plot (bool): Whether to save the plot. Default is True.
+		plotname_append (string): Appended to the default plot filename. Default is ''.
         show_plot (bool): Whether to how the plot. Default is False.
         data_timestamp (str): The string used as a save name. Default is None.
         bias_group (int or int array): which bias groups were used. Default is None. 
@@ -983,8 +990,8 @@ class SmurfNoiseMixin(SmurfBase):
                 plt.show()
 
             if save_plot:
-                plot_name = 'noise_vs_bias_band{}_g{}ch{:03}.png'.format(band,
-                    file_name_string, ch)
+                plot_name = 'noise_vs_bias_band{}_g{}ch{:03}{}.png'.format(band,
+                    file_name_string, ch, plotname_append)
                 if data_timestamp is not None:
                     plot_name = '{}_'.format(data_timestamp) + plot_name
                 else:
@@ -1071,7 +1078,8 @@ class SmurfNoiseMixin(SmurfBase):
         if show_plot:
             plt.show()
         if save_plot:
-            plot_name = 'noise_vs_bias_band{}_g{}NEI_hist.png'.format(band,file_name_string)
+            plot_name = 'noise_vs_bias_band{}_g{}NEI_hist{}.png'.format(band,
+			file_name_string,plotname_append)
             if data_timestamp is not None:
                 plot_name = '{}_'.format(data_timestamp) + plot_name
             else:
@@ -1117,7 +1125,8 @@ class SmurfNoiseMixin(SmurfBase):
             if show_plot:
                 plt.show()
             if save_plot:
-                plot_name = 'noise_vs_bias_band{}_g{}NEP_hist.png'.format(band,file_name_string)
+                plot_name = 'noise_vs_bias_band{}_g{}NEP_hist{}.png'.format(band,
+				file_name_string, plotname_append)
                 if data_timestamp is not None:
                     plot_name = '{}_'.format(data_timestamp) + plot_name
                 else:
@@ -1334,7 +1343,7 @@ class SmurfNoiseMixin(SmurfBase):
 
     def analyze_noise_vs_tone(self, tone, datafile, channel=None, band=None,
         nperseg=2**13, detrend='constant', fs=None, save_plot=True, 
-        show_plot=False, make_timestream_plot=False, data_timestamp=None,
+        plotname_append='', show_plot=False, make_timestream_plot=False, data_timestamp=None,
         psd_ylim=(10.,1000.), bias_group=None, smooth_len=11,
         show_legend=True, freq_range_summary=None):
         """
@@ -1396,7 +1405,7 @@ class SmurfNoiseMixin(SmurfBase):
                         plt.show()
                     if save_plot:
                         plt.savefig(os.path.join(self.plot_dir, basename + \
-                                    '_timestream_ch{:03}.png'.format(ch)),\
+                                    '_timestream_ch{:03}{}.png'.format(ch, plotname_append)),\
                                     bbox_inches='tight')
                         plt.close()
 
@@ -1512,7 +1521,8 @@ class SmurfNoiseMixin(SmurfBase):
                 plt.show()
 
             if save_plot:
-                plot_name = 'noise_vs_tone_band{}_g{}ch{:03}.png'.format(band,file_name_string,ch)
+                plot_name = 'noise_vs_tone_band{}_g{}ch{:03}{}.png'.format(band,
+				file_name_string,ch,plotname_append)
                 if data_timestamp is not None:
                     plot_name = '{}_'.format(data_timestamp) + plot_name
                 else:

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -310,7 +310,9 @@ class SmurfNoiseMixin(SmurfBase):
 
     def noise_vs_tone(self, band, tones=np.arange(10,15), meas_time=30,
                       analyze=False, bias_group=None, lms_freq_hz=None,
-                      fraction_full_scale=.72):
+                      fraction_full_scale=.72, save_plot=False, 
+					  plotname_append='', show_plot=False, 
+					  make_timestream_plot=False):
         """
         """
         timestamp = self.get_timestamp()
@@ -346,7 +348,11 @@ class SmurfNoiseMixin(SmurfBase):
         
         if analyze:
             self.analyze_noise_vs_tone(tone_save, datafile_save,
-                                       band=band, bias_group=bias_group)
+                                       band=band, bias_group=bias_group, 
+									   save_plot=save_plot, 
+									   plotname_append=plotname_append,
+									   show_plot=show_plot, 
+									   make_timestream_plot=make_timestream_plot)
         
 
 

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -297,7 +297,6 @@ class SmurfNoiseMixin(SmurfBase):
         band (int): The band to search
         noise (float array): The noise floors. Presumably calculated
             using take_noise_psd.
-
         Optional Args:
         --------------
         cutoff (float) : The value to cut at in the same units as noise.
@@ -310,9 +309,7 @@ class SmurfNoiseMixin(SmurfBase):
 
     def noise_vs_tone(self, band, tones=np.arange(10,15), meas_time=30,
                       analyze=False, bias_group=None, lms_freq_hz=None,
-                      fraction_full_scale=.72, save_plot=False, 
-					  plotname_append='', show_plot=False, 
-					  make_timestream_plot=False):
+                      fraction_full_scale=.72):
         """
         """
         timestamp = self.get_timestamp()
@@ -348,11 +345,7 @@ class SmurfNoiseMixin(SmurfBase):
         
         if analyze:
             self.analyze_noise_vs_tone(tone_save, datafile_save,
-                                       band=band, bias_group=bias_group, 
-									   save_plot=save_plot, 
-									   plotname_append=plotname_append,
-									   show_plot=show_plot, 
-									   make_timestream_plot=make_timestream_plot)
+                                       band=band, bias_group=bias_group)
         
 
 
@@ -360,7 +353,7 @@ class SmurfNoiseMixin(SmurfBase):
                       step_size=0.25, bias=None, high_current_mode=True, 
                       overbias_voltage=9., meas_time=30., analyze=False, 
                       channel=None, nperseg=2**13, detrend='constant', 
-                      fs=None, plotname_append='', show_plot=False, cool_wait=30.,
+                      fs=None, show_plot=False, cool_wait=30.,
                       psd_ylim=(10.,1000.),make_timestream_plot=False,
                       only_overbias_once=False):
         """
@@ -368,12 +361,10 @@ class SmurfNoiseMixin(SmurfBase):
         measurements. You can make it analyze the data and make plots with the
         optional argument analyze=True. Note that the analysis is a little
         slow.
-
         Args:
         -----
         band (int): The band to take noise vs bias data on
         bias_group (int or int array): which bias group(s) to bias/read back.
-
         Opt Args:
         ---------
         bias (float array): The array of bias values to step through. If None,
@@ -391,7 +382,6 @@ class SmurfNoiseMixin(SmurfBase):
         detrend (str): Whether to detrend the data before taking the PSD.
             Default is to remove a constant.
         fs (float): The sample frequency.
-		plotname_append (string): Appended to the default plot filename. Default is ''.
         show_plot: Whether to show analysis plots. Defaults to False.
         only_overbias_once (bool): Whether or not to overbias right
             before each TES bias step
@@ -405,8 +395,7 @@ class SmurfNoiseMixin(SmurfBase):
                       var_range=bias, meas_time=meas_time,
                       analyze=analyze, channel=channel,
                       nperseg=nperseg, detrend=detrend, fs=fs,
-                      plotname_append=plotname_append, 
-					  show_plot=show_plot, psd_ylim=psd_ylim,
+                      show_plot=show_plot, psd_ylim=psd_ylim,
                       overbias_voltage=overbias_voltage,
                       cool_wait=cool_wait,high_current_mode=high_current_mode,
                       make_timestream_plot=make_timestream_plot,
@@ -415,7 +404,7 @@ class SmurfNoiseMixin(SmurfBase):
     def noise_vs_amplitude(self, band, amplitude_high=11, amplitude_low=9, step_size=1,
                            amplitudes=None,
                            meas_time=30., analyze=False, channel=None, nperseg=2**13,
-                           detrend='constant', fs=None, plotname_append='', show_plot=False,
+                           detrend='constant', fs=None, show_plot = False,
                            make_timestream_plot=False, 
                            psd_ylim = None):
         """
@@ -431,14 +420,13 @@ class SmurfNoiseMixin(SmurfBase):
 
         self.noise_vs(band=band,var='amplitude',var_range=amplitudes,
                  meas_time=meas_time, analyze=analyze, channel=channel, 
-                 nperseg=nperseg, detrend=detrend, fs=fs, 
-				 plotname_append=plotname_append, show_plot=show_plot, 
+                 nperseg=nperseg, detrend=detrend, fs=fs, show_plot=show_plot, 
                  make_timestream_plot=make_timestream_plot,  
                  psd_ylim=psd_ylim)
 
     def noise_vs(self, band, var, var_range, meas_time=30,
                  analyze=False, channel=None, nperseg=2**13,
-                 detrend='constant', fs=None, plotname_append='', show_plot=False,
+                 detrend='constant', fs=None, show_plot=False,
                  psd_ylim=None, make_timestream_plot=False,
                  only_overbias_once=False, **kwargs):
 
@@ -508,7 +496,7 @@ class SmurfNoiseMixin(SmurfBase):
                 self.run_serial_gradient_descent(band)
                 self.run_serial_eta_scan(band)
                 self.tracking_setup(band,lms_freq_hz=self.lms_freq_hz[band],
-                    save_plot=True, plotname_append=plotname_append, make_plot=True, channel=self.which_on(band),
+                    save_plot=True, make_plot=True, channel=self.which_on(band),
                     show_plot=False)
 
             self.log('Taking data')
@@ -532,8 +520,7 @@ class SmurfNoiseMixin(SmurfBase):
                                        band=band, 
                                        bias_group = kwargs['bias_group'], 
                                        nperseg=nperseg, detrend=detrend, fs=fs, 
-                                       save_plot=True, plotname_append=plotname_append, 
-									   show_plot=show_plot, 
+                                       save_plot=True, show_plot=show_plot, 
                                        data_timestamp=timestamp ,psd_ylim=psd_ylim,
                                        make_timestream_plot=make_timestream_plot,
                                        xlabel_override=xlabel_override, 
@@ -543,7 +530,6 @@ class SmurfNoiseMixin(SmurfBase):
         '''
         For, e.g., noise_vs_bias, the list of datafiles is recorded in a txt file. 
         This function simply extracts those filenames and returns them as a list.
-
         Args:
         -----
         fn_datafiles (str): full path to txt containing names of data files
@@ -560,7 +546,6 @@ class SmurfNoiseMixin(SmurfBase):
         For, e.g., noise_vs_bias, the list of commanded bias voltages is 
         recorded in a txt file. This function simply extracts those values and 
         returns them as a list.
-
         Args:
         -----
         fn_biases (str): full path to txt containing list of bias voltages
@@ -581,7 +566,6 @@ class SmurfNoiseMixin(SmurfBase):
         '''
         Takes IV data and extracts responsivities as a function of commanded
         bias voltage.
-
         Parameters
         ----------
         iv_data_filename (str): filename of output of IV analysis
@@ -612,7 +596,6 @@ class SmurfNoiseMixin(SmurfBase):
     def NEI_to_NEP(self,iv_band_data,ch,v_bias):
         '''
         Takes NEI in pA/rtHz and converts to NEP in aW/rtHz.
-
         Parameters
         ----------
         si_dict (dict): dictionary indexed by channel number; each entry is
@@ -623,7 +606,6 @@ class SmurfNoiseMixin(SmurfBase):
                                each element of si_dict.
         v_bias (float): commanded bias voltage at which to estimate NEP
         Pxx (array): NEI in pA/rtHz
-
         Returns
         -------
         1/si (float): noise-equivalent power in aW/rtHz
@@ -634,7 +616,7 @@ class SmurfNoiseMixin(SmurfBase):
 
     def analyze_noise_vs_bias(self, bias, datafile, channel=None, band=None,
         nperseg=2**13, detrend='constant', fs=None, save_plot=True, 
-        plotname_append='', show_plot=False, make_timestream_plot=False, data_timestamp=None,
+        show_plot=False, make_timestream_plot=False, data_timestamp=None,
         psd_ylim=(10.,1000.), bias_group=None, smooth_len=15,
         show_legend=True, freq_range_summary=None, R_sh=None,
         high_current_mode=True, iv_data_filename=None, NEP_ylim=(10.,1000.),
@@ -642,7 +624,6 @@ class SmurfNoiseMixin(SmurfBase):
         unit_override=None):
         """
         Analysis script associated with noise_vs_bias.
-
         Args:
         -----
         bias (float array): The bias in voltage. Can also pass an absolute 
@@ -650,7 +631,6 @@ class SmurfNoiseMixin(SmurfBase):
         datafile (str array): The paths to the datafiles. Must be same length 
             as bias array. Can also pass an absolute path to a txt containing 
             the names of the datafiles.
-
         Opt Args:
         ---------
         channel (int array): The channels to analyze.
@@ -660,7 +640,6 @@ class SmurfNoiseMixin(SmurfBase):
         detrend (str): Passed to scipy.signal.welch.
         fs (float): Passed to scipy.signal.welch. The sample rate.
         save_plot (bool): Whether to save the plot. Default is True.
-		plotname_append (string): Appended to the default plot filename. Default is ''.
         show_plot (bool): Whether to how the plot. Default is False.
         data_timestamp (str): The string used as a save name. Default is None.
         bias_group (int or int array): which bias groups were used. Default is None. 
@@ -996,8 +975,8 @@ class SmurfNoiseMixin(SmurfBase):
                 plt.show()
 
             if save_plot:
-                plot_name = 'noise_vs_bias_band{}_g{}ch{:03}{}.png'.format(band,
-                    file_name_string, ch, plotname_append)
+                plot_name = 'noise_vs_bias_band{}_g{}ch{:03}.png'.format(band,
+                    file_name_string, ch)
                 if data_timestamp is not None:
                     plot_name = '{}_'.format(data_timestamp) + plot_name
                 else:
@@ -1084,8 +1063,7 @@ class SmurfNoiseMixin(SmurfBase):
         if show_plot:
             plt.show()
         if save_plot:
-            plot_name = 'noise_vs_bias_band{}_g{}NEI_hist{}.png'.format(band,
-			file_name_string,plotname_append)
+            plot_name = 'noise_vs_bias_band{}_g{}NEI_hist.png'.format(band,file_name_string)
             if data_timestamp is not None:
                 plot_name = '{}_'.format(data_timestamp) + plot_name
             else:
@@ -1131,8 +1109,7 @@ class SmurfNoiseMixin(SmurfBase):
             if show_plot:
                 plt.show()
             if save_plot:
-                plot_name = 'noise_vs_bias_band{}_g{}NEP_hist{}.png'.format(band,
-				file_name_string, plotname_append)
+                plot_name = 'noise_vs_bias_band{}_g{}NEP_hist.png'.format(band,file_name_string)
                 if data_timestamp is not None:
                     plot_name = '{}_'.format(data_timestamp) + plot_name
                 else:
@@ -1149,19 +1126,16 @@ class SmurfNoiseMixin(SmurfBase):
         Return model fit for a PSD.
         p0 (float array): initial guesses for model fitting: [white-noise level 
         in pA/rtHz, exponent of 1/f^n component, knee frequency in Hz]
-
         Args:
         -----
         f (float array) : The frequency information
         Pxx (float array) : The power spectral data
-
         Opt Args:
         ---------
         fs (float) : Sampling frequency. If None, loads in the current
             sampling frequency.
         flux_ramp_freq (float) : The flux ramp frequency in Hz
         p0 (float array) : Initial guess for fitting PSDs
-
         Ret:
         ----
         popt (float array) : The fit parameters - [white_noise_level, n, f_knee]
@@ -1219,11 +1193,9 @@ class SmurfNoiseMixin(SmurfBase):
         """
         Measures the noise with all the resonators on, then measures
         every channel individually.
-
         Args:
         -----
         band (int) : The band number
-
         Opt Args:
         ---------
         meas_time (float) : The measurement time per resonator in
@@ -1260,7 +1232,6 @@ class SmurfNoiseMixin(SmurfBase):
                                         make_channel_plot=False):
         """
         analyzes the data from noise_all_vs_noise_solo
-
         Args:
         -----
         ret (dict) : The returned values from noise_all_vs_noise_solo.
@@ -1313,21 +1284,18 @@ class SmurfNoiseMixin(SmurfBase):
         '''
         Converts current spectral noise density to NET in uK rt(s). Assumes NEI 
         is white-noise level.
-
         Args
         ----
         NEI (float): current spectral density in pA/rtHz
         V_b (float): commanded bias voltage in V
         R_tes (float): resistance of TES at bias point in Ohm
         opt_eff (float): optical efficiency (in the range 0-1)
-
         Opt Args:
         ---------
         f_center (float): center optical frequency of detector in Hz, e.g., 150 GHz for E4c
         bw (float): effective optical bandwidth of detector in Hz, e.g., 32 GHz for E4c
         R_sh (float): shunt resistance in Ohm; defaults to stored config figure
         high_current_mode (bool): whether the bias voltage was set in high-current mode
-
         Ret:
         ----
         NET (float) : The noise equivalent temperature in units of uKrts
@@ -1349,7 +1317,7 @@ class SmurfNoiseMixin(SmurfBase):
 
     def analyze_noise_vs_tone(self, tone, datafile, channel=None, band=None,
         nperseg=2**13, detrend='constant', fs=None, save_plot=True, 
-        plotname_append='', show_plot=False, make_timestream_plot=False, data_timestamp=None,
+        show_plot=False, make_timestream_plot=False, data_timestamp=None,
         psd_ylim=(10.,1000.), bias_group=None, smooth_len=11,
         show_legend=True, freq_range_summary=None):
         """
@@ -1411,7 +1379,7 @@ class SmurfNoiseMixin(SmurfBase):
                         plt.show()
                     if save_plot:
                         plt.savefig(os.path.join(self.plot_dir, basename + \
-                                    '_timestream_ch{:03}{}.png'.format(ch, plotname_append)),\
+                                    '_timestream_ch{:03}.png'.format(ch)),\
                                     bbox_inches='tight')
                         plt.close()
 
@@ -1527,8 +1495,7 @@ class SmurfNoiseMixin(SmurfBase):
                 plt.show()
 
             if save_plot:
-                plot_name = 'noise_vs_tone_band{}_g{}ch{:03}{}.png'.format(band,
-				file_name_string,ch,plotname_append)
+                plot_name = 'noise_vs_tone_band{}_g{}ch{:03}.png'.format(band,file_name_string,ch)
                 if data_timestamp is not None:
                     plot_name = '{}_'.format(data_timestamp) + plot_name
                 else:
@@ -1548,17 +1515,14 @@ class SmurfNoiseMixin(SmurfBase):
         """
         Calculates the SVD modes of the input data.
         Only uses the data called out by the mask
-
         Args:
         -----
         d (float array) : The raw data
         mask (int array) : The channel mask
-
         Opt Args:
         ---------
         mean_subtract (bool) : Whether to mean subtract
             before taking the SVDs.
-
         Ret:
         ----
         u (float array) : The SVD coefficients
@@ -1577,12 +1541,10 @@ class SmurfNoiseMixin(SmurfBase):
         """
         Requires seaborn to be installed. Plots a heatmap
         of the coefficients and the log10 of the amplitudes.
-
         Args:
         -----
         u (float array) : SVD coefficients from noise_svd
         s (float array) : SVD amplitudes from noise_svd
-
         Opt Args:
         ---------
         save_plot (bool) : Whether to save the plot
@@ -1630,7 +1592,6 @@ class SmurfNoiseMixin(SmurfBase):
         save_plot=False, save_name=None, show_plot=False, sharey=True):
         """
         Plots the first N modes where N is n_row x n_col.
-
         Args:
         -----
         vh (float array) : SVD modes from noise_svd
@@ -1680,7 +1641,6 @@ class SmurfNoiseMixin(SmurfBase):
     def remove_svd(self, d, mask, u, s, vh, modes=3):
         """
         Removes the requsted SVD modes
-
         Args:
         -----
         d (float array) : The input data
@@ -1688,12 +1648,10 @@ class SmurfNoiseMixin(SmurfBase):
         s (float array) : The SVD amplitudes
         mask (int array) : The channel mask
         vh (float arrry) : The SVD modes
-
         Opt Args:
         ---------
         modes (int or int array) : The modes to remove. If int, removes the first
             N modes. If array, uses the modes indicated in the array. Default 3.
-
         Ret:
         ----
         diff (float array) : The difference of the input data matrix and the 

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -30,7 +30,7 @@ class SmurfNoiseMixin(SmurfBase):
         channel=None, nperseg=2**12, 
         detrend='constant', fs=None, low_freq=np.array([.1, 1.]), 
         high_freq=np.array([1., 10.]), make_channel_plot=True,
-        make_summary_plot=True, save_data=False, plotname_append='', show_plot=False,
+        make_summary_plot=True, save_data=False, show_plot=False,
         grid_on=False, datafile=None, downsample_factor=None,
         write_log=True):
 
@@ -39,11 +39,9 @@ class SmurfNoiseMixin(SmurfBase):
         attempts to fit a white noise and 1/f component to the data.
         It takes into account the sampling frequency and the downsampling
         filter and downsampler. 
-
         Args:
         -----
         meas_time (float): The amount of time to observe in seconds.
-
         Opt Args:
         ---------
         channel (int array): The channels to plot. Note that this script always
@@ -62,7 +60,6 @@ class SmurfNoiseMixin(SmurfBase):
             is True.
         save_data (bool): Whether to save the band averaged data as a text file.
             Default is False.
-		plotname_append (string): Appended to the default plot filename. Default is ''.
         show_plot (bool): Show the plot on the screen. Default False.
         datefile (str): if data has already been taken, can point to a file to 
             bypass data taking and just analyze.
@@ -212,8 +209,7 @@ class SmurfNoiseMixin(SmurfBase):
                 fig.tight_layout()
 
                 plot_name = basename + \
-                            f'_noise_timestream_b{b}_ch{ch:03}' + \
-							plotname_append + '.png'
+                            f'_noise_timestream_b{b}_ch{ch:03}.png'
                 fig.savefig(os.path.join(self.plot_dir, plot_name), 
                     bbox_inches='tight')
 
@@ -241,7 +237,7 @@ class SmurfNoiseMixin(SmurfBase):
                 ax.set_xlabel(r'Mean noise [$\mathrm{pA}/\sqrt{\mathrm{Hz}}$]')
 
                 plot_name = basename + \
-                    '{}_{}_noise_hist{}.png'.format(l, h, plotname_append)
+                    '{}_{}_noise_hist.png'.format(l, h)
                 plt.savefig(os.path.join(self.plot_dir, plot_name), 
                     bbox_inches='tight')
                 if show_plot:
@@ -278,7 +274,7 @@ class SmurfNoiseMixin(SmurfBase):
                 plt.tight_layout()
                 fig.subplots_adjust(top = 0.9)
                 noise_params_hist_fname = basename + \
-                    '_b{}_noise_params{}.png'.format(b, plotname_append)
+                    '_b{}_noise_params.png'.format(b)
                 plt.savefig(os.path.join(self.plot_dir,
                     noise_params_hist_fname),
                     bbox_inches='tight')

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -30,7 +30,8 @@ class SmurfNoiseMixin(SmurfBase):
         channel=None, nperseg=2**12, 
         detrend='constant', fs=None, low_freq=np.array([.1, 1.]), 
         high_freq=np.array([1., 10.]), make_channel_plot=True,
-        make_summary_plot=True, save_data=False, show_plot=False,
+        make_summary_plot=True, plotname_append='',
+        save_data=False, show_plot=False,
         grid_on=False, datafile=None, downsample_factor=None,
         write_log=True):
 
@@ -60,6 +61,7 @@ class SmurfNoiseMixin(SmurfBase):
             is True.
         save_data (bool): Whether to save the band averaged data as a text file.
             Default is False.
+        plotname_append (string): Appended to the default plot filename. Default ''.
         show_plot (bool): Show the plot on the screen. Default False.
         datefile (str): if data has already been taken, can point to a file to 
             bypass data taking and just analyze.
@@ -209,7 +211,7 @@ class SmurfNoiseMixin(SmurfBase):
                 fig.tight_layout()
 
                 plot_name = basename + \
-                            f'_noise_timestream_b{b}_ch{ch:03}.png'
+                            f'_noise_timestream_b{b}_ch{ch:03}{plotname_append}.png'
                 fig.savefig(os.path.join(self.plot_dir, plot_name), 
                     bbox_inches='tight')
 
@@ -237,7 +239,7 @@ class SmurfNoiseMixin(SmurfBase):
                 ax.set_xlabel(r'Mean noise [$\mathrm{pA}/\sqrt{\mathrm{Hz}}$]')
 
                 plot_name = basename + \
-                    '{}_{}_noise_hist.png'.format(l, h)
+                    '{}_{}_noise_hist{}.png'.format(l, h, plotname_append)
                 plt.savefig(os.path.join(self.plot_dir, plot_name), 
                     bbox_inches='tight')
                 if show_plot:
@@ -274,7 +276,7 @@ class SmurfNoiseMixin(SmurfBase):
                 plt.tight_layout()
                 fig.subplots_adjust(top = 0.9)
                 noise_params_hist_fname = basename + \
-                    '_b{}_noise_params.png'.format(b)
+                    '_b{}_noise_params{}.png'.format(b, plotname_append)
                 plt.savefig(os.path.join(self.plot_dir,
                     noise_params_hist_fname),
                     bbox_inches='tight')

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -381,7 +381,7 @@ class SmurfTuneMixin(SmurfBase):
 
         
     def plot_tune_summary(self, band, eta_scan=False, show_plot=False,
-        save_plot=True, eta_width=.3):
+        save_plot=True, plotname_append='', eta_width=.3):
         """
         Plots summary of tuning. Requires self.freq_resp to be filled.
         In other words, you must run find_freq and setup_notches
@@ -399,6 +399,7 @@ class SmurfTuneMixin(SmurfBase):
            Warning this is slow. Default is False.
         show_plot (bool) : Whether to display the plot. Default is False.
         save_plot (bool) : Whether to save the plot. Default is True.
+        plotname_append (string): Appended to the default plot filename. Default is ''.
         eta_width (float) : The width to plot in MHz.
         """
         if show_plot:
@@ -456,7 +457,8 @@ class SmurfTuneMixin(SmurfBase):
                             wspace=.21, hspace=.21)
 
         if save_plot:
-            save_name = '{}_tune_summary.png'.format(timestamp)
+            save_name = '{}_tune_summary{}.png'.format(timestamp, 
+                                                        plotname_append)
             path = os.path.join(self.plot_dir, save_name)
             plt.savefig(path, bbox_inches='tight')
             self.pub.register_file(path, 'tune', plot=True)
@@ -482,8 +484,9 @@ class SmurfTuneMixin(SmurfBase):
                     self.plot_eta_fit(freq[idx], resp[idx], 
                         eta_mag=r['eta_mag'], eta_phase_deg=r['eta_phase'],
                         band=band, res_num=k, timestamp=timestamp, 
-                        save_plot=save_plot, show_plot=show_plot, 
-                        peak_freq=center_freq, channel=r['channel'])
+                        save_plot=save_plot, plotname_append=plotname_append, 
+                        show_plot=show_plot, peak_freq=center_freq, 
+                        channel=r['channel'])
             # This is for data from find_freq/setup_notches
             else:
                 for k in keys:
@@ -493,6 +496,7 @@ class SmurfTuneMixin(SmurfBase):
                         eta=r['eta'], eta_mag=r['eta_mag'], 
                         eta_phase_deg=r['eta_phase'], band=band, res_num=k,
                         timestamp=timestamp, save_plot=save_plot,
+                        plotname_append=plotname_append, 
                         show_plot=show_plot, peak_freq=r['freq'])
 
 
@@ -659,10 +663,10 @@ class SmurfTuneMixin(SmurfBase):
 
     def find_peak(self, freq, resp, rolling_med=True, window=5000,
         grad_cut=.5, amp_cut=.25, freq_min=-2.5E8, freq_max=2.5E8, 
-        make_plot=False, save_plot=True, show_plot=False, band=None, 
-        subband=None, make_subband_plot=False,  subband_plot_with_slow=False, 
-        timestamp=None, pad=50, min_gap=100, plot_title=None, 
-        grad_kernel_width=8):
+        make_plot=False, save_plot=True, plotname_append='', show_plot=False, 
+        band=None, subband=None, make_subband_plot=False, 
+        subband_plot_with_slow=False, timestamp=None, pad=50, min_gap=100,
+        plot_title=None, grad_kernel_width=8):
         """find the peaks within a given subband
         Args:
         -----
@@ -686,6 +690,8 @@ class SmurfTuneMixin(SmurfBase):
             very slow. Default is False.
         save_plot (bool): Whether to save the plot to self.plot_dir. Default
             is True.
+        plotname_append (string): Appended to the default plot filename. 
+            Default is ''.
         band (int): The band to take find the peaks in. Mainly for saving
             and plotting.
         timestamp (str): The timestamp. Mainly for saving and plotting
@@ -778,7 +784,7 @@ class SmurfTuneMixin(SmurfBase):
                     save_name = save_name + '_b{}'.format(int(band))
                 if subband is not None:
                     save_name = save_name + '_sb{}'.format(int(subband))
-                save_name = save_name + '_find_freq.png'
+                save_name = save_name + '_find_freq' + plotname_append + '.png'
                 path = os.path.join(self.plot_dir, save_name)
                 plt.savefig(path, bbox_inches='tight', dpi=300)
                 self.pub.register_file(path, 'find_freq', plot=True)
@@ -858,7 +864,8 @@ class SmurfTuneMixin(SmurfBase):
                         ax[1].plot(ff+sbc[1][sb], np.abs(dd)/2.5E6)
 
                     if save_plot:
-                        save_name = f'{timestamp}_find_freq_b{band}_sb{sb:03}.png'
+                        pna = plotname_append
+                        save_name = f'{timestamp}_find_freq_b{band}_sb{sb:03}{pna}.png'
                         os.path.join(self.plot_dir, save_name)
                         plt.savefig(path, bbox_inches='tight')
                         self.pub.register_file(path, 'find_freq', plot=True)
@@ -1120,9 +1127,9 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def plot_eta_fit(self, freq, resp, eta=None, eta_mag=None, peak_freq=None,
-        eta_phase_deg=None, r2=None, save_plot=True, show_plot=False, timestamp=None, 
-        res_num=None, band=None, sk_fit=None, f_slow=None, resp_slow=None,
-        channel=None):
+        eta_phase_deg=None, r2=None, save_plot=True, plotname_append='', 
+        show_plot=False, timestamp=None, res_num=None, band=None, 
+        sk_fit=None, f_slow=None, resp_slow=None, channel=None):
         """
         Plots the eta parameter fits
         Args:
@@ -1136,6 +1143,7 @@ class SmurfTuneMixin(SmurfBase):
         eta_phase_deg (float): The angle of the eta parameter in degrees
         r2 (float): The R^2 value
         save_plot (bool): Whether to save the plot. Default True.
+        plotname_append (string): Appended to the default plot filename. Default ''.
         timestamp (str): The timestamp to name the file
         res_num (int): The resonator number to label the plot
         band (int): The band number to label the plot
@@ -1258,10 +1266,10 @@ class SmurfTuneMixin(SmurfBase):
 
         if save_plot:
             if res_num is not None and band is not None:
-                save_name = '{}_eta_b{}_res{:03}.png'.format(timestamp, band, 
-                    res_num)
+                save_name = '{}_eta_b{}_res{:03}{}.png'.format(timestamp, band, 
+                    res_num, plotname_append)
             else:
-                save_name = '{}_eta.png'.format(timestamp)
+                save_name = '{}_eta{}.png'.format(timestamp, plotname_append)
 
             path = os.path.join(self.plot_dir, save_name)
             plt.savefig(path, bbox_inches='tight')
@@ -1993,11 +2001,11 @@ class SmurfTuneMixin(SmurfBase):
         return d, df, sync
 
     def tracking_setup(self, band, channel=None, reset_rate_khz=None, 
-        write_log=False, make_plot=False, save_plot=True, show_plot=True, 
-        nsamp=2**19, lms_freq_hz=None, meas_lms_freq=False, flux_ramp=True, 
-        fraction_full_scale=None, lms_enable1=True, lms_enable2=True, 
-        lms_enable3=True, lms_gain=None, return_data=True, new_epics_root=None,
-        feedback_start_frac=None, feedback_end_frac=None):
+        write_log=False, make_plot=False, save_plot=True, plotname_append='',
+        show_plot=True, nsamp=2**19, lms_freq_hz=None, meas_lms_freq=False, 
+        flux_ramp=True, fraction_full_scale=None, lms_enable1=True, 
+        lms_enable2=True, lms_enable3=True, lms_gain=None, return_data=True,
+        new_epics_root=None, feedback_start_frac=None, feedback_end_frac=None):
         """
         The function to start tracking. Starts the flux ramp and if requested
         attempts to measure the lms (demodulation) frequency. Otherwise this
@@ -2013,6 +2021,7 @@ class SmurfTuneMixin(SmurfBase):
         write_log (bool) : Whether to write output to the log.  Default False.
         make_plot (bool) : Whether to make plots. Default False.
         save_plot (bool) : Whether to save plots. Default True.
+        plotname_append (string): Appended to the default plot filename. Default ''.
         show_plot (bool) : Whether to display the plot. Default True.
         lms_freq_hz (float) : The frequency of the tracking algorithm.
            Default is 4000
@@ -2189,7 +2198,7 @@ class SmurfTuneMixin(SmurfBase):
             
             if save_plot:
                 path = os.path.join(self.plot_dir, 
-                    timestamp + '_FR_amp_v_err.png')
+                    timestamp + '_FR_amp_v_err' + plotname_append + '.png')
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'amp_vs_err', plot=True)
 
@@ -2247,7 +2256,8 @@ class SmurfTuneMixin(SmurfBase):
 
                     if save_plot:
                         path = os.path.join(self.plot_dir, timestamp + 
-                            '_FRtracking_band{}_ch{:03}.png'.format(band,ch))                        
+                            '_FRtracking_band{}_ch{:03}{}.png'.format(band,ch,
+                            plotname_append))                        
                         plt.savefig(path, bbox_inches='tight')
                         self.pub.register_file(path, 'tracking', plot=True)
 
@@ -2762,8 +2772,8 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def find_freq(self, band, subband=np.arange(13,115), drive_power=None,
-        n_read=2, make_plot=False, save_plot=True, window=50, rolling_med=True,
-        make_subband_plot=False, show_plot=False):
+        n_read=2, make_plot=False, save_plot=True, plotname_append='', 
+        window=50, rolling_med=True, make_subband_plot=False, show_plot=False):
         '''
         Finds the resonances in a band (and specified subbands)
         Args:
@@ -2776,7 +2786,7 @@ class SmurfTuneMixin(SmurfBase):
         n_read (int) : The number sweeps to do per subband
         make_plot (bool) : make the plot frequency sweep. Default False.
         save_plot (bool) : save the plot. Default True.
-        save_name (string) : What to name the plot. default find_freq.png
+        plotname_append (string): Appended to the default plot filename. Default ''.
         rolling_med (bool) : Whether to iterate on a rolling median or just
            the median of the whole sample.
         window (int) : The width of the rolling median window
@@ -2822,8 +2832,9 @@ class SmurfTuneMixin(SmurfBase):
         # Find resonator peaks
         res_freq = self.find_all_peak(self.freq_resp[band]['find_freq']['f'],
             self.freq_resp[band]['find_freq']['resp'], subband, 
-            make_plot=make_plot, band=band, rolling_med=rolling_med, 
-            window=window, make_subband_plot=make_subband_plot)
+            make_plot=make_plot, plotname_append=plotname_append, band=band, 
+            rolling_med=rolling_med, window=window, 
+            make_subband_plot=make_subband_plot)
         self.freq_resp[band]['find_freq']['resonance'] = res_freq
 
         # Save resonances
@@ -2837,7 +2848,8 @@ class SmurfTuneMixin(SmurfBase):
             self.plot_find_freq(self.freq_resp[band]['find_freq']['f'], 
                 self.freq_resp[band]['find_freq']['resp'], save_plot=save_plot,
                 show_plot=show_plot, 
-                save_name=save_name.replace('.txt', '.png').format(timestamp, band))
+                save_name=save_name.replace('.txt', plotname_append + \
+                                            '.png').format(timestamp, band))
 
         return f, resp
 
@@ -2927,8 +2939,9 @@ class SmurfTuneMixin(SmurfBase):
 
     def find_all_peak(self, freq, resp, subband=None, rolling_med=False, 
         window=500, grad_cut=0.05, amp_cut=0.25, freq_min=-2.5E8, freq_max=2.5E8, 
-        make_plot=False, save_plot=True, band=None, make_subband_plot=False, 
-        subband_plot_with_slow=False, timestamp=None, pad=2, min_gap=2):
+        make_plot=False, save_plot=True, plotname_append='', band=None,
+        make_subband_plot=False, subband_plot_with_slow=False, timestamp=None,
+        pad=2, min_gap=2):
         """
         find the peaks within each subband requested from a fullbandamplsweep
         Args:
@@ -2960,7 +2973,8 @@ class SmurfTuneMixin(SmurfBase):
         peaks = self.find_peak(f_stack, r_stack, rolling_med=rolling_med, 
             window=window, grad_cut=grad_cut, amp_cut=amp_cut, freq_min=freq_min,
             freq_max=freq_max, make_plot=make_plot, save_plot=save_plot, 
-            band=band, make_subband_plot=make_subband_plot,
+            plotname_append=plotname_append, band=band, 
+            make_subband_plot=make_subband_plot,
             subband_plot_with_slow=subband_plot_with_slow, timestamp=timestamp, 
             pad=pad, min_gap=min_gap)
 

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -307,6 +307,7 @@ class SmurfTuneMixin(SmurfBase):
             self.get_att_uc(band, write_log=True)
             freq, resp = self.full_band_resp(band, n_samples=n_samples,
                                          make_plot=make_plot, save_data=save_data, 
+										 plotname_append=plotname_append, 
                                          show_plot=False, timestamp=timestamp,
                                          n_scan=n_scan)
             self.set_att_uc(band, old_att, write_log=True)
@@ -1039,7 +1040,8 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def eta_fit(self, freq, resp, peak_freq, delta_freq,
-                make_plot=False, plot_chans=[], save_plot=True, plotname_append='', band=None,
+                make_plot=False, plot_chans=[], save_plot=True, 
+				plotname_append='', band=None,
                 timestamp=None, res_num=None, use_slow_eta=False):
         """
         Cyndia's eta finding code
@@ -1983,8 +1985,8 @@ class SmurfTuneMixin(SmurfBase):
         self.set_feedback_enable_array(band, np.zeros_like(old_fb))
         d, df, sync = self.tracking_setup(band,0, reset_rate_khz=reset_rate_khz,
                                           fraction_full_scale=fraction_full_scale,
-                                          make_plot=False,
-                                          save_plot=False, show_plot=False,
+                                          make_plot=False, save_plot=False, 
+										  plotname_append='', show_plot=False,
                                           lms_enable1=False, lms_enable2=False,
                                           lms_enable3=False, flux_ramp=flux_ramp)
 
@@ -2429,11 +2431,11 @@ class SmurfTuneMixin(SmurfBase):
 
         # Check the lock status and cut channels based on inputs.
         self.check_lock(band, f_min=f_min, f_max=f_max, df_max=df_max,
-            make_plot=make_plot, flux_ramp=flux_ramp, 
+            make_plot=False, flux_ramp=flux_ramp, 
             fraction_full_scale=fraction_full_scale, lms_freq_hz=lms_freq_hz,
             reset_rate_khz=reset_rate_khz, 
             feedback_start_frac=feedback_start_frac,
-            feedback_end_frac=feedback_end_frac)
+            feedback_end_frac=feedback_end_frac) 
     
 
     def eta_phase_check(self, band, rot_step_size=30, rot_max=360,
@@ -2765,7 +2767,7 @@ class SmurfTuneMixin(SmurfBase):
         f_min (float) : The maximum frequency swing.
         f_max (float) : The minimium frequency swing
         df_max (float) : The maximum value of the stddev of df
-        make_plot (bool) : Whether to make plots. Default False
+        make_plot (bool) : Whether to make plots. Default False. Does nothing in this function. 
         flux_ramp (bool) : Whether to flux ramp or not. Default True
         faction_full_scale (float): Number between 0 and 1. The amplitude
            of the flux ramp.
@@ -2855,8 +2857,8 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def find_freq(self, band, subband=np.arange(13,115), drive_power=None,
-        n_read=2, make_plot=False, save_plot=True, plotname_append='', window=50, rolling_med=True,
-        make_subband_plot=False, show_plot=False):
+        n_read=2, make_plot=False, save_plot=True, plotname_append='', 
+		window=50, rolling_med=True, make_subband_plot=False, show_plot=False):
         '''
         Finds the resonances in a band (and specified subbands)
 
@@ -3027,8 +3029,9 @@ class SmurfTuneMixin(SmurfBase):
 
     def find_all_peak(self, freq, resp, subband=None, rolling_med=False, 
         window=500, grad_cut=0.05, amp_cut=0.25, freq_min=-2.5E8, freq_max=2.5E8, 
-        make_plot=False, save_plot=True, plotname_append='', band=None, make_subband_plot=False, 
-        subband_plot_with_slow=False, timestamp=None, pad=2, min_gap=2):
+        make_plot=False, save_plot=True, plotname_append='', band=None, 
+		make_subband_plot=False, subband_plot_with_slow=False, timestamp=None, 
+		pad=2, min_gap=2):
         """
         find the peaks within each subband requested from a fullbandamplsweep
 
@@ -3070,7 +3073,7 @@ class SmurfTuneMixin(SmurfBase):
         return peaks
 
     def fast_eta_scan(self, band, subband, freq, n_read, drive, 
-        make_plot=False):
+        make_plot=False, plotname_append=''):
         """copy of fastEtaScan.m from Matlab. Sweeps quickly across a range of
         freq and gets I, Q response
 
@@ -3083,7 +3086,8 @@ class SmurfTuneMixin(SmurfBase):
          drive (int): tone power
 
         Optional Args:
-        make_plot (bool): Make eta plots
+        make_plot (bool): Make eta plots. Not yet functional.
+		plotname_append (string): Appended to the default plot filename. Default is ''.
 
         Outputs:
          resp (n_freq x 2 array): real, imag response as a function of 
@@ -3129,6 +3133,7 @@ class SmurfTuneMixin(SmurfBase):
 
         if make_plot:
             # To do : make plotting
+			# remember to include the plotname_append when saving.
             self.log('Plotting does not work in this function yet...')
 
         return freq, response
@@ -3654,6 +3659,7 @@ class SmurfTuneMixin(SmurfBase):
         lms_freq_hz=None, flux_ramp=True, fraction_full_scale=.4950,
         lms_enable1=True, lms_enable2=True, lms_enable3=True, lms_gain=None):
         """
+		Does not actually allow any plotmaking.
         """
         if reset_rate_khz is None:
             reset_rate_khz = self.reset_rate_khz

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -34,13 +34,12 @@ class SmurfTuneMixin(SmurfBase):
     def tune(self, load_tune=True, tune_file=None, last_tune=False,
              retune=False, f_min=.02, f_max=.3, df_max=.03,
              fraction_full_scale=None, make_plot=False,
-             save_plot=True, plotname_append='', show_plot=False,
+             save_plot=True, show_plot=False,
              new_master_assignment=False, track_and_check=True):
         """
         This runs a tuning, does tracking setup, and prunes bad
         channels using check lock. When this is done, we should
         be ready to take data.
-
         Opt Args:
         ---------
         load_tune (bool): Whether to load in a tuning file. If False, will
@@ -59,7 +58,6 @@ class SmurfTuneMixin(SmurfBase):
             flux ramp amplitude.
         make_plot (bool): Whether to make a plot. Default is False.
         save_plot (bool): If making plots, whether to save them. Default is True.
-		plotname_append (string) : Appended to the default plot filename. Default is ''.
         show_plot (bool): Whether to display the plots to screen. Default is False.
         track_and_check (bool): Whether or not after tuning to run
             track and check.  Default is True.
@@ -98,8 +96,7 @@ class SmurfTuneMixin(SmurfBase):
                 self.log('Running tune band serial on band {}'.format(b))
                 self.tune_band_serial(b, from_old_tune=load_tune,
                     old_tune=tune_file, make_plot=make_plot, 
-                    show_plot=show_plot, save_plot=save_plot, 
-					plotname_append=plotname_append,
+                    show_plot=show_plot, save_plot=save_plot,
                     new_master_assignment=new_master_assignment)
 
         # Starts tracking and runs check_lock to prune bad resonators
@@ -108,12 +105,11 @@ class SmurfTuneMixin(SmurfBase):
                 self.log('Tracking and checking band {}'.format(b))
                 self.track_and_check(b, fraction_full_scale=fraction_full_scale, 
                     f_min=f_min, f_max=f_max, df_max=df_max, make_plot=make_plot,
-                    save_plot=save_plot, plotname_append=plotname_append, 
-					show_plot=show_plot)
+                    save_plot=save_plot, show_plot=show_plot)
         
 
     def tune_band(self, band, freq=None, resp=None, n_samples=2**19, 
-        make_plot=False, show_plot=False, plot_chans=[], save_plot=True, plotname_append='', 
+        make_plot=False, show_plot=False, plot_chans=[], save_plot=True, 
         save_data=True,  make_subband_plot=False, subband=None, n_scan=5,
         subband_plot_with_slow=False, drive=None, grad_cut=.05, freq_min=-2.5E8, 
         freq_max=2.5E8, amp_cut=.5, use_slow_eta=False):
@@ -121,11 +117,9 @@ class SmurfTuneMixin(SmurfBase):
         This does the full_band_resp, which takes the raw resonance data.
         It then finds the where the resonances are. Using the resonance
         locations, it calculates the eta parameters.
-
         Args:
         -----
         band (int): The band to tune
-
         Opt Args:
         ---------
         freq (float array): The frequency information. If both freq and resp
@@ -141,7 +135,6 @@ class SmurfTuneMixin(SmurfBase):
         save_plot (bool): Whether to save the plot. If True, it will close the
             plots before they are shown. If False, plots will be brought to the
             screen.
-		plotname_append (string) : Appended to the default plot filename. Default is ''.
         save_data (bool): If True, saves the data to disk.
         grad_cut (float): The value of the gradient of phase to look for 
             resonances. Default is .05
@@ -151,12 +144,10 @@ class SmurfTuneMixin(SmurfBase):
             the band to look for resonances. Units of Hz. Defaults is -2.5E8
         freq_max (float): The maximum frequency relative to the center of
             the band to look for resonances. Units of Hz. Defaults is 2.5E8
-
         Returns:
         --------
         res (dict): A dictionary with resonance frequency, eta, eta_phase,
             R^2, and amplitude.
-
         """
         timestamp = self.get_timestamp()
 
@@ -178,8 +169,7 @@ class SmurfTuneMixin(SmurfBase):
         # Find peaks
         peaks = self.find_peak(freq, resp, rolling_med=True, band=band, 
             make_plot=make_plot, show_plot=show_plot, window=5000,
-            save_plot=save_plot, plotname_append=plotname_append, 
-			grad_cut=grad_cut, freq_min=freq_min,
+            save_plot=save_plot, grad_cut=grad_cut, freq_min=freq_min,
             freq_max=freq_max, amp_cut=amp_cut, 
             make_subband_plot=make_subband_plot, timestamp=timestamp,
             subband_plot_with_slow=subband_plot_with_slow, pad=50, min_gap=50)
@@ -190,8 +180,7 @@ class SmurfTuneMixin(SmurfBase):
         for i, p in enumerate(peaks):
             eta, eta_scaled, eta_phase_deg, r2, eta_mag, latency, Q= \
                 self.eta_fit(band, freq, resp, p, 50E3, make_plot=False, 
-                plot_chans=plot_chans, save_plot=save_plot, 
-				plotname_append=plotname_append, res_num=i, 
+                plot_chans=plot_chans, save_plot=save_plot, res_num=i, 
                 band=band, timestamp=timestamp, use_slow_eta=use_slow_eta)
 
             # Fill the resonances dict
@@ -239,7 +228,7 @@ class SmurfTuneMixin(SmurfBase):
         return resonances
 
     def tune_band_serial(self, band, n_samples=2**19,
-        make_plot=False, save_plot=True, plotname_append='', save_data=True, show_plot=False,
+        make_plot=False, save_plot=True, save_data=True, show_plot=False,
         make_subband_plot=False, subband=None, n_scan=5,
         subband_plot_with_slow=False, window=5000, rolling_med=True,
         grad_cut=.03, freq_min=-2.5E8, freq_max=2.5E8, amp_cut=.25,
@@ -250,13 +239,10 @@ class SmurfTuneMixin(SmurfBase):
         This requires an initial guess, which this function gets by either
         loading an old tune or by using the full_band_resp.  This takes about 3 
         minutes per band if there are about 150 resonators.
-
         This saves the results to the freq_resp dictionary.
-
         Args:
         -----
         band (int): The band the tune
-
         Opt Args:
         ---------
         from_old_tune (bool): Whether to use an old tuning file. This
@@ -268,7 +254,6 @@ class SmurfTuneMixin(SmurfBase):
         make_plot (bool): Whether to make plots. Default is False.
         save_plot (bool): If make_make plot is True, whether to save
             the plots. Default is True.
-		plotname_append (string) : Appended to the default plot filename. Default is ''.
         show_plot (bool): If make_plot is True, whether to display
             the plots to screen.
         """
@@ -307,7 +292,6 @@ class SmurfTuneMixin(SmurfBase):
             self.get_att_uc(band, write_log=True)
             freq, resp = self.full_band_resp(band, n_samples=n_samples,
                                          make_plot=make_plot, save_data=save_data, 
-										 plotname_append=plotname_append, 
                                          show_plot=False, timestamp=timestamp,
                                          n_scan=n_scan)
             self.set_att_uc(band, old_att, write_log=True)
@@ -315,8 +299,7 @@ class SmurfTuneMixin(SmurfBase):
             # Find peaks
             peaks = self.find_peak(freq, resp, rolling_med=rolling_med, 
                 window=window, band=band, make_plot=make_plot, 
-                save_plot=save_plot, plotname_append=plotname_append,
-				show_plot=show_plot, grad_cut=grad_cut, 
+                save_plot=save_plot,  show_plot=show_plot, grad_cut=grad_cut, 
                 freq_min=freq_min, freq_max=freq_max, amp_cut=amp_cut,
                 make_subband_plot=make_subband_plot, timestamp=timestamp,
                 subband_plot_with_slow=subband_plot_with_slow, pad=pad, 
@@ -517,25 +500,21 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def full_band_resp(self, band, n_scan=1, n_samples=2**19, make_plot=False, 
-        save_plot=True, plotname_append='', show_plot=False, save_data=False, timestamp=None, 
+        save_plot=True, show_plot=False, save_data=False, timestamp=None, 
         save_raw_data=False, correct_att=True, swap=False, hw_trigger=True, 
         write_log=False):
         """
         Injects high amplitude noise with known waveform. The ADC measures it.
         The cross correlation contains the information about the resonances.
-
         Args:
         -----
         band (int): The band to sweep.
-
         Opt Args:
         ---------
         n_scan (int): The number of scans to take and average
         n_samples (int): The number of samples to take. Default 2^18.
         make_plot (bool): Whether the make plots. Default is False.
-		save_plot (bool): Whether to save plots.
-		plotname_append (string) : Appended to the default plot filename. Default is ''.
-        save_data (bool): Whether to save the data. Default is True.
+        save_data (bool): Whether to save the data.
         timestamp (str): The timestamp as a string.
         correct_att (bool): Correct the response for the attenuators. Default
             is True.
@@ -641,7 +620,7 @@ class SmurfTuneMixin(SmurfBase):
 
             if save_plot:
                 path = os.path.join(self.plot_dir,
-                    '{}_b{}_full_band_resp_raw{}.png'.format(timestamp, band, plotname_append))
+                    '{}_b{}_full_band_resp_raw.png'.format(timestamp, band))
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'response', plot=True)
                 plt.close()
@@ -654,9 +633,8 @@ class SmurfTuneMixin(SmurfBase):
             ax.set_title(timestamp)
             if save_plot:
                 path = os.path.join(self.plot_dir,
-                             '{}_b{}_full_band_resp{}.png'.format(timestamp,
-                                                                band,
-																plotname_append))
+                             '{}_b{}_full_band_resp.png'.format(timestamp,
+                                                                band))
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'response', plot=True)
             if show_plot:
@@ -901,19 +879,16 @@ class SmurfTuneMixin(SmurfBase):
     def find_flag_blocks(self, flag, minimum=None, min_gap=None):
         """ 
         Find blocks of adjacent points in a boolean array with the same value. 
-
         Args:
         -----
         flag : bool, array_like 
             The array in which to find blocks 
-
         Opt Args:
         ---------
         minimum : int (optional)
             The minimum length of block to return. Discards shorter blocks 
         min_gap : int (optional)
             The minimum gap between flag blocks. Fills in gaps smaller.
-
         Returns
         ------- 
         starts, ends : int arrays
@@ -945,18 +920,15 @@ class SmurfTuneMixin(SmurfBase):
     def pad_flags(self, f, before_pad=0, after_pad=0, min_gap=0, min_length=0):
         """
         Adds and combines flagging. 
-
         Args:
         -----
         f (bool array): The flag array to pad
-
         Opt Args:
         ---------
         before_pad (int): The number of samples to pad before a flag
         after_pad (int); The number of samples to pad after a flag
         min_gap (int): The smallest allowable gap. If bigger, it combines.
         min_length (int): The smallest length a pad can be.
-
         Ret:
         ----
         pad_flag (bool array): The padded boolean array
@@ -982,13 +954,11 @@ class SmurfTuneMixin(SmurfBase):
         save_name=None):
         """
         Plots the output of find_Freq
-
         Args:
         -----
         freq (float array): The frequency data
         resp (float array): The response to full_band_resp
         peak_ind (int array): The indicies of peaks found
-
         Opt Args:
         ---------
         save_plot (bool): Whether to save the plot
@@ -1040,31 +1010,26 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def eta_fit(self, freq, resp, peak_freq, delta_freq,
-                make_plot=False, plot_chans=[], save_plot=True, 
-				plotname_append='', band=None,
+                make_plot=False, plot_chans=[], save_plot=True, band=None,
                 timestamp=None, res_num=None, use_slow_eta=False):
         """
         Cyndia's eta finding code
-
         Args:
         -----
         freq (float array): The frequency data
         resp (float array): The response data
         peak_freq (float): The frequency of the resonance peak
         delta_freq (float): The width of frequency to calculate values
-
         Opt Args:
         ---------
         make_plot (bool): Whether to make plots. Default is False.
         save_plot (bool): Whether to save plots. Default is True.
-		plotname_append (string) : Appended to the default plot filename. Default is ''.
         plot_chans (int array): The channels to plot. If an empty array, it
             will make plots for all channels.
         band (int): Only used for plotting - the band number of the resontaor
         timestamp (str): The timestamp of the data.
         res_num (int): The resonator number
         
-
         Rets:
         -----
         eta (complex): The eta parameter
@@ -1146,8 +1111,7 @@ class SmurfTuneMixin(SmurfBase):
                 self.plot_eta_fit(freq[left_plot:right_plot], 
                     resp[left_plot:right_plot], 
                     eta=eta, eta_mag=eta_mag, r2=r2,
-                    save_plot=save_plot, plotname_append=plotname_append, 
-					timestamp=timestamp, band=band,
+                    save_plot=save_plot, timestamp=timestamp, band=band,
                     res_num=res_num, sk_fit=sk_fit, f_slow=f_slow, resp_slow=resp_slow)
             else:
                 if res_num in plot_chans:
@@ -1156,8 +1120,7 @@ class SmurfTuneMixin(SmurfBase):
                     self.plot_eta_fit(freq[left_plot:right_plot], 
                         resp[left_plot:right_plot], 
                         eta=eta, eta_mag=eta_mag, eta_phase_deg=eta_phase_deg, 
-                        r2=r2, save_plot=save_plot, plotname_append=plotname_append, 
-						timestamp=timestamp, 
+                        r2=r2, save_plot=save_plot, timestamp=timestamp, 
                         band=band, res_num=res_num, sk_fit=sk_fit, 
                         f_slow=f_slow, resp_slow=resp_slow)
 
@@ -1321,12 +1284,10 @@ class SmurfTuneMixin(SmurfBase):
     def get_closest_subband(self, f, band, as_offset=True):
         """
         Gives the closest subband number for a given input frequency.
-
         Args:
         -----
         f (float): The frequency to search for a subband
         band (int): The band to identify
-
         Ret:
         ----
         subband (int): The subband that contains the frequency
@@ -1345,12 +1306,10 @@ class SmurfTuneMixin(SmurfBase):
     def check_freq_scale(self, f1, f2):
         """
         Makes sure that items are the same frequency scale (ie MHz, kHZ, etc.)
-
         Args:
         -----
         f1 (float): The first frequency
         f2 (float): The second frequency
-
         Ret:
         ----
         same_scale (bool): Whether the frequency scales are the same
@@ -1364,7 +1323,6 @@ class SmurfTuneMixin(SmurfBase):
         """
         By default, pysmurf loads the most recent master assignment.
         Use this function to overwrite the default one.
-
         Args:
         -----
         band (int): The band for the master assignment file
@@ -1382,11 +1340,9 @@ class SmurfTuneMixin(SmurfBase):
     def get_master_assignment(self, band):
         """
         Returns the master assignment list.
-
         Args:
         -----
         band (int) : The band number
-
         Ret:
         ----
         freqs (float array): The frequency of the resonators
@@ -1410,13 +1366,11 @@ class SmurfTuneMixin(SmurfBase):
         new_master_assignment=False):
         """
         Figures out the subbands and channels to assign to resonators
-
         Args:
         -----
         freq (flot array): The frequency of the resonators. This is not the
             same as the frequency output from full_band_resp. This is only
             where the resonators are.
-
         Opt Args:
         ---------
         band (int): The band to assign channels
@@ -1426,7 +1380,6 @@ class SmurfTuneMixin(SmurfBase):
             subband. Default is 4.
         min_offset (float): The minimum offset between two resonators in MHz.
             If closer, then both are ignored.
-
         Ret:
         ----
         subbands (int array): An array of subbands to assign resonators
@@ -1531,7 +1484,6 @@ class SmurfTuneMixin(SmurfBase):
     def make_master_assignment_from_file(self, band, tuning_filename):
         """
         Makes a master assignment file
-
         Args:
         -----
         band (int) : The band number
@@ -1588,7 +1540,6 @@ class SmurfTuneMixin(SmurfBase):
     def compare_tune(self, tune, ref_tune=None, make_plot=False):
         """
         Compares tuning file to a reference tuning file. Does not work yet.
-
         """
 
         # Load data
@@ -1619,11 +1570,9 @@ class SmurfTuneMixin(SmurfBase):
         write_log=False):
         """
         Turns on the tones. Also cuts bad resonators.
-
         Args:
         -----
         band (int): The band to relock
-
         Opt args:
         ---------
         res_num (int array): The resonators to lock. If None, tries all the
@@ -1732,11 +1681,9 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convenience function that gets the frequency results from
         eta scans.
-
         Args:
         -----
         band (int) : The band
-
         Ret:
         freq (float array) : The frequency in MHz of the resonators.
         """
@@ -1747,11 +1694,9 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convenience function that gets thee eta values from
         eta scans.
-
         Args:
         -----
         band (int) : The band
-
         Ret:
         ----
         eta (complex array) : The eta of the resonators.
@@ -1762,11 +1707,9 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convenience function that gets thee eta mags from
         eta scans.
-
         Args:
         -----
         band (int) : The band
-
         Ret:
         ----
         eta_mag (float array) : The eta of the resonators.
@@ -1777,11 +1720,9 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convenience function that gets the eta scaled from
         eta scans. eta_scaled is eta_mag/digitizer_freq_mhz/n_subbands
-
         Args:
         -----
         band (int) : The band
-
         Ret:
         ----
         eta_mag (float array) : The eta_scaled of the resonators.
@@ -1793,11 +1734,9 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convenience function that gets the eta phase values from
         eta scans.
-
         Args:
         -----
         band (int) : The band
-
         Ret:
         ----
         eta_phase (float array) : The eta_phase of the resonators.
@@ -1809,11 +1748,9 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convenience function that gets the channel assignments from
         eta scans.
-
         Args:
         -----
         band (int) : The band
-
         Ret:
         ----
         channels (int array) : The channels of the resonators.
@@ -1825,11 +1762,9 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convenience function that gets the subband from
         eta scans.
-
         Args:
         -----
         band (int) : The band
-
         Ret:
         ----
         subband (float array) : The subband of the resonators.
@@ -1841,11 +1776,9 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convenience function that gets the offset from center frequency 
         from eta scans.
-
         Args:
         -----
         band (int) : The band
-
         Ret:
         ----
         offset (float array) : The offset from the subband centers  of 
@@ -1949,16 +1882,14 @@ class SmurfTuneMixin(SmurfBase):
 
     def flux_ramp_check(self, band, reset_rate_khz=None, 
                         fraction_full_scale=None, flux_ramp=True,
-                        save_plot=True, plotname_append='', show_plot=False):
+                        save_plot=True, show_plot=False):
         """
         Tries to measure the V-phi curve in feedback disable mode. 
         You can also run this with flux ramp off to see the intrinsic
         noise on the readout channel.
-
         Args:
         -----
         band (int) : The band to check.
-
         Opt Args:
         ---------
         reset_rate_khz (float) : The flux ramp rate in kHz.
@@ -1966,7 +1897,6 @@ class SmurfTuneMixin(SmurfBase):
            zero to one.
         flux_ramp (bool) : Whether to flux ramp. Default is True.
         save_plot (bool) : Whether to save the plot. Default True.
-		plotname_append (string) : Appended to the default plot filename. Default is ''.
         show_plot (bool) : Whether to show the plot. Default False.
         """
         if show_plot:
@@ -1985,8 +1915,8 @@ class SmurfTuneMixin(SmurfBase):
         self.set_feedback_enable_array(band, np.zeros_like(old_fb))
         d, df, sync = self.tracking_setup(band,0, reset_rate_khz=reset_rate_khz,
                                           fraction_full_scale=fraction_full_scale,
-                                          make_plot=False, save_plot=False, 
-										  plotname_append='', show_plot=False,
+                                          make_plot=False,
+                                          save_plot=False, show_plot=False,
                                           lms_enable1=False, lms_enable2=False,
                                           lms_enable3=False, flux_ramp=flux_ramp)
 
@@ -2063,7 +1993,7 @@ class SmurfTuneMixin(SmurfBase):
                 if not flux_ramp:
                     save_name = save_name + '_no_FR'
                 save_name = save_name+ \
-                    '_b{}_sb{:03}_flux_ramp_check{}.png'.format(band, sb, plotname_append)
+                    '_b{}_sb{:03}_flux_ramp_check.png'.format(band, sb)
                 path = os.path.join(self.plot_dir, save_name)
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'flux_ramp', plot=True)
@@ -2074,7 +2004,7 @@ class SmurfTuneMixin(SmurfBase):
         return d, df, sync
 
     def tracking_setup(self, band, channel=None, reset_rate_khz=None, 
-        write_log=False, make_plot=False, save_plot=True, plotname_append='', show_plot=True, 
+        write_log=False, make_plot=False, save_plot=True, show_plot=True, 
         nsamp=2**19, lms_freq_hz=None, meas_lms_freq=False, flux_ramp=True, 
         fraction_full_scale=None, lms_enable1=True, lms_enable2=True, 
         lms_enable3=True, lms_gain=None, return_data=True, new_epics_root=None,
@@ -2084,11 +2014,9 @@ class SmurfTuneMixin(SmurfBase):
         attempts to measure the lms (demodulation) frequency. Otherwise this
         just tracks at the input lms frequency. This will also make plots for
         the channels listed in {channel} input. 
-
         Args:
         -----
         band (int) : The band number
-
         Opt Args:
         ---------
         channel (int) : The channel to check
@@ -2096,7 +2024,6 @@ class SmurfTuneMixin(SmurfBase):
         write_log (bool) : Whether to write output to the log.  Default False.
         make_plot (bool) : Whether to make plots. Default False.
         save_plot (bool) : Whether to save plots. Default True.
-		plotname_append (string) : Appended to the default plot filename. Default is ''.
         show_plot (bool) : Whether to display the plot. Default True.
         lms_freq_hz (float) : The frequency of the tracking algorithm.
            Default is 4000
@@ -2273,7 +2200,7 @@ class SmurfTuneMixin(SmurfBase):
             
             if save_plot:
                 path = os.path.join(self.plot_dir, 
-                    timestamp + '_FR_amp_v_err' + plotname_append + '.png')
+                    timestamp + '_FR_amp_v_err.png')
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'amp_vs_err', plot=True)
 
@@ -2331,8 +2258,7 @@ class SmurfTuneMixin(SmurfBase):
 
                     if save_plot:
                         path = os.path.join(self.plot_dir, timestamp + 
-                            '_FRtracking_band{}_ch{:03}{}.png'.format(band,ch,
-							plotname_append))                        
+                            '_FRtracking_band{}_ch{:03}.png'.format(band,ch))                        
                         plt.savefig(path, bbox_inches='tight')
                         self.pub.register_file(path, 'tracking', plot=True)
 
@@ -2345,7 +2271,7 @@ class SmurfTuneMixin(SmurfBase):
             return f, df, sync
 
     def track_and_check(self, band, channel=None, reset_rate_khz=None, 
-        make_plot=False, save_plot=True, plotname_append='', show_plot=True,
+        make_plot=False, save_plot=True, show_plot=True,
         lms_freq_hz=None, flux_ramp=True, fraction_full_scale=None,
         lms_enable1=True, lms_enable2=True, lms_enable3=True, lms_gain=None,
         f_min=.015, f_max=.2, df_max=.03, toggle_feedback=True,
@@ -2373,7 +2299,6 @@ class SmurfTuneMixin(SmurfBase):
         write_log (bool) : Whether to write output to the log.  Default False.
         make_plot (bool) : Whether to make plots. Default False.
         save_plot (bool) : Whether to save plots. Default True.
-		plotname_append (string) : Appended to the default plot filename. Default is ''.
         show_plot (bool) : Whether to display the plot. Default True.
         lms_freq_hz (float) : The frequency of the tracking algorithm.
            Default is 4000
@@ -2414,8 +2339,7 @@ class SmurfTuneMixin(SmurfBase):
         if tracking_setup:
             self.tracking_setup(band, channel=channel, 
                 reset_rate_khz=reset_rate_khz, make_plot=make_plot, 
-                save_plot=save_plot, plotname_append=plotname_append, 
-				show_plot=show_plot,
+                save_plot=save_plot, show_plot=show_plot,
                 lms_freq_hz=lms_freq_hz, flux_ramp=flux_ramp, 
                 fraction_full_scale=fraction_full_scale, lms_enable1=lms_enable1, 
                 lms_enable2=lms_enable2, lms_enable3=lms_enable3, 
@@ -2431,11 +2355,11 @@ class SmurfTuneMixin(SmurfBase):
 
         # Check the lock status and cut channels based on inputs.
         self.check_lock(band, f_min=f_min, f_max=f_max, df_max=df_max,
-            make_plot=False, flux_ramp=flux_ramp, 
+            make_plot=make_plot, flux_ramp=flux_ramp, 
             fraction_full_scale=fraction_full_scale, lms_freq_hz=lms_freq_hz,
             reset_rate_khz=reset_rate_khz, 
             feedback_start_frac=feedback_start_frac,
-            feedback_end_frac=feedback_end_frac) 
+            feedback_end_frac=feedback_end_frac)
     
 
     def eta_phase_check(self, band, rot_step_size=30, rot_max=360,
@@ -2554,7 +2478,6 @@ class SmurfTuneMixin(SmurfBase):
         do_config=True):
         """
         ???
-
         Args:
         -----
         fractionFullScale (float) : Fraction of full flux ramp scale to output 
@@ -2617,23 +2540,19 @@ class SmurfTuneMixin(SmurfBase):
         """
         Set flux ramp sawtooth rate and amplitude. If there are errors, check 
         that you are using an allowed reset rate! Not all rates are allowed.
-
         Allowed rates: 1, 2, 3, 4, 5, 6, 8, 10, 12, 15 kHz
-
         Args:
         -----
         reset_rate_khz (int) : The flux ramp rate to set in kHz. The allowable
             values are 1, 2, 3, 4, 5, 6, 8, 10, 12, 15 kHz
         fraction_full_scale (float) : The amplitude of the flux ramp as a
             fraction of the maximum possible value.
-
         Opt Args:
         ---------
         df_range (float) : 
         band (int) : The band to setup the flux ramp on. 
         write_log (bool) : Whether to write output to the log
         new_epics_root (str) : Override the original epics root.
-
         """
 
         # Disable flux ramp
@@ -2736,11 +2655,9 @@ class SmurfTuneMixin(SmurfBase):
     def get_fraction_full_scale(self, new_epics_root=None):
         """
         Returns the fraction_full_scale.
-
         Opt Args:
         ---------
         new_epics_root (str) : Overrides the initialized epics root.
-
         Ret:
         ----
         fraction_full_scale (float) : The fraction of the flux ramp amplitude
@@ -2761,13 +2678,12 @@ class SmurfTuneMixin(SmurfBase):
         Args:
         -----
         band (int) : The band the check
-
         Opt Args:
         ---------
         f_min (float) : The maximum frequency swing.
         f_max (float) : The minimium frequency swing
         df_max (float) : The maximum value of the stddev of df
-        make_plot (bool) : Whether to make plots. Default False. Does nothing in this function. 
+        make_plot (bool) : Whether to make plots. Default False
         flux_ramp (bool) : Whether to flux ramp or not. Default True
         faction_full_scale (float): Number between 0 and 1. The amplitude
            of the flux ramp.
@@ -2987,14 +2903,12 @@ class SmurfTuneMixin(SmurfBase):
 
     def full_band_ampl_sweep(self, band, subband, drive, n_read, n_step=121):
         """sweep a full band in amplitude, for finding frequencies
-
         args:
         -----
             band (int) = bandNo (500MHz band)
             subband (int) = which subbands to sweep
             drive (int) = drive power (defaults to 10)
             n_read (int) = numbers of times to sweep, defaults to 2
-
         returns:
         --------
             freq (list, n_freq x 1) = frequencies swept
@@ -3073,10 +2987,9 @@ class SmurfTuneMixin(SmurfBase):
         return peaks
 
     def fast_eta_scan(self, band, subband, freq, n_read, drive, 
-        make_plot=False, plotname_append=''):
+        make_plot=False):
         """copy of fastEtaScan.m from Matlab. Sweeps quickly across a range of
         freq and gets I, Q response
-
         Args:
          band (int): which 500MHz band to scan
          subband (int): which subband to scan
@@ -3084,11 +2997,8 @@ class SmurfTuneMixin(SmurfBase):
             center
          n_read (int): number of times to scan
          drive (int): tone power
-
         Optional Args:
-        make_plot (bool): Make eta plots. Not yet functional.
-		plotname_append (string): Appended to the default plot filename. Default is ''.
-
+        make_plot (bool): Make eta plots
         Outputs:
          resp (n_freq x 2 array): real, imag response as a function of 
             frequency
@@ -3133,7 +3043,6 @@ class SmurfTuneMixin(SmurfBase):
 
         if make_plot:
             # To do : make plotting
-			# remember to include the plotname_append when saving.
             self.log('Plotting does not work in this function yet...')
 
         return freq, response
@@ -3146,11 +3055,9 @@ class SmurfTuneMixin(SmurfBase):
         information is used for placing tones onto resonators. It is
         recommended that you follow this up with run_serial_gradient_descent()
         afterwards. 
-
         Args:
         -----
         band (int) : The 500 MHz band to setup.
-
         Optional Args:
         --------------
         resonance (float array) : A 2 dimensional array with resonance 
@@ -3271,8 +3178,6 @@ class SmurfTuneMixin(SmurfBase):
     def load_tune(self, filename=None, override=True, last_tune=True, band=None):
         """
         Loads the tuning information (self.freq_resp) from tuning directory
-
-
         Opt Args:
         ---------
         filename (str) : The name of the tuning.
@@ -3328,7 +3233,6 @@ class SmurfTuneMixin(SmurfBase):
         """
         Does all the eta scans at once. The center frequency
         array must already be populated.
-
         Args:
         -----
         band (int) : The band to eta scan
@@ -3384,7 +3288,6 @@ class SmurfTuneMixin(SmurfBase):
         band (int): Will attempt to estimate the carrier rate on the
                     channels which are on in this band.
         reset_rate_khz (float): The flux ramp reset rate (in kHz).
-
         Opt Args:
         ---------
         fraction_full_scale (float): Passed on to the internal
@@ -3401,7 +3304,6 @@ class SmurfTuneMixin(SmurfBase):
                              Which channels (if any) to plot.  Default
                              is None.
         make_plot (bool): Whether or not to make plots.
-
         Ret:
         ----
         The estimated lms frequency in Hz
@@ -3428,14 +3330,12 @@ class SmurfTuneMixin(SmurfBase):
         """
         Attempts to find the number of phi0s in a tracking_setup.
         Takes df and sync from a tracking_setup with feedback off.
-
         Args:
         -----
         band (int) : which band
         df (float array): The df term from tracking setup with
             feedback off.
         sync (float array): The sync term from tracking setup.
-
         Opt Args:
         ---------
         min_scale (float): The minimum df amplitude used in analysis.
@@ -3448,7 +3348,6 @@ class SmurfTuneMixin(SmurfBase):
             arg.
         channel (int or int array): The channels to plot. Default 
             is None.
-
         Ret:
         ----
         n (float): The number of phi0 swept out per sync. To get
@@ -3530,11 +3429,9 @@ class SmurfTuneMixin(SmurfBase):
         """
         Takes the sync from tracking setup and makes a flag for when the sync
         is True.
-
         Args:
         -----
         sync (float array): The sync term from tracking_setup
-
         Ret:
         ----
         start (int array): The start index of the sync
@@ -3655,11 +3552,10 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def find_bad_pairs(self, band, reset_rate_khz=None, write_log=False,
-        make_plot=False, save_plot=True, plotname_append='', show_plot=True,
+        make_plot=False, save_plot=True, show_plot=True,
         lms_freq_hz=None, flux_ramp=True, fraction_full_scale=.4950,
         lms_enable1=True, lms_enable2=True, lms_enable3=True, lms_gain=None):
         """
-		Does not actually allow any plotmaking.
         """
         if reset_rate_khz is None:
             reset_rate_khz = self.reset_rate_khz
@@ -3714,7 +3610,6 @@ class SmurfTuneMixin(SmurfBase):
     def dump_state(self, output_file=None, return_screen=False):
         """
         Dump the current tuning info to config file and write to disk
-
         Args:
         -----
         output_file (str): path to output file location. Defaults to the config 
@@ -3767,7 +3662,6 @@ class SmurfTuneMixin(SmurfBase):
         """
         Takes a list of resonance frequencies and fakes a resonance dictionary 
         so that we can run setup_notches on a subset without find_freqs
-
         Args:
         freqs (list of floats): given in MHz, list of frequencies to tune. 
         Need to be within 100kHz to be really effective
@@ -3775,7 +3669,6 @@ class SmurfTuneMixin(SmurfBase):
         file but I can't find it...)
         save_sweeps (bool): whether to save each band as an amplitude sweep. 
         Defaults False.
-
         Outputs:
         resonance dictionary like the one that comes out of find_freqs
         You probably want to assign it to the right place, as in S.freq_resp = 
@@ -3831,13 +3724,11 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convert the frequency to which band we're in. This is almost certainly 
         a duplicate but I can't find the original...
-
         Args:
         -----
         frequency (float): frequency in MHz
         band_center_list (list): frequency centers of bands we're running with.
         Formatted as [[band_no, band_center],[band_no, band_center],etc.]
-
         Ret:
         ----
         band_no of the frequency

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -34,7 +34,7 @@ class SmurfTuneMixin(SmurfBase):
     def tune(self, load_tune=True, tune_file=None, last_tune=False,
              retune=False, f_min=.02, f_max=.3, df_max=.03,
              fraction_full_scale=None, make_plot=False,
-             save_plot=True, show_plot=False,
+             save_plot=True, plotname_append='', show_plot=False,
              new_master_assignment=False, track_and_check=True):
         """
         This runs a tuning, does tracking setup, and prunes bad
@@ -59,6 +59,7 @@ class SmurfTuneMixin(SmurfBase):
             flux ramp amplitude.
         make_plot (bool): Whether to make a plot. Default is False.
         save_plot (bool): If making plots, whether to save them. Default is True.
+		plotname_append (string) : Appended to the default plot filename. Default is ''.
         show_plot (bool): Whether to display the plots to screen. Default is False.
         track_and_check (bool): Whether or not after tuning to run
             track and check.  Default is True.
@@ -97,7 +98,8 @@ class SmurfTuneMixin(SmurfBase):
                 self.log('Running tune band serial on band {}'.format(b))
                 self.tune_band_serial(b, from_old_tune=load_tune,
                     old_tune=tune_file, make_plot=make_plot, 
-                    show_plot=show_plot, save_plot=save_plot,
+                    show_plot=show_plot, save_plot=save_plot, 
+					plotname_append=plotname_append,
                     new_master_assignment=new_master_assignment)
 
         # Starts tracking and runs check_lock to prune bad resonators
@@ -106,11 +108,12 @@ class SmurfTuneMixin(SmurfBase):
                 self.log('Tracking and checking band {}'.format(b))
                 self.track_and_check(b, fraction_full_scale=fraction_full_scale, 
                     f_min=f_min, f_max=f_max, df_max=df_max, make_plot=make_plot,
-                    save_plot=save_plot, show_plot=show_plot)
+                    save_plot=save_plot, plotname_append=plotname_append, 
+					show_plot=show_plot)
         
 
     def tune_band(self, band, freq=None, resp=None, n_samples=2**19, 
-        make_plot=False, show_plot=False, plot_chans=[], save_plot=True, 
+        make_plot=False, show_plot=False, plot_chans=[], save_plot=True, plotname_append='', 
         save_data=True,  make_subband_plot=False, subband=None, n_scan=5,
         subband_plot_with_slow=False, drive=None, grad_cut=.05, freq_min=-2.5E8, 
         freq_max=2.5E8, amp_cut=.5, use_slow_eta=False):
@@ -138,6 +141,7 @@ class SmurfTuneMixin(SmurfBase):
         save_plot (bool): Whether to save the plot. If True, it will close the
             plots before they are shown. If False, plots will be brought to the
             screen.
+		plotname_append (string) : Appended to the default plot filename. Default is ''.
         save_data (bool): If True, saves the data to disk.
         grad_cut (float): The value of the gradient of phase to look for 
             resonances. Default is .05
@@ -174,7 +178,8 @@ class SmurfTuneMixin(SmurfBase):
         # Find peaks
         peaks = self.find_peak(freq, resp, rolling_med=True, band=band, 
             make_plot=make_plot, show_plot=show_plot, window=5000,
-            save_plot=save_plot, grad_cut=grad_cut, freq_min=freq_min,
+            save_plot=save_plot, plotname_append=plotname_append, 
+			grad_cut=grad_cut, freq_min=freq_min,
             freq_max=freq_max, amp_cut=amp_cut, 
             make_subband_plot=make_subband_plot, timestamp=timestamp,
             subband_plot_with_slow=subband_plot_with_slow, pad=50, min_gap=50)
@@ -185,7 +190,8 @@ class SmurfTuneMixin(SmurfBase):
         for i, p in enumerate(peaks):
             eta, eta_scaled, eta_phase_deg, r2, eta_mag, latency, Q= \
                 self.eta_fit(band, freq, resp, p, 50E3, make_plot=False, 
-                plot_chans=plot_chans, save_plot=save_plot, res_num=i, 
+                plot_chans=plot_chans, save_plot=save_plot, 
+				plotname_append=plotname_append, res_num=i, 
                 band=band, timestamp=timestamp, use_slow_eta=use_slow_eta)
 
             # Fill the resonances dict
@@ -233,7 +239,7 @@ class SmurfTuneMixin(SmurfBase):
         return resonances
 
     def tune_band_serial(self, band, n_samples=2**19,
-        make_plot=False, save_plot=True, save_data=True, show_plot=False,
+        make_plot=False, save_plot=True, plotname_append='', save_data=True, show_plot=False,
         make_subband_plot=False, subband=None, n_scan=5,
         subband_plot_with_slow=False, window=5000, rolling_med=True,
         grad_cut=.03, freq_min=-2.5E8, freq_max=2.5E8, amp_cut=.25,
@@ -262,6 +268,7 @@ class SmurfTuneMixin(SmurfBase):
         make_plot (bool): Whether to make plots. Default is False.
         save_plot (bool): If make_make plot is True, whether to save
             the plots. Default is True.
+		plotname_append (string) : Appended to the default plot filename. Default is ''.
         show_plot (bool): If make_plot is True, whether to display
             the plots to screen.
         """
@@ -307,7 +314,8 @@ class SmurfTuneMixin(SmurfBase):
             # Find peaks
             peaks = self.find_peak(freq, resp, rolling_med=rolling_med, 
                 window=window, band=band, make_plot=make_plot, 
-                save_plot=save_plot,  show_plot=show_plot, grad_cut=grad_cut, 
+                save_plot=save_plot, plotname_append=plotname_append,
+				show_plot=show_plot, grad_cut=grad_cut, 
                 freq_min=freq_min, freq_max=freq_max, amp_cut=amp_cut,
                 make_subband_plot=make_subband_plot, timestamp=timestamp,
                 subband_plot_with_slow=subband_plot_with_slow, pad=pad, 
@@ -389,7 +397,7 @@ class SmurfTuneMixin(SmurfBase):
 
         
     def plot_tune_summary(self, band, eta_scan=False, show_plot=False,
-        save_plot=True, eta_width=.3):
+        save_plot=True, plotname_append='', eta_width=.3):
         """
         Plots summary of tuning. Requires self.freq_resp to be filled.
         In other words, you must run find_freq and setup_notches
@@ -408,6 +416,7 @@ class SmurfTuneMixin(SmurfBase):
            Warning this is slow. Default is False.
         show_plot (bool) : Whether to display the plot. Default is False.
         save_plot (bool) : Whether to save the plot. Default is True.
+		plotname_append (string) : filename = <default filename><plotname_append>. 
         eta_width (float) : The width to plot in MHz.
         """
         if show_plot:
@@ -465,7 +474,7 @@ class SmurfTuneMixin(SmurfBase):
                             wspace=.21, hspace=.21)
 
         if save_plot:
-            save_name = '{}_tune_summary.png'.format(timestamp)
+            save_name = '{}_tune_summary{}.png'.format(timestamp, plotname_append)
             path = os.path.join(self.plot_dir, save_name)
             plt.savefig(path, bbox_inches='tight')
             self.pub.register_file(path, 'tune', plot=True)
@@ -491,8 +500,8 @@ class SmurfTuneMixin(SmurfBase):
                     self.plot_eta_fit(freq[idx], resp[idx], 
                         eta_mag=r['eta_mag'], eta_phase_deg=r['eta_phase'],
                         band=band, res_num=k, timestamp=timestamp, 
-                        save_plot=save_plot, show_plot=show_plot, 
-                        peak_freq=center_freq, channel=r['channel'])
+                        save_plot=save_plot, plotname_append=plotname_append, 
+						show_plot=show_plot, peak_freq=center_freq, channel=r['channel'])
             # This is for data from find_freq/setup_notches
             else:
                 for k in keys:
@@ -501,12 +510,13 @@ class SmurfTuneMixin(SmurfBase):
                     self.plot_eta_fit(r['freq_eta_scan'], r['resp_eta_scan'],
                         eta=r['eta'], eta_mag=r['eta_mag'], 
                         eta_phase_deg=r['eta_phase'], band=band, res_num=k,
-                        timestamp=timestamp, save_plot=save_plot,
+                        timestamp=timestamp, save_plot=save_plot, 
+						plotname_append=plotname_append,
                         show_plot=show_plot, peak_freq=r['freq'])
 
 
     def full_band_resp(self, band, n_scan=1, n_samples=2**19, make_plot=False, 
-        save_plot=True, show_plot=False, save_data=False, timestamp=None, 
+        save_plot=True, plotname_append='', show_plot=False, save_data=False, timestamp=None, 
         save_raw_data=False, correct_att=True, swap=False, hw_trigger=True, 
         write_log=False):
         """
@@ -522,7 +532,9 @@ class SmurfTuneMixin(SmurfBase):
         n_scan (int): The number of scans to take and average
         n_samples (int): The number of samples to take. Default 2^18.
         make_plot (bool): Whether the make plots. Default is False.
-        save_data (bool): Whether to save the data.
+		save_plot (bool): Whether to save plots.
+		plotname_append (string) : Appended to the default plot filename. Default is ''.
+        save_data (bool): Whether to save the data. Default is True.
         timestamp (str): The timestamp as a string.
         correct_att (bool): Correct the response for the attenuators. Default
             is True.
@@ -628,7 +640,7 @@ class SmurfTuneMixin(SmurfBase):
 
             if save_plot:
                 path = os.path.join(self.plot_dir,
-                    '{}_b{}_full_band_resp_raw.png'.format(timestamp, band))
+                    '{}_b{}_full_band_resp_raw{}.png'.format(timestamp, band, plotname_append))
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'response', plot=True)
                 plt.close()
@@ -641,8 +653,9 @@ class SmurfTuneMixin(SmurfBase):
             ax.set_title(timestamp)
             if save_plot:
                 path = os.path.join(self.plot_dir,
-                             '{}_b{}_full_band_resp.png'.format(timestamp,
-                                                                band))
+                             '{}_b{}_full_band_resp{}.png'.format(timestamp,
+                                                                band,
+																plotname_append))
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'response', plot=True)
             if show_plot:
@@ -670,7 +683,7 @@ class SmurfTuneMixin(SmurfBase):
 
     def find_peak(self, freq, resp, rolling_med=True, window=5000,
         grad_cut=.5, amp_cut=.25, freq_min=-2.5E8, freq_max=2.5E8, 
-        make_plot=False, save_plot=True, show_plot=False, band=None, 
+        make_plot=False, save_plot=True, plotname_append='', show_plot=False, band=None, 
         subband=None, make_subband_plot=False,  subband_plot_with_slow=False, 
         timestamp=None, pad=50, min_gap=100, plot_title=None, 
         grad_kernel_width=8):
@@ -699,6 +712,7 @@ class SmurfTuneMixin(SmurfBase):
             very slow. Default is False.
         save_plot (bool): Whether to save the plot to self.plot_dir. Default
             is True.
+		plotname_append (string) : Appended to the default plot filename. Default is ''.
         band (int): The band to take find the peaks in. Mainly for saving
             and plotting.
         timestamp (str): The timestamp. Mainly for saving and plotting
@@ -792,7 +806,7 @@ class SmurfTuneMixin(SmurfBase):
                     save_name = save_name + '_b{}'.format(int(band))
                 if subband is not None:
                     save_name = save_name + '_sb{}'.format(int(subband))
-                save_name = save_name + '_find_freq.png'
+                save_name = save_name + '_find_freq' + plotname_append+'.png'
                 path = os.path.join(self.plot_dir, save_name)
                 plt.savefig(path, bbox_inches='tight', dpi=300)
                 self.pub.register_file(path, 'find_freq', plot=True)
@@ -872,7 +886,8 @@ class SmurfTuneMixin(SmurfBase):
                         ax[1].plot(ff+sbc[1][sb], np.abs(dd)/2.5E6)
 
                     if save_plot:
-                        save_name = f'{timestamp}_find_freq_b{band}_sb{sb:03}.png'
+                        save_name = f'{timestamp}_find_freq_b{band}_sb{sb:03}'
+						save_name = save_name + plotname_append + '.png'
                         os.path.join(self.plot_dir, save_name)
                         plt.savefig(path, bbox_inches='tight')
                         self.pub.register_file(path, 'find_freq', plot=True)
@@ -1024,7 +1039,7 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def eta_fit(self, freq, resp, peak_freq, delta_freq,
-                make_plot=False, plot_chans=[], save_plot=True, band=None,
+                make_plot=False, plot_chans=[], save_plot=True, plotname_append='', band=None,
                 timestamp=None, res_num=None, use_slow_eta=False):
         """
         Cyndia's eta finding code
@@ -1040,6 +1055,7 @@ class SmurfTuneMixin(SmurfBase):
         ---------
         make_plot (bool): Whether to make plots. Default is False.
         save_plot (bool): Whether to save plots. Default is True.
+		plotname_append (string) : Appended to the default plot filename. Default is ''.
         plot_chans (int array): The channels to plot. If an empty array, it
             will make plots for all channels.
         band (int): Only used for plotting - the band number of the resontaor
@@ -1128,7 +1144,8 @@ class SmurfTuneMixin(SmurfBase):
                 self.plot_eta_fit(freq[left_plot:right_plot], 
                     resp[left_plot:right_plot], 
                     eta=eta, eta_mag=eta_mag, r2=r2,
-                    save_plot=save_plot, timestamp=timestamp, band=band,
+                    save_plot=save_plot, plotname_append=plotname_append, 
+					timestamp=timestamp, band=band,
                     res_num=res_num, sk_fit=sk_fit, f_slow=f_slow, resp_slow=resp_slow)
             else:
                 if res_num in plot_chans:
@@ -1137,7 +1154,8 @@ class SmurfTuneMixin(SmurfBase):
                     self.plot_eta_fit(freq[left_plot:right_plot], 
                         resp[left_plot:right_plot], 
                         eta=eta, eta_mag=eta_mag, eta_phase_deg=eta_phase_deg, 
-                        r2=r2, save_plot=save_plot, timestamp=timestamp, 
+                        r2=r2, save_plot=save_plot, plotname_append=plotname_append, 
+						timestamp=timestamp, 
                         band=band, res_num=res_num, sk_fit=sk_fit, 
                         f_slow=f_slow, resp_slow=resp_slow)
 
@@ -1145,7 +1163,7 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def plot_eta_fit(self, freq, resp, eta=None, eta_mag=None, peak_freq=None,
-        eta_phase_deg=None, r2=None, save_plot=True, show_plot=False, timestamp=None, 
+        eta_phase_deg=None, r2=None, save_plot=True, plotname_append='', show_plot=False, timestamp=None, 
         res_num=None, band=None, sk_fit=None, f_slow=None, resp_slow=None,
         channel=None):
         """
@@ -1163,6 +1181,7 @@ class SmurfTuneMixin(SmurfBase):
         eta_phase_deg (float): The angle of the eta parameter in degrees
         r2 (float): The R^2 value
         save_plot (bool): Whether to save the plot. Default True.
+		plotname_append (string) : Appended to the default plot filename. Default is ''.
         timestamp (str): The timestamp to name the file
         res_num (int): The resonator number to label the plot
         band (int): The band number to label the plot
@@ -1285,8 +1304,8 @@ class SmurfTuneMixin(SmurfBase):
 
         if save_plot:
             if res_num is not None and band is not None:
-                save_name = '{}_eta_b{}_res{:03}.png'.format(timestamp, band, 
-                    res_num)
+                save_name = '{}_eta_b{}_res{:03}{}.png'.format(timestamp, band, 
+                    res_num,plotname_append)
             else:
                 save_name = '{}_eta.png'.format(timestamp)
 
@@ -1928,7 +1947,7 @@ class SmurfTuneMixin(SmurfBase):
 
     def flux_ramp_check(self, band, reset_rate_khz=None, 
                         fraction_full_scale=None, flux_ramp=True,
-                        save_plot=True, show_plot=False):
+                        save_plot=True, plotname_append='', show_plot=False):
         """
         Tries to measure the V-phi curve in feedback disable mode. 
         You can also run this with flux ramp off to see the intrinsic
@@ -1945,6 +1964,7 @@ class SmurfTuneMixin(SmurfBase):
            zero to one.
         flux_ramp (bool) : Whether to flux ramp. Default is True.
         save_plot (bool) : Whether to save the plot. Default True.
+		plotname_append (string) : Appended to the default plot filename. Default is ''.
         show_plot (bool) : Whether to show the plot. Default False.
         """
         if show_plot:
@@ -2041,7 +2061,7 @@ class SmurfTuneMixin(SmurfBase):
                 if not flux_ramp:
                     save_name = save_name + '_no_FR'
                 save_name = save_name+ \
-                    '_b{}_sb{:03}_flux_ramp_check.png'.format(band, sb)
+                    '_b{}_sb{:03}_flux_ramp_check{}.png'.format(band, sb, plotname_append)
                 path = os.path.join(self.plot_dir, save_name)
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'flux_ramp', plot=True)
@@ -2052,7 +2072,7 @@ class SmurfTuneMixin(SmurfBase):
         return d, df, sync
 
     def tracking_setup(self, band, channel=None, reset_rate_khz=None, 
-        write_log=False, make_plot=False, save_plot=True, show_plot=True, 
+        write_log=False, make_plot=False, save_plot=True, plotname_append='', show_plot=True, 
         nsamp=2**19, lms_freq_hz=None, meas_lms_freq=False, flux_ramp=True, 
         fraction_full_scale=None, lms_enable1=True, lms_enable2=True, 
         lms_enable3=True, lms_gain=None, return_data=True, new_epics_root=None,
@@ -2074,6 +2094,7 @@ class SmurfTuneMixin(SmurfBase):
         write_log (bool) : Whether to write output to the log.  Default False.
         make_plot (bool) : Whether to make plots. Default False.
         save_plot (bool) : Whether to save plots. Default True.
+		plotname_append (string) : Appended to the default plot filename. Default is ''.
         show_plot (bool) : Whether to display the plot. Default True.
         lms_freq_hz (float) : The frequency of the tracking algorithm.
            Default is 4000
@@ -2250,7 +2271,7 @@ class SmurfTuneMixin(SmurfBase):
             
             if save_plot:
                 path = os.path.join(self.plot_dir, 
-                    timestamp + '_FR_amp_v_err.png')
+                    timestamp + '_FR_amp_v_err' + plotname_append + '.png')
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'amp_vs_err', plot=True)
 
@@ -2308,7 +2329,8 @@ class SmurfTuneMixin(SmurfBase):
 
                     if save_plot:
                         path = os.path.join(self.plot_dir, timestamp + 
-                            '_FRtracking_band{}_ch{:03}.png'.format(band,ch))                        
+                            '_FRtracking_band{}_ch{:03}{}.png'.format(band,ch,
+							plotname_append))                        
                         plt.savefig(path, bbox_inches='tight')
                         self.pub.register_file(path, 'tracking', plot=True)
 
@@ -2321,7 +2343,7 @@ class SmurfTuneMixin(SmurfBase):
             return f, df, sync
 
     def track_and_check(self, band, channel=None, reset_rate_khz=None, 
-        make_plot=False, save_plot=True, show_plot=True,
+        make_plot=False, save_plot=True, plotname_append='', show_plot=True,
         lms_freq_hz=None, flux_ramp=True, fraction_full_scale=None,
         lms_enable1=True, lms_enable2=True, lms_enable3=True, lms_gain=None,
         f_min=.015, f_max=.2, df_max=.03, toggle_feedback=True,
@@ -2349,6 +2371,7 @@ class SmurfTuneMixin(SmurfBase):
         write_log (bool) : Whether to write output to the log.  Default False.
         make_plot (bool) : Whether to make plots. Default False.
         save_plot (bool) : Whether to save plots. Default True.
+		plotname_append (string) : Appended to the default plot filename. Default is ''.
         show_plot (bool) : Whether to display the plot. Default True.
         lms_freq_hz (float) : The frequency of the tracking algorithm.
            Default is 4000
@@ -2389,7 +2412,8 @@ class SmurfTuneMixin(SmurfBase):
         if tracking_setup:
             self.tracking_setup(band, channel=channel, 
                 reset_rate_khz=reset_rate_khz, make_plot=make_plot, 
-                save_plot=save_plot, show_plot=show_plot,
+                save_plot=save_plot, plotname_append=plotname_append, 
+				show_plot=show_plot,
                 lms_freq_hz=lms_freq_hz, flux_ramp=flux_ramp, 
                 fraction_full_scale=fraction_full_scale, lms_enable1=lms_enable1, 
                 lms_enable2=lms_enable2, lms_enable3=lms_enable3, 
@@ -2831,7 +2855,7 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def find_freq(self, band, subband=np.arange(13,115), drive_power=None,
-        n_read=2, make_plot=False, save_plot=True, window=50, rolling_med=True,
+        n_read=2, make_plot=False, save_plot=True, plotname_append='', window=50, rolling_med=True,
         make_subband_plot=False, show_plot=False):
         '''
         Finds the resonances in a band (and specified subbands)
@@ -2847,6 +2871,7 @@ class SmurfTuneMixin(SmurfBase):
         n_read (int) : The number sweeps to do per subband
         make_plot (bool) : make the plot frequency sweep. Default False.
         save_plot (bool) : save the plot. Default True.
+		plotname_append (string) : Appended to the default plot filename. Default is ''.
         save_name (string) : What to name the plot. default find_freq.png
         rolling_med (bool) : Whether to iterate on a rolling median or just
            the median of the whole sample.
@@ -2894,21 +2919,21 @@ class SmurfTuneMixin(SmurfBase):
         res_freq = self.find_all_peak(self.freq_resp[band]['find_freq']['f'],
             self.freq_resp[band]['find_freq']['resp'], subband, 
             make_plot=make_plot, band=band, rolling_med=rolling_med, 
-            window=window, make_subband_plot=make_subband_plot)
+            window=window, make_subband_plot=make_subband_plot, plotname_append=plotname_append)
         self.freq_resp[band]['find_freq']['resonance'] = res_freq
 
         # Save resonances
         path = os.path.join(self.output_dir, 
             save_name.format(timestamp, 'resonance'))
         np.savetxt(path, self.freq_resp[band]['find_freq']['resonance'])
-        self.pub.register_file(path, 'resonances', format='txt')
+        self.pub.register_file(path, 'resonances', format='txt')			
 
         # Call plotting
         if make_plot:
             self.plot_find_freq(self.freq_resp[band]['find_freq']['f'], 
-                self.freq_resp[band]['find_freq']['resp'], save_plot=save_plot,
+                self.freq_resp[band]['find_freq']['resp'], save_plot=save_plot, 
                 show_plot=show_plot, 
-                save_name=save_name.replace('.txt', '.png').format(timestamp, band))
+                save_name=save_name.replace('.txt', plotname_append+'.png').format(timestamp, band)
 
         return f, resp
 
@@ -2924,7 +2949,7 @@ class SmurfTuneMixin(SmurfBase):
         Opt Args:
         ---------
         save_plot (bool) : save the plot. Default True.
-        save_name (string) : What to name the plot. default find_freq.png
+        save_name (string) : What to name the plot. default amp_sweep.png
         '''
         if subband is None:
             subband = np.arange(128)
@@ -3002,7 +3027,7 @@ class SmurfTuneMixin(SmurfBase):
 
     def find_all_peak(self, freq, resp, subband=None, rolling_med=False, 
         window=500, grad_cut=0.05, amp_cut=0.25, freq_min=-2.5E8, freq_max=2.5E8, 
-        make_plot=False, save_plot=True, band=None, make_subband_plot=False, 
+        make_plot=False, save_plot=True, plotname_append='', band=None, make_subband_plot=False, 
         subband_plot_with_slow=False, timestamp=None, pad=2, min_gap=2):
         """
         find the peaks within each subband requested from a fullbandamplsweep
@@ -3037,7 +3062,8 @@ class SmurfTuneMixin(SmurfBase):
         peaks = self.find_peak(f_stack, r_stack, rolling_med=rolling_med, 
             window=window, grad_cut=grad_cut, amp_cut=amp_cut, freq_min=freq_min,
             freq_max=freq_max, make_plot=make_plot, save_plot=save_plot, 
-            band=band, make_subband_plot=make_subband_plot,
+			plotname_append=plotname_append, band=band, 
+			make_subband_plot=make_subband_plot,
             subband_plot_with_slow=subband_plot_with_slow, timestamp=timestamp, 
             pad=pad, min_gap=min_gap)
 
@@ -3624,7 +3650,7 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def find_bad_pairs(self, band, reset_rate_khz=None, write_log=False,
-        make_plot=False, save_plot=True, show_plot=True,
+        make_plot=False, save_plot=True, plotname_append='', show_plot=True,
         lms_freq_hz=None, flux_ramp=True, fraction_full_scale=.4950,
         lms_enable1=True, lms_enable2=True, lms_enable3=True, lms_gain=None):
         """

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -381,12 +381,11 @@ class SmurfTuneMixin(SmurfBase):
 
         
     def plot_tune_summary(self, band, eta_scan=False, show_plot=False,
-        save_plot=True, plotname_append='', eta_width=.3):
+        save_plot=True, eta_width=.3):
         """
         Plots summary of tuning. Requires self.freq_resp to be filled.
         In other words, you must run find_freq and setup_notches
         before calling this function. Saves the plot to plot_dir.
-
         This will also make individual eta plots as well if {eta_scan} is True.
         The eta scan plots are slow because there are many of them.
         
@@ -400,7 +399,6 @@ class SmurfTuneMixin(SmurfBase):
            Warning this is slow. Default is False.
         show_plot (bool) : Whether to display the plot. Default is False.
         save_plot (bool) : Whether to save the plot. Default is True.
-		plotname_append (string) : filename = <default filename><plotname_append>. 
         eta_width (float) : The width to plot in MHz.
         """
         if show_plot:
@@ -458,7 +456,7 @@ class SmurfTuneMixin(SmurfBase):
                             wspace=.21, hspace=.21)
 
         if save_plot:
-            save_name = '{}_tune_summary{}.png'.format(timestamp, plotname_append)
+            save_name = '{}_tune_summary.png'.format(timestamp)
             path = os.path.join(self.plot_dir, save_name)
             plt.savefig(path, bbox_inches='tight')
             self.pub.register_file(path, 'tune', plot=True)
@@ -484,8 +482,8 @@ class SmurfTuneMixin(SmurfBase):
                     self.plot_eta_fit(freq[idx], resp[idx], 
                         eta_mag=r['eta_mag'], eta_phase_deg=r['eta_phase'],
                         band=band, res_num=k, timestamp=timestamp, 
-                        save_plot=save_plot, plotname_append=plotname_append, 
-						show_plot=show_plot, peak_freq=center_freq, channel=r['channel'])
+                        save_plot=save_plot, show_plot=show_plot, 
+                        peak_freq=center_freq, channel=r['channel'])
             # This is for data from find_freq/setup_notches
             else:
                 for k in keys:
@@ -494,8 +492,7 @@ class SmurfTuneMixin(SmurfBase):
                     self.plot_eta_fit(r['freq_eta_scan'], r['resp_eta_scan'],
                         eta=r['eta'], eta_mag=r['eta_mag'], 
                         eta_phase_deg=r['eta_phase'], band=band, res_num=k,
-                        timestamp=timestamp, save_plot=save_plot, 
-						plotname_append=plotname_append,
+                        timestamp=timestamp, save_plot=save_plot,
                         show_plot=show_plot, peak_freq=r['freq'])
 
 
@@ -662,18 +659,16 @@ class SmurfTuneMixin(SmurfBase):
 
     def find_peak(self, freq, resp, rolling_med=True, window=5000,
         grad_cut=.5, amp_cut=.25, freq_min=-2.5E8, freq_max=2.5E8, 
-        make_plot=False, save_plot=True, plotname_append='', show_plot=False, band=None, 
+        make_plot=False, save_plot=True, show_plot=False, band=None, 
         subband=None, make_subband_plot=False,  subband_plot_with_slow=False, 
         timestamp=None, pad=50, min_gap=100, plot_title=None, 
         grad_kernel_width=8):
         """find the peaks within a given subband
-
         Args:
         -----
         freq (float array): should be a single row of the broader freq
                             array, in Mhz.
         resp (complex array): complex response for just this subband
-
         Opt Args:
         ---------
         rolling_med (bool): whether to use a rolling median for the background
@@ -691,7 +686,6 @@ class SmurfTuneMixin(SmurfBase):
             very slow. Default is False.
         save_plot (bool): Whether to save the plot to self.plot_dir. Default
             is True.
-		plotname_append (string) : Appended to the default plot filename. Default is ''.
         band (int): The band to take find the peaks in. Mainly for saving
             and plotting.
         timestamp (str): The timestamp. Mainly for saving and plotting
@@ -700,7 +694,6 @@ class SmurfTuneMixin(SmurfBase):
         min_gap (int): minimum number of samples between resonances
         grad_kernel_width (int) : The number of samples to take after a point
             to calculate the gradient of phase. Default is 8.
-
         Returns:
         -------_
         resonances (float array): The frequency of the resonances in the band
@@ -785,7 +778,7 @@ class SmurfTuneMixin(SmurfBase):
                     save_name = save_name + '_b{}'.format(int(band))
                 if subband is not None:
                     save_name = save_name + '_sb{}'.format(int(subband))
-                save_name = save_name + '_find_freq' + plotname_append+'.png'
+                save_name = save_name + '_find_freq.png'
                 path = os.path.join(self.plot_dir, save_name)
                 plt.savefig(path, bbox_inches='tight', dpi=300)
                 self.pub.register_file(path, 'find_freq', plot=True)
@@ -865,8 +858,7 @@ class SmurfTuneMixin(SmurfBase):
                         ax[1].plot(ff+sbc[1][sb], np.abs(dd)/2.5E6)
 
                     if save_plot:
-                        save_name = f'{timestamp}_find_freq_b{band}_sb{sb:03}'
-						save_name = save_name + plotname_append + '.png'
+                        save_name = f'{timestamp}_find_freq_b{band}_sb{sb:03}.png'
                         os.path.join(self.plot_dir, save_name)
                         plt.savefig(path, bbox_inches='tight')
                         self.pub.register_file(path, 'find_freq', plot=True)
@@ -1128,17 +1120,15 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def plot_eta_fit(self, freq, resp, eta=None, eta_mag=None, peak_freq=None,
-        eta_phase_deg=None, r2=None, save_plot=True, plotname_append='', show_plot=False, timestamp=None, 
+        eta_phase_deg=None, r2=None, save_plot=True, show_plot=False, timestamp=None, 
         res_num=None, band=None, sk_fit=None, f_slow=None, resp_slow=None,
         channel=None):
         """
         Plots the eta parameter fits
-
         Args:
         -----
         freq (float array): The frequency data
         resp (complex array): THe response data
-
         Opt Args:
         ---------
         eta (complex): The eta parameter
@@ -1146,7 +1136,6 @@ class SmurfTuneMixin(SmurfBase):
         eta_phase_deg (float): The angle of the eta parameter in degrees
         r2 (float): The R^2 value
         save_plot (bool): Whether to save the plot. Default True.
-		plotname_append (string) : Appended to the default plot filename. Default is ''.
         timestamp (str): The timestamp to name the file
         res_num (int): The resonator number to label the plot
         band (int): The band number to label the plot
@@ -1269,8 +1258,8 @@ class SmurfTuneMixin(SmurfBase):
 
         if save_plot:
             if res_num is not None and band is not None:
-                save_name = '{}_eta_b{}_res{:03}{}.png'.format(timestamp, band, 
-                    res_num,plotname_append)
+                save_name = '{}_eta_b{}_res{:03}.png'.format(timestamp, band, 
+                    res_num)
             else:
                 save_name = '{}_eta.png'.format(timestamp)
 
@@ -2773,15 +2762,13 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def find_freq(self, band, subband=np.arange(13,115), drive_power=None,
-        n_read=2, make_plot=False, save_plot=True, plotname_append='', 
-		window=50, rolling_med=True, make_subband_plot=False, show_plot=False):
+        n_read=2, make_plot=False, save_plot=True, window=50, rolling_med=True,
+        make_subband_plot=False, show_plot=False):
         '''
         Finds the resonances in a band (and specified subbands)
-
         Args:
         -----
         band (int) : The band to search
-
         Optional Args:
         --------------
         subband (int) : An int array for the subbands
@@ -2789,7 +2776,6 @@ class SmurfTuneMixin(SmurfBase):
         n_read (int) : The number sweeps to do per subband
         make_plot (bool) : make the plot frequency sweep. Default False.
         save_plot (bool) : save the plot. Default True.
-		plotname_append (string) : Appended to the default plot filename. Default is ''.
         save_name (string) : What to name the plot. default find_freq.png
         rolling_med (bool) : Whether to iterate on a rolling median or just
            the median of the whole sample.
@@ -2837,21 +2823,21 @@ class SmurfTuneMixin(SmurfBase):
         res_freq = self.find_all_peak(self.freq_resp[band]['find_freq']['f'],
             self.freq_resp[band]['find_freq']['resp'], subband, 
             make_plot=make_plot, band=band, rolling_med=rolling_med, 
-            window=window, make_subband_plot=make_subband_plot, plotname_append=plotname_append)
+            window=window, make_subband_plot=make_subband_plot)
         self.freq_resp[band]['find_freq']['resonance'] = res_freq
 
         # Save resonances
         path = os.path.join(self.output_dir, 
             save_name.format(timestamp, 'resonance'))
         np.savetxt(path, self.freq_resp[band]['find_freq']['resonance'])
-        self.pub.register_file(path, 'resonances', format='txt')			
+        self.pub.register_file(path, 'resonances', format='txt')
 
         # Call plotting
         if make_plot:
             self.plot_find_freq(self.freq_resp[band]['find_freq']['f'], 
-                self.freq_resp[band]['find_freq']['resp'], save_plot=save_plot, 
+                self.freq_resp[band]['find_freq']['resp'], save_plot=save_plot,
                 show_plot=show_plot, 
-                save_name=save_name.replace('.txt', plotname_append+'.png').format(timestamp, band)
+                save_name=save_name.replace('.txt', '.png').format(timestamp, band))
 
         return f, resp
 
@@ -2860,14 +2846,12 @@ class SmurfTuneMixin(SmurfBase):
         '''
         Plots the response of the frequency sweep. Must input f and resp, or
         give a path to a text file containing the data for offline plotting.
-
         To do:
         Add ability to use timestamp and multiple plots
-
         Opt Args:
         ---------
         save_plot (bool) : save the plot. Default True.
-        save_name (string) : What to name the plot. default amp_sweep.png
+        save_name (string) : What to name the plot. default find_freq.png
         '''
         if subband is None:
             subband = np.arange(128)
@@ -2943,19 +2927,16 @@ class SmurfTuneMixin(SmurfBase):
 
     def find_all_peak(self, freq, resp, subband=None, rolling_med=False, 
         window=500, grad_cut=0.05, amp_cut=0.25, freq_min=-2.5E8, freq_max=2.5E8, 
-        make_plot=False, save_plot=True, plotname_append='', band=None, 
-		make_subband_plot=False, subband_plot_with_slow=False, timestamp=None, 
-		pad=2, min_gap=2):
+        make_plot=False, save_plot=True, band=None, make_subband_plot=False, 
+        subband_plot_with_slow=False, timestamp=None, pad=2, min_gap=2):
         """
         find the peaks within each subband requested from a fullbandamplsweep
-
         Args:
         -----
         freq (array):  (n_subbands x n_freq_swept) array of frequencies swept
         response (complex array): n_subbands x n_freq_swept array of complex 
             response
         subbands (list of ints): subbands that we care to search in
-
         Optional Args:
         --------------
         see find_peak for optional arguments. Used the same defaults here.
@@ -2979,8 +2960,7 @@ class SmurfTuneMixin(SmurfBase):
         peaks = self.find_peak(f_stack, r_stack, rolling_med=rolling_med, 
             window=window, grad_cut=grad_cut, amp_cut=amp_cut, freq_min=freq_min,
             freq_max=freq_max, make_plot=make_plot, save_plot=save_plot, 
-			plotname_append=plotname_append, band=band, 
-			make_subband_plot=make_subband_plot,
+            band=band, make_subband_plot=make_subband_plot,
             subband_plot_with_slow=subband_plot_with_slow, timestamp=timestamp, 
             pad=pad, min_gap=min_gap)
 


### PR DESCRIPTION
Disclaimer: I DID NOT GET TO TEST THIS, because I couldn't get pip3 on my system. Please test it! I don't think anything is wrong, but nobody ever does.

I was searching for all the plotmaking functions called in the script [here](https://simons1.princeton.edu/confluence/pages/viewpage.action?spaceKey=UD&title=20200218_SPB_DAQSMuRF_meeting), which also covers all the ones I've used. After I figured out what files they were in, I went through those files and systematically ensured all plotting functions within them had the ability to append to the plot filenames as an optional argument, and updated their calls to each other to pass it along. I also added a description of the argument to all the functions that had any documentation of their optional arguments. 