### PR TITLE
Issue281

### DIFF
--- a/scratch/shawn/scripts/rogue4.sh
+++ b/scratch/shawn/scripts/rogue4.sh
@@ -1,5 +1,6 @@
 # updated 2/12/20 : smurf-srv12
 # Drop into rogue 4 configuration
+
 pwd=$PWD
 
 rm -v /data/smurf_startup_cfg/smurf_startup.cfg
@@ -13,8 +14,6 @@ sudo ./install.sh
 
 rm /home/cryo/docker/smurf/current
 
-#ln -s /home/cryo/docker/smurf/stable/slotN/v0.0.1 /home/cryo/docker/smurf/current
-# ln -s /home/cryo/docker/smurf/dev_fw/v4.0.0-rc15 /home/cryo/docker/smurf/current
-ln -s /home/cryo/docker/smurf/dev_fw/slotN/v4.0.0-rc18 /home/cryo/docker/smurf/current
+ln -s /home/cryo/docker/smurf/dev_fw/slotN/v4.0.0-rc21/ /home/cryo/docker/smurf/current
 
 cd $pwd


### PR DESCRIPTION
Adds ADC saturation check to full_band_resp using new boolean flag check_if_adc_is_saturated.  Default is true, and full_band_resp now throws an exception if the noise file is saturating the ADC.  Addresses issue https://github.com/slaclab/pysmurf/issues/281.