### PR TITLE
Update smurf-rogue base image to version R2.6.1

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.6.0
+FROM tidair/smurf-rogue:R2.6.1
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src


### PR DESCRIPTION
This will update Rogue to version v4.10.6, which has bug fixes we need. Specifically it has a bug fix for the PyDM interface Mitch discovered, described here: https://jira.slac.stanford.edu/browse/ESCRYODET-600