### PR TITLE
Properly decode f, dF streams for either bay0 or bay1

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -478,7 +478,7 @@ class SmurfUtilMixin(SmurfBase):
             header = header1[::2] + header1[1::2] * (2**16) # what am I doing
         else:
             raise TypeError('Type {} not yet supported!'.format(dtype))
-        if header[1,1] == 2:
+        if (header[1,1]>>24 == 2) or (header[1,1]>>24 == 0):
             header = np.fliplr(header)
             data = np.fliplr(data)
 


### PR DESCRIPTION
Bay 0 uses Stream0 and Stream1.  Bay 1 uses Stream2 and Stream3.  Need to parse file header to determine which stream is f and which is dF.  This works for bay 1, need to confirm bay 0 still works as well.

 *       headerA:
 *          [31:0] = Length of data block in bytes
 *       headerB
 *          31:24  = Channel ID
 *          23:16  = Frame error
 *          15:0   = Frame flags