### PR TITLE
Expose the server startup script name and list of arguments

### DIFF
--- a/docker/server/scripts/server_common.sh
+++ b/docker/server/scripts/server_common.sh
@@ -463,10 +463,10 @@ detect_amc_board()
             # Check if a board is present in this slot
             printf "  Checking if board is present...                 "
             if [ -z ${pn_str} ]; then
-                echo "Board not present.\n"
+                echo "Board not present."
                 continue
             else
-                echo "Board present.\n"
+                echo "Board present."
             fi
 
             # Verify if the part number is correct

--- a/python/pysmurf/core/devices/_SmurfApplication.py
+++ b/python/pysmurf/core/devices/_SmurfApplication.py
@@ -20,6 +20,7 @@
 import pyrogue
 import pysmurf
 import os
+import sys
 
 class SmurfApplication(pyrogue.Device):
     """
@@ -30,19 +31,31 @@ class SmurfApplication(pyrogue.Device):
 
         self.add(pyrogue.LocalVariable(
             name='SmurfVersion',
-            description='SMURF Version Field',
+            description='PySMuRF Version',
             mode='RO',
             value=pysmurf.__version__))
 
         self.add(pyrogue.LocalVariable(
             name='SmurfDirectory',
-            description='Path to SMURF Python Files',
+            description='Path to the PySMuRF Python Files',
             value=os.path.dirname(pysmurf.__file__),
             mode='RO'))
 
         self.add(pyrogue.LocalVariable(
+            name='StartupScript',
+            description='PySMuRF Server Startup Script',
+            value=sys.argv[0],
+            mode='RO'))
+
+        self.add(pyrogue.LocalVariable(
+            name='StartupArguments',
+            description='PySMuRF Server Startup Arguments',
+            value=' '.join(sys.argv[1:]),
+            mode='RO'))
+
+        self.add(pyrogue.LocalVariable(
             name='SomePySmurfVariable',
-            description='PySmurf Variable Example',
+            description='PySMuRF Variable Example',
             mode='RW',
             value=0, # Initial value determine variable type, (int, float, list, etc)
         ))


### PR DESCRIPTION
under the SmurfApplication device. With this change there are these 2 new registers: 
- **<epics_prefix>:AMCc:SmurfApplication:StartupScript** : name of the startup script used to start the pysmurf-server
- **<epics_prefix>:AMCc:SmurfApplication:StartupStartupArguments** : list of arguments passed to the startup script

For example:
```
cryo@smurf-srv13:/$ caget -S smurf_server_s5:AMCc:SmurfApplication:StartupScript
smurf_server_s5:AMCc:SmurfApplication:StartupScript /usr/local/src/pysmurf/server_scripts/cmb_pcie.py
cryo@smurf-srv13:/$ caget -S smurf_server_s5:AMCc:SmurfApplication:StartupArguments
smurf_server_s5:AMCc:SmurfApplication:StartupArguments -g -w smurf_server_s5 -e smurf_server_s5 -d /tmp/fw/config/defaults.yml -l 3 -a 10.0.1.105 -z /tmp/fw/rogue_MicrowaveMuxBpEthGen2_v0.0.3.zip -d /tmp/fw/smurf_cfg/defaults/defaults_c03_lb_lb.yml --enable-em22xx
```

With this feature, the content of **<epics_prefix>:AMCc:SmurfApplication:StartupStartupArguments** can be used to determine for example if the `--disable-bay0` or `--disable-bay1` were used, as requested in [ESCRYODET-601](https://jira.slac.stanford.edu/browse/ESCRYODET-601).