### PR TITLE
Fix shawnhammer smurf server detection

### DIFF
--- a/cfg_files/stanford/fp30_smurf_startup.cfg
+++ b/cfg_files/stanford/fp30_smurf_startup.cfg
@@ -2,12 +2,8 @@ shelfmanager=shm-smrf-sp01
 
 set_crate_fans_to_full=true
 # COMTEL max fan level is 100, ASIS is 15, ELMA is 15
-## COMTEL in RF lab
+## We're using an ELMA crate on campus right now.
 max_fan_level=10
-## ELMA in RF lab
-#max_fan_level=15
-## ASIS in RF lab
-#max_fan_level=15
 
 attach_at_end=true
 screenshot_signal_analyzer=false

--- a/cfg_files/stanford/fp30_smurf_startup.cfg
+++ b/cfg_files/stanford/fp30_smurf_startup.cfg
@@ -3,7 +3,7 @@ shelfmanager=shm-smrf-sp01
 set_crate_fans_to_full=true
 # COMTEL max fan level is 100, ASIS is 15, ELMA is 15
 ## COMTEL in RF lab
-max_fan_level=15
+max_fan_level=10
 ## ELMA in RF lab
 #max_fan_level=15
 ## ASIS in RF lab

--- a/scratch/shawn/scripts/shawnhammer.sh
+++ b/scratch/shawn/scripts/shawnhammer.sh
@@ -153,6 +153,10 @@ tmux rename-window -t ${tmux_session_name}:0 utils
 tmux send-keys -t ${tmux_session_name}:0 'cd /home/cryo/docker/utils' C-m
 tmux send-keys -t ${tmux_session_name}:0 './run.sh' C-m
 
+# wait for utils docker to come up and record the container ID
+utilsdockerid=`wait_for_docker_instance smurf-base`
+docker rename ${utilsdockerid} smurf_utils
+
 if [ "$using_timing_master" = true ] ; then
     # display tpg log in tmux 0 with utils term
     tmux split-window -v -t ${tmux_session_name}:0

--- a/scratch/shawn/scripts/shawnhammer.sh
+++ b/scratch/shawn/scripts/shawnhammer.sh
@@ -242,8 +242,8 @@ if [ "$parallel_setup" = true ] ; then
 	    fi
 	    
 	    if [ "${slot_status[${slot_idx}]}" = "3" ]; then
-	    	echo "-> Waiting for gui to come up on slot ${slot}."
-	    	if is_slot_gui_up ${slot}; then
+	    	echo "-> Waiting for server to come up on slot ${slot}."
+	    	if is_slot_server_up ${slot}; then
 	    	    slot_status[$slot_idx]=4;
 	    	fi
 	    fi
@@ -262,14 +262,14 @@ if [ "$parallel_setup" = true ] ; then
 
 	    # Run pysmurf setup
 	    if [ "${slot_status[${slot_idx}]}" = "5" ]; then
-		echo "-> Running pysmurf setup on slot ${slot}."
+		echo "-> Running pysmurf setup on slot ${slot} ..."
 		run_pysmurf_setup ${slot}
 		slot_status[$slot_idx]=6
 	    fi
 
 	    # Check for pysmurf setup completion
 	    if [ "${slot_status[${slot_idx}]}" = "6" ]; then
-		echo "-> Waiting for carrier setup on slot ${slot} (watching pysmurf docker ${pysmurf_docker})"		
+		echo "-> Waiting for carrier setup on slot ${slot} ..."		
 	    	if is_slot_pysmurf_setup_complete ${slot}; then
 	    	    slot_status[$slot_idx]=7;
 	    	fi		

--- a/scratch/shawn/scripts/shawnhammerfunctions.sh
+++ b/scratch/shawn/scripts/shawnhammerfunctions.sh
@@ -54,9 +54,14 @@ is_slot_pyrogue_up() {
     return 0
 }
 
-is_slot_gui_up() {
+is_slot_server_up() {
     slot_number=$1
-    tmux capture-pane -pt ${tmux_session_name}:${slot_number} | grep -q "Running GUI."
+
+    ## Old, bad way of determining if server is up
+    #tmux capture-pane -pt ${tmux_session_name}:${slot_number} | grep -q "Running GUI."
+    #return $?
+    
+    is_rogue_server_up ${slot_number}
     return $?
 }
 
@@ -138,7 +143,7 @@ run_pysmurf_setup () {
 
 is_slot_pysmurf_setup_complete() {
     slot_number=$1
-    tmux capture-pane -pt ${tmux_session_name}:${slot_number} | grep -q "Done with setup"
+    tmux capture-pane -pt ${tmux_session_name}:${slot_number} -S -10 | grep -q "Done with setup"
     return $?
 }
 


### PR DESCRIPTION
shawnhammer now detects when the pysmurf server is up by waiting until it gets a valid timestamp from the server (smurf_server_s#:AMCc:LocalTime) and that timestamp is incrementing in both serial and parallel bootup modes.  Previously shawnhammer detected server up by looking for a print statement in the rogue docker, which has already broken a couple of times when that print statement was changed.  The print statement shawnhammer used to parse was the "GUI is up" print statement, so now shawnhammer can detect the server is up even if the GUI is not enabled, and can setup faster, since it seems like the server often comes up before the GUI does.  Also fixes an issue with attaching at the end of pysmurf setup ; the function in shawnhammer that detects when pysmurf is done setting up (by looking for the "Done with setup" print statement at the end of pysmurf setup) wasn't grabbing enough lines of the tmux buffer to catch the statement for some versions of pysmurf where extra printout after setup in the python terminal was pushing the "Done with setup" statement out of the buffer being parsed for that statement.






