### PR TITLE
Add missing import which was remove during flake8 cleanup

### DIFF
--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -139,7 +139,8 @@ class Common(pyrogue.Root):
         self._epics = None
         if epics_prefix:
             print("Starting EPICS server using prefix \"{}\"".format(epics_prefix))
-            self._epics = pyrogue.protocols.epics.EpicsCaServer(base=epics_prefix, root=self)
+            from pyrogue.protocols import epics
+            self._epics = epics.EpicsCaServer(base=epics_prefix, root=self)
             self._pv_dump_file = pv_dump_file
 
             # PVs for stream data


### PR DESCRIPTION
and fix the usage of the epics module after import, it was being
used incorrect, and triggering the flake8 error