### PR TITLE
Adds default server_port when IP Address is not defined

### DIFF
--- a/python/pysmurf/core/roots/EmulationRoot.py
+++ b/python/pysmurf/core/roots/EmulationRoot.py
@@ -35,6 +35,7 @@ class EmulationRoot(Common):
                  disable_bay0   = False,
                  disable_bay1   = False,
                  txDevice       = None,
+                 server_port    = 0,
                  **kwargs):
 
         # Create the SRP Engine
@@ -58,6 +59,7 @@ class EmulationRoot(Common):
                         polling_en     = polling_en,
                         pv_dump_file   = pv_dump_file,
                         txDevice       = txDevice,
+                        server_port    = server_port,
                         **kwargs)
 
         self.add(self._streaming_stream)

--- a/python/pysmurf/core/server_scripts/Common.py
+++ b/python/pysmurf/core/server_scripts/Common.py
@@ -92,9 +92,13 @@ def process_args(args):
         if args.pcie_rssi_lane:
             # If the RSSI lane number was defined, get the slot number from it
             args.server_port = 9000 + 2 * ( args.pcie_rssi_lane + 2 )
-        else:
+        elif args.ip_addr:
             # Otherwise, get th slot number from the last digit of the IP address
             args.server_port = 9000 + 2 * int(args.ip_addr[-1:])
+        else:
+            # If the IP Address is not defined, we're probably running in emulation
+            # mode, and we default to port 9000
+            args.server_port = 9000
 
     return args
 

--- a/python/pysmurf/core/server_scripts/Common.py
+++ b/python/pysmurf/core/server_scripts/Common.py
@@ -43,7 +43,8 @@ def get_args():
 def process_args(args):
     """
         Processes args from argparse. Unzips zip_file and finds/sets the
-        args.config_file
+        args.config_file. Also set the server port to  a default values
+        if it was not defined.
     """
 
     # Verify if the zip file was specified
@@ -86,18 +87,20 @@ def process_args(args):
         else:
             print("Invalid zip file. Omitting it.")
 
-    # If the server port was not defined, set it to  (9000 + 2 * slot_number)
+    # If the server port was not defined, set it to a default value
     if args.server_port is None:
-        # Either the IP address or the RSSI lane number must be defined.
+        # When using a real target (AMC carrier or dev board), set the server port to
+        # (9000 + 2 * slot_number). Either the IP address or the RSSI lane number
+        # must be defined, so calculate the slot number based on those two cases
         if args.pcie_rssi_lane:
             # If the RSSI lane number was defined, get the slot number from it
             args.server_port = 9000 + 2 * ( args.pcie_rssi_lane + 2 )
         elif args.ip_addr:
             # Otherwise, get th slot number from the last digit of the IP address
             args.server_port = 9000 + 2 * int(args.ip_addr[-1:])
+        # Otherwise, for the emulator target set the server port to 9000.
+        # This target doesn't require IP address nor RSSI lane.
         else:
-            # If the IP Address is not defined, we're probably running in emulation
-            # mode, and we default to port 9000
             args.server_port = 9000
 
     return args

--- a/server_scripts/emulate.py
+++ b/server_scripts/emulate.py
@@ -38,6 +38,7 @@ if __name__ == "__main__":
                          pv_dump_file   = args['pv_dump_file'],
                          disable_bay0   = args['disable_bay0'],
                          disable_bay1   = args['disable_bay1'],
+                         server_port    = args['server_port'],
                          txDevice       = pysmurf.core.transmitters.BaseTransmitter(name='Transmitter')) as root:
 
         # Add dummy TES bias values ([-8:7]), for testing purposes.


### PR DESCRIPTION
This PR adds a default server_port in the process_args function. This is to support running in emulation mode when neither the pcie_rssi_lane or the ip address is defined.