### PR TITLE
Publisher actions

### DIFF
--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -20,9 +20,11 @@ import os
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
 import matplotlib.colors as Colors
+from pysmurf.client.util.pub import set_action
 
 class SmurfIVMixin(SmurfBase):
 
+    @set_action()
     def slow_iv_all(self, bias_groups=None, wait_time=.1, bias=None,
                     bias_high=1.5, bias_low=0, bias_step=.005,
                     show_plot=False, overbias_wait=2., cool_wait=30,
@@ -158,6 +160,7 @@ class SmurfIVMixin(SmurfBase):
 
         return path
 
+    @set_action()
     def partial_load_curve_all(self, bias_high_array, bias_low_array=None,
             wait_time=0.1, bias_step=0.1, show_plot=False, analyze=True,
             make_plot=True, save_plot=True, channels=None, overbias_voltage=None,
@@ -282,9 +285,9 @@ class SmurfIVMixin(SmurfBase):
                 show_plot=show_plot, save_plot=save_plot, R_sh=self.R_sh,
                 phase_excursion_min=phase_excursion_min, channels=channels)
 
-
         return path
 
+    @set_action()
     def analyze_slow_iv_from_file(self, fn_iv_raw_data, make_plot=True,
                                   show_plot=False, save_plot=True,
                                   plotname_append='', R_sh=None,
@@ -553,7 +556,7 @@ class SmurfIVMixin(SmurfBase):
             if not show_plot:
                 plt.close()
 
-
+    @set_action()
     def analyze_slow_iv(self, v_bias, resp, make_plot=True, show_plot=False,
             save_plot=True, basename=None, band=None, channel=None, R_sh=None,
             plot_dir=None, high_current_mode=False, bias_group=None,
@@ -920,6 +923,7 @@ class SmurfIVMixin(SmurfBase):
 
         return iv_dict
 
+    @set_action()
     def analyze_plc_from_file(self, fn_plc_raw_data, make_plot=True,
             show_plot=False, save_plot=True, R_sh=None,
             phase_excursion_min=1., channels=None):
@@ -1008,7 +1012,7 @@ class SmurfIVMixin(SmurfBase):
                 if not show_plot:
                     plt.close()
 
-
+    @set_action()
     def estimate_opt_eff(self, iv_fn_hot, iv_fn_cold,t_hot=293.,t_cold=77.,
             channels = None, dPdT_lim=(0.,0.5)):
         """
@@ -1128,7 +1132,7 @@ class SmurfIVMixin(SmurfBase):
         self.pub.register_file(hist_filename, 'opt_efficiency', plot=True)
         plt.close()
 
-
+    @set_action()
     def estimate_bias_voltage(self, iv_file, target_r_frac=.5,
                               normal_resistance=None,
                               normal_resistance_frac=.25,

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -24,12 +24,12 @@ from ..util import tools
 from pysmurf.client.command.sync_group import SyncGroup as SyncGroup
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
+from pysmurf.client.util.pub import set_action
 
 class SmurfTuneMixin(SmurfBase):
     """
     This contains all the tuning scripts
     """
-
     def tune(self, load_tune=True, tune_file=None, last_tune=False,
              retune=False, f_min=.02, f_max=.3, df_max=.03,
              fraction_full_scale=None, make_plot=False,

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -30,6 +30,7 @@ class SmurfTuneMixin(SmurfBase):
     """
     This contains all the tuning scripts
     """
+    @set_action()
     def tune(self, load_tune=True, tune_file=None, last_tune=False,
              retune=False, f_min=.02, f_max=.3, df_max=.03,
              fraction_full_scale=None, make_plot=False,
@@ -117,7 +118,7 @@ class SmurfTuneMixin(SmurfBase):
                     f_min=f_min, f_max=f_max, df_max=df_max, make_plot=make_plot,
                     save_plot=save_plot, show_plot=show_plot)
 
-
+    @set_action()
     def tune_band(self, band, freq=None, resp=None, n_samples=2**19,
             make_plot=False, show_plot=False, plot_chans=[],
             save_plot=True, save_data=True, make_subband_plot=False,
@@ -255,6 +256,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return resonances
 
+    @set_action()
     def tune_band_serial(self, band, n_samples=2**19, make_plot=False,
             save_plot=True, save_data=True, show_plot=False,
             make_subband_plot=False, subband=None, n_scan=5,
@@ -422,7 +424,7 @@ class SmurfTuneMixin(SmurfBase):
 
         self.log('Done with serial tuning')
 
-
+    @set_action()
     def plot_tune_summary(self, band, eta_scan=False, show_plot=False,
             save_plot=True, eta_width=.3, channels=None,
             plot_summary=True, plotname_append=''):
@@ -565,7 +567,7 @@ class SmurfTuneMixin(SmurfBase):
                             show_plot=show_plot, peak_freq=r['freq'],
                             channel=channel, plotname_append=plotname_append)
 
-
+    @set_action()
     def full_band_resp(self, band, n_scan=1, n_samples=2**19, make_plot=False,
             save_plot=True, show_plot=False, save_data=False, timestamp=None,
             save_raw_data=False, correct_att=True, swap=False, hw_trigger=True,
@@ -780,7 +782,7 @@ class SmurfTuneMixin(SmurfBase):
         else:
             return f, resp
 
-
+    @set_action()
     def find_peak(self, freq, resp, rolling_med=True, window=5000,
             grad_cut=.5, amp_cut=.25, freq_min=-2.5E8, freq_max=2.5E8,
             make_plot=False, save_plot=True, plotname_append='', show_plot=False,
@@ -1040,6 +1042,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return freq[peak]
 
+    @set_action()
     def find_flag_blocks(self, flag, minimum=None, min_gap=None):
         """
         Find blocks of adjacent points in a boolean array with the
@@ -1085,7 +1088,7 @@ class SmurfTuneMixin(SmurfBase):
         else:
             return start,end
 
-
+    @set_action()
     def pad_flags(self, f, before_pad=0, after_pad=0, min_gap=0, min_length=0):
         """
         Adds and combines flagging.
@@ -1126,6 +1129,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return padded
 
+    @set_action()
     def plot_find_peak(self, freq, resp, peak_ind, save_plot=True,
             save_name=None):
         """
@@ -1188,7 +1192,7 @@ class SmurfTuneMixin(SmurfBase):
 
             plt.close()
 
-
+    @set_action()
     def eta_fit(self, freq, resp, peak_freq, delta_freq,
                 make_plot=False, plot_chans=[], save_plot=True, band=None,
                 timestamp=None, res_num=None, use_slow_eta=False):
@@ -1315,7 +1319,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return eta, eta_scaled, eta_phase_deg, r2, eta_mag, latency, Q
 
-
+    @set_action()
     def plot_eta_fit(self, freq, resp, eta=None, eta_mag=None, peak_freq=None,
             eta_phase_deg=None, r2=None, save_plot=True, plotname_append='',
             show_plot=False, timestamp=None, res_num=None, band=None,
@@ -1480,7 +1484,7 @@ class SmurfTuneMixin(SmurfBase):
         if not show_plot:
             plt.close()
 
-
+    @set_action()
     def get_closest_subband(self, f, band, as_offset=True):
         """
         Gives the closest subband number for a given input frequency.
@@ -1507,7 +1511,7 @@ class SmurfTuneMixin(SmurfBase):
         idx = np.argmin([abs(x - f) for x in centers])
         return idx
 
-
+    @set_action()
     def check_freq_scale(self, f1, f2):
         """
         Makes sure that items are the same frequency scale (ie MHz, kHZ, etc.)
@@ -1529,7 +1533,7 @@ class SmurfTuneMixin(SmurfBase):
         else:
             return True
 
-
+    @set_action()
     def load_master_assignment(self, band, filename):
         """
         By default, pysmurf loads the most recent master assignment.
@@ -1550,7 +1554,7 @@ class SmurfTuneMixin(SmurfBase):
         self.log('New master assignment file:'+
                  ' {}'.format(self.channel_assignment_files['band_{}'.format(band)]))
 
-
+    @set_action()
     def get_master_assignment(self, band):
         """
         Returns the master assignment list.
@@ -1581,7 +1585,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return freqs, subbands, channels, groups
 
-
+    @set_action()
     def assign_channels(self, freq, band=None, bandcenter=None,
             channel_per_subband=4, as_offset=True, min_offset=0.1,
             new_master_assignment=False):
@@ -1688,7 +1692,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return subbands, channels, offsets
 
-
+    @set_action()
     def write_master_assignment(self, band, freqs, subbands, channels,
             bias_groups=None):
         '''
@@ -1721,10 +1725,11 @@ class SmurfTuneMixin(SmurfBase):
             f.write('%.4f,%i,%i,%i\n' % (freqs[i],subbands[i],channels[i],
                 bias_groups[i]))
         f.close()
+        self.pub.register_file(fn, 'master_assignment', format='txt')
 
         self.load_master_assignment(band, fn)
 
-
+    @set_action()
     def make_master_assignment_from_file(self, band, tuning_filename):
         """
         Makes a master assignment file
@@ -1754,7 +1759,7 @@ class SmurfTuneMixin(SmurfBase):
 
         self.write_master_assignment(band, freqs, subbands, channels)
 
-
+    @set_action()
     def get_group_list(self, band, group):
         """
         Returns a list of all the channels in a band and bias
@@ -1780,7 +1785,7 @@ class SmurfTuneMixin(SmurfBase):
                 chs_in_group.append(channels[i])
         return np.array(chs_in_group)
 
-
+    @set_action()
     def get_group_number(self, band, ch):
         """
         Gets the bias group number of a band, channel pair. The
@@ -1804,7 +1809,7 @@ class SmurfTuneMixin(SmurfBase):
                 return groups[i]
         return None
 
-
+    @set_action()
     def write_group_assignment(self, bias_group_dict):
         '''
         Combs master channel assignment and assigns group number to all channels
@@ -1845,7 +1850,7 @@ class SmurfTuneMixin(SmurfBase):
                                          channels_master,
                                          bias_groups=groups_master)
 
-
+    @set_action()
     def relock(self, band, res_num=None, drive=None, r2_max=.08,
             q_max=100000, q_min=0, check_vals=False, min_gap=None,
             write_log=False):
@@ -1946,6 +1951,7 @@ class SmurfTuneMixin(SmurfBase):
         self.log('Setting on {} channels on band {}'.format(counter, band),
             self.LOG_USER)
 
+    @set_action()
     def fast_relock(self, band):
         """
         """
@@ -2168,7 +2174,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return f_sweep + sbc[subband], resp, eta
 
-
+    @set_action()
     def eta_scan(self, band, subband, freq, drive, write_log=False,
                  sync_group=True):
         """
@@ -2207,6 +2213,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return rr, ii
 
+    @set_action()
     def flux_ramp_check(self, band, reset_rate_khz=None,
             fraction_full_scale=None, flux_ramp=True, save_plot=True,
             show_plot=False, setup_flux_ramp=True):
@@ -2329,7 +2336,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return d, df, sync
 
-
+    @set_action()
     def tracking_setup(self, band, channel=None, reset_rate_khz=None,
             write_log=False, make_plot=False, save_plot=True, show_plot=True,
             nsamp=2**19, lms_freq_hz=None, meas_lms_freq=False,
@@ -2638,7 +2645,7 @@ class SmurfTuneMixin(SmurfBase):
         if return_data:
             return f, df, sync
 
-
+    @set_action()
     def track_and_check(self, band, channel=None, reset_rate_khz=None,
             make_plot=False, save_plot=True, show_plot=True,
             lms_freq_hz=None, flux_ramp=True, fraction_full_scale=None,
@@ -2741,7 +2748,7 @@ class SmurfTuneMixin(SmurfBase):
             feedback_end_frac=feedback_end_frac,
             setup_flux_ramp=setup_flux_ramp)
 
-
+    @set_action()
     def eta_phase_check(self, band, rot_step_size=30, rot_max=360,
             reset_rate_khz=None, fraction_full_scale=None, flux_ramp=True):
         """
@@ -2786,7 +2793,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return ret
 
-
+    @set_action()
     def analyze_eta_phase_check(self, dat, channel):
         """
         """
@@ -2827,6 +2834,7 @@ class SmurfTuneMixin(SmurfBase):
     _cryo_card_flux_ramp_relay_bit = 16
     _cryo_card_relay_wait = 0.25 #sec
 
+    @set_action()
     def unset_fixed_flux_ramp_bias(self,acCouple=True):
         """
         Alias for setting ModeControl=0
@@ -2853,7 +2861,7 @@ class SmurfTuneMixin(SmurfBase):
                          self.LOG_USER)
                 time.sleep(self._cryo_card_relay_wait)
 
-
+    @set_action()
     def set_fixed_flux_ramp_bias(self,fractionFullScale,debug=True,
             do_config=True):
         """
@@ -2915,7 +2923,7 @@ class SmurfTuneMixin(SmurfBase):
                      self.LOG_USER)
         self.set_flux_ramp_dac(LTC1668RawDacData)
 
-
+    @set_action()
     def flux_ramp_setup(self, reset_rate_khz, fraction_full_scale, df_range=.1,
             band=2, write_log=False, new_epics_root=None):
         """
@@ -3053,7 +3061,7 @@ class SmurfTuneMixin(SmurfBase):
         return 1-2*(self.get_fast_slow_rst_value(new_epics_root=new_epics_root)/
                     2**self.num_flux_ramp_counter_bits)
 
-
+    @set_action()
     def check_lock(self, band, f_min=.015, f_max=.2, df_max=.03,
             make_plot=False, flux_ramp=True, fraction_full_scale=None,
             lms_freq_hz=None, reset_rate_khz=None, feedback_start_frac=None,
@@ -3161,7 +3169,7 @@ class SmurfTuneMixin(SmurfBase):
             'channels_after' : chan_after
         }
 
-
+    @set_action()
     def check_lock_flux_ramp_off(self, band,df_max=.03,
             make_plot=False, **kwargs):
         """
@@ -3170,7 +3178,7 @@ class SmurfTuneMixin(SmurfBase):
         self.check_lock(band, f_min=0., f_max=np.inf, df_max=df_max,
             make_plot=make_plot, flux_ramp=False, **kwargs)
 
-
+    @set_action()
     def find_freq(self, band, subband=np.arange(13,115), drive_power=None,
             n_read=2, make_plot=False, save_plot=True, plotname_append='',
             window=50, rolling_med=True, make_subband_plot=False,
@@ -3275,6 +3283,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return f, resp
 
+    @set_action()
     def plot_find_freq(self, f=None, resp=None, subband=None, filename=None,
             save_plot=True, save_name='amp_sweep.png', show_plot=False):
         '''
@@ -3332,7 +3341,7 @@ class SmurfTuneMixin(SmurfBase):
             else:
                 plt.close()
 
-
+    @set_action()
     def full_band_ampl_sweep(self, band, subband, drive, n_read, n_step=121):
         """sweep a full band in amplitude, for finding frequencies
 
@@ -3376,7 +3385,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return freq, resp
 
-
+    @set_action()
     def find_all_peak(self, freq, resp, subband=None, rolling_med=False,
             window=500, grad_cut=0.05, amp_cut=0.25, freq_min=-2.5E8,
             freq_max=2.5E8, make_plot=False, save_plot=True, plotname_append='',
@@ -3459,7 +3468,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return peaks
 
-
+    @set_action()
     def fast_eta_scan(self, band, subband, freq, n_read, drive,
             make_plot=False):
         """copy of fastEtaScan.m from Matlab. Sweeps quickly across a
@@ -3529,6 +3538,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return freq, response
 
+    @set_action()
     def setup_notches(self, band, resonance=None, drive=None,
                       sweep_width=.3, df_sweep=.002, min_offset=0.1,
                       delta_freq=None, new_master_assignment=False,
@@ -3653,7 +3663,7 @@ class SmurfTuneMixin(SmurfBase):
 
         self.relock(band)
 
-
+    @set_action()
     def save_tune(self, update_last_tune=True):
         """
         Saves the tuning information (self.freq_resp) to tuning directory
@@ -3668,7 +3678,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return savedir + ".npy"
 
-
+    @set_action()
     def load_tune(self, filename=None, override=True, last_tune=True, band=None):
         """
         Loads the tuning information (self.freq_resp) from tuning directory
@@ -3717,7 +3727,7 @@ class SmurfTuneMixin(SmurfBase):
             # doesn't know about the band arg.
             return fs
 
-
+    @set_action()
     def last_tune(self):
         """
         Returns the full path to the most recent tuning file.
@@ -3725,7 +3735,7 @@ class SmurfTuneMixin(SmurfBase):
         return np.sort(glob.glob(os.path.join(self.tune_dir,
                                               '*_tune.npy')))[-1]
 
-
+    @set_action()
     def estimate_lms_freq(self, band, reset_rate_khz,
                           fraction_full_scale=None,
                           new_epics_root=None, channel=None,
@@ -3779,7 +3789,7 @@ class SmurfTuneMixin(SmurfBase):
         self.set_feedback_enable(band, old_feedback)
         return reset_rate_khz * s * 1000  # convert to Hz
 
-
+    @set_action()
     def estimate_flux_ramp_amp(self, band, n_phi0, write_log=True,
                                reset_rate_khz=None,
                                new_epics_root=None, channel=None):
@@ -3838,7 +3848,7 @@ class SmurfTuneMixin(SmurfBase):
         else:
             return new_fraction_full_scale
 
-
+    @set_action()
     def flux_mod2(self, band, df, sync, min_scale=0, make_plot=False,
             channel=None, threshold=.5):
         """
@@ -3941,7 +3951,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return max_len/np.nanmedian(peaks)
 
-
+    @set_action()
     def make_sync_flag(self, sync):
         """
         Takes the sync from tracking setup and makes a flag for when
@@ -3963,7 +3973,7 @@ class SmurfTuneMixin(SmurfBase):
         n_proc=self.get_number_processed_channels()
         return s//n_proc
 
-
+    @set_action()
     def flux_mod(self, df, sync, threshold=.4, minscale=.02,
                  min_spectrum=.9, make_plot=False):
         """
@@ -4124,7 +4134,7 @@ class SmurfTuneMixin(SmurfBase):
         if return_screen:
             return self.config.config
 
-
+    @set_action()
     def fake_resonance_dict(self, freqs, save_sweeps=False):
         """
         Takes a list of resonance frequencies and fakes a resonance dictionary
@@ -4191,6 +4201,7 @@ class SmurfTuneMixin(SmurfBase):
 
         return freq_dict
 
+    @set_action()
     def freq_to_band(self, frequency, band_center_list):
         """
         Convert the frequency to which band we're in. This is almost certainly

--- a/python/pysmurf/client/util/pub.py
+++ b/python/pysmurf/client/util/pub.py
@@ -11,10 +11,50 @@ import os
 import sys
 import time
 import pysmurf
+from functools import wraps
 
 DEFAULT_ENV_ROOT = 'SMURFPUB_'
 DEFAULT_UDP_PORT = 8200
 UDP_MAX_BYTES = 64000
+
+def set_action(action=None):
+    """
+        Decorator to set the publisher action string and action timestamp. This 
+        provides a way to group all outputs/plots from a single function call 
+        together. This decorator is to handle nested function calls, so even
+        if the `tune` function calls `find_freq`, all output will be grouped
+        in a single directory `<action_ts>_tune.
+    """
+    def dec(func):
+        if action is None:
+            action = func.__name__
+
+        @wraps(func)
+        def wrapper(S, *args, **kwargs):
+            is_top = False
+            try:
+                if S.pub._action is None
+                    is_top = True
+                    S.pub._action = action
+                    S.pub._action_ts = S.get_timestamp()
+
+                    print("{}: Setting action to {}".format(func.__name__, action))
+                else:
+                    print("{}: Action already set to {}".format(func.__name__, action))
+
+                    
+                func(S, *args, **kwargs)
+
+            finally:
+                if is_top:
+                    S.pub._action = None
+                    S.pub._action_ts = None
+
+        return wrapper
+    return dec
+
+
+
 
 class Publisher:
     seq_no = 0

--- a/python/pysmurf/client/util/pub.py
+++ b/python/pysmurf/client/util/pub.py
@@ -17,20 +17,21 @@ DEFAULT_ENV_ROOT = 'SMURFPUB_'
 DEFAULT_UDP_PORT = 8200
 UDP_MAX_BYTES = 64000
 
+
 def set_action(action=None):
     """
-        Decorator to set the publisher action string and action timestamp. This 
-        provides a way to group all outputs/plots from a single function call 
+        Decorator to set the publisher action string and action timestamp. This
+        provides a way to group all outputs/plots from a single function call
         together. This decorator is to handle nested function calls, so even
         if the `tune` function calls `find_freq`, all output will be grouped
         in a single directory `<action_ts>_tune.
     """
     def dec(func):
-    
+
         @wraps(func)
         def wrapper(S, *args, pub_action=None, **kwargs):
             nonlocal action
-    
+
             is_top = False
             try:
                 if S.pub._action is None:
@@ -40,7 +41,7 @@ def set_action(action=None):
                         S.pub._action = pub_action
                     elif action:
                         S.pub._action = action
-                    else: 
+                    else:
                         S.pub._action = func.__name__
 
                     S.pub._action_ts = S.get_timestamp()

--- a/python/pysmurf/client/util/pub.py
+++ b/python/pysmurf/client/util/pub.py
@@ -24,7 +24,7 @@ def set_action(action=None):
         provides a way to group all outputs/plots from a single function call
         together. This decorator is to handle nested function calls, so even
         if the `tune` function calls `find_freq`, all output will be grouped
-        in a single directory `<action_ts>_tune.
+        in a single directory `<action_ts>_tune`.
     """
     def dec(func):
 
@@ -202,8 +202,6 @@ class Publisher:
         """
         if timestamp is None:
             timestamp = time.time()
-
-        print("Registering File {}".format(path))
 
         file_data = {
             'path': path,

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -25,10 +25,13 @@ from contextlib import contextmanager
 # for hardware logging
 import threading
 from pysmurf.client.util.SmurfFileReader import SmurfStreamReader
+from pysmurf.client.util.pub import set_action
+
 
 
 class SmurfUtilMixin(SmurfBase):
 
+    @set_action()
     def take_debug_data(self, band, channel=None, nsamp=2**19, filename=None,
             IQstream=1, single_channel_readout=1, debug=False, write_log=True):
         """ Takes raw debugging data
@@ -151,6 +154,7 @@ class SmurfUtilMixin(SmurfBase):
         subprocess.Popen([sys.executable,JesdWatchdog.__file__])
 
     # Shawn needs to make this better and add documentation.
+    @set_action()
     def estimate_phase_delay(self, band, n_samples=2**19, make_plot=True,
             show_plot=True, save_plot=True, save_data=True, n_scan=5,
             timestamp=None, uc_att=24, dc_att=0, freq_min=-2.5E8, freq_max=2.5E8):
@@ -498,7 +502,7 @@ class SmurfUtilMixin(SmurfBase):
 
         return header, data
 
-
+    @set_action()
     def decode_data(self, filename, swapFdF=False, recast=True, truncate=True):
         """ Take a dataset from take_debug_data and spit out results.
 
@@ -610,6 +614,7 @@ class SmurfUtilMixin(SmurfBase):
 
         return f, df, flux_ramp_strobe
 
+    @set_action()
     def decode_single_channel(self, filename, swapFdF=False):
         """
         decode take_debug_data file if in singlechannel mode
@@ -666,6 +671,7 @@ class SmurfUtilMixin(SmurfBase):
 
         return f, df, flux_ramp_strobe
 
+    @set_action(action=None)
     def take_stream_data(self, meas_time, downsample_factor=None,
                          write_log=True, update_payload_size=True,
                          reset_unwrapper=True, reset_filter=True,
@@ -781,6 +787,7 @@ class SmurfUtilMixin(SmurfBase):
             self.stream_data_off(write_log=write_log,
                                  register_file=register_file)
 
+    @set_action()
     def stream_data_on(self, write_config=False, data_filename=None,
                        downsample_factor=None, write_log=True,
                        update_payload_size=True, reset_filter=True,
@@ -921,12 +928,15 @@ class SmurfUtilMixin(SmurfBase):
                 freq_mask = self.make_freq_mask(output_mask)
                 np.savetxt(os.path.join(data_filename.replace('.dat', '_freq.txt')),
                            freq_mask, fmt='%4.4f')
+                self.pub.register_file(
+                    os.path.join(data_filename.replace('.dat', '_freq.txt')),
+                    'mask', format='txt')
 
             self.open_data_file(write_log=write_log)
 
             return data_filename
 
-
+    @set_action()
     def stream_data_off(self, write_log=True, register_file=False):
         """
         Turns off streaming data.
@@ -949,7 +959,7 @@ class SmurfUtilMixin(SmurfBase):
 
         self.set_stream_enable(0, write_log=write_log, wait_after=.15)
 
-
+    @set_action()
     def read_stream_data(self, datafile, channel=None,
                          n_samp=None, array_size=None,
                          return_header=False,
@@ -1133,7 +1143,7 @@ class SmurfUtilMixin(SmurfBase):
         else:
             return t, phase, mask
 
-
+    @set_action()
     def read_stream_data_gcp_save(self, datafile, channel=None,
             unwrap=True, downsample=1, n_samp=None):
         """
@@ -1257,7 +1267,7 @@ class SmurfUtilMixin(SmurfBase):
 
         return timestamp2, phase, mask
 
-
+    @set_action()
     def header_to_tes_bias(self, header, as_volt=True,
                            n_tes_bias=15):
         """
@@ -1321,7 +1331,7 @@ class SmurfUtilMixin(SmurfBase):
 
         return bias
 
-
+    @set_action()
     def make_mask_lookup(self, mask_file, mask_channel_offset=0,
             make_freq_mask=False):
         """ Makes an n_band x n_channel array where the elements correspond
@@ -1383,7 +1393,7 @@ class SmurfUtilMixin(SmurfBase):
 
         return ret
 
-
+    @set_action()
     def read_stream_data_daq(self, data_length, bay=0, hw_trigger=False,
             write_log=False):
         """
@@ -1428,7 +1438,7 @@ class SmurfUtilMixin(SmurfBase):
 
         return r0, r1
 
-
+    @set_action()
     def check_adc_saturation(self, band):
         """
         Reads data directly off the ADC.  Checks for input saturation.
@@ -1456,7 +1466,7 @@ class SmurfUtilMixin(SmurfBase):
             self.log(f'\033[92mADC{band} not saturated\033[00m') # color green
         return saturated
 
-
+    @set_action()
     def check_dac_saturation(self, band):
         """
         Reads data directly off the DAC.  Checks for input saturation.
@@ -1484,7 +1494,7 @@ class SmurfUtilMixin(SmurfBase):
             self.log(f'\033[92mDAC{band} not saturated\033[00m') # color green
         return saturated
 
-
+    @set_action()
     def read_adc_data(self, band, data_length=2**19,
                       hw_trigger=False, do_plot=False, save_data=True,
                       timestamp=None, show_plot=True, save_plot=True,
@@ -1586,6 +1596,7 @@ class SmurfUtilMixin(SmurfBase):
 
         return dat
 
+    @set_action()
     def read_dac_data(self, band, data_length=2**19,
                       hw_trigger=False, do_plot=False, save_data=True,
                       timestamp=None, show_plot=True, save_plot=True,
@@ -1686,7 +1697,7 @@ class SmurfUtilMixin(SmurfBase):
 
         return dat
 
-
+    @set_action()
     def setup_daq_mux(self, converter, converter_number, data_length,
                       band=0, debug=False, write_log=False):
         """
@@ -1731,7 +1742,7 @@ class SmurfUtilMixin(SmurfBase):
         # which f,df stream to route to MUX, maybe?
         self.set_debug_select(bay, band%4, write_log=True)
 
-
+    @set_action()
     def set_buffer_size(self, bay, size, debug=False,
                         write_log=False):
         """
@@ -1755,7 +1766,7 @@ class SmurfUtilMixin(SmurfBase):
             if debug:
                 self.log('DAQ number {}: start {} - end {}'.format(daq_num, s, e))
 
-
+    @set_action()
     def config_cryo_channel(self, band, channel, frequencyMHz, amplitude,
             feedback_enable, eta_phase, eta_mag):
         """
@@ -1816,7 +1827,7 @@ class SmurfUtilMixin(SmurfBase):
         self.set_eta_phase_degree_channel(band, channel, phase)
         self.set_eta_mag_scaled_channel(band, channel, eta_mag)
 
-
+    @set_action()
     def which_on(self, band):
         """
         Finds all detectors that are on.
@@ -1834,7 +1845,7 @@ class SmurfUtilMixin(SmurfBase):
         amps = self.get_amplitude_scale_array(band)
         return np.ravel(np.where(amps != 0))
 
-
+    @set_action()
     def toggle_feedback(self, band, **kwargs):
         """
         Toggles feedbackEnable (->0->1) and lmsEnables1-3 (->0->1) for
@@ -1886,6 +1897,7 @@ class SmurfUtilMixin(SmurfBase):
         self.log(logstr,
                  self.LOG_USER)
 
+    @set_action()
     def band_off(self, band, **kwargs):
         """
         Turns off all tones in a band
@@ -3309,7 +3321,7 @@ class SmurfUtilMixin(SmurfBase):
 
         return ret
 
-
+    @set_action()
     def make_gcp_mask(self, band=None, smurf_chans=None, gcp_chans=None,
                       read_gcp_mask=True, mask_channel_offset=0):
         """
@@ -3379,7 +3391,7 @@ class SmurfUtilMixin(SmurfBase):
         else:
             self.log('Warning: new mask has not been read in yet.')
 
-
+    @set_action()
     def bias_bump(self, bias_group, wait_time=.5, step_size=0.001,
                   duration=5.0, start_bias=None, make_plot=False,
                   skip_samp_start=10, high_current_mode=True,
@@ -4121,7 +4133,7 @@ class SmurfUtilMixin(SmurfBase):
         # Zero TES biases on this bias group
         self.set_tes_bias_bipolar(bias_group, 0)
 
-
+    @set_action()
     def get_sample_frequency(self):
         """ Gives the data rate.
 
@@ -4314,6 +4326,9 @@ class SmurfUtilMixin(SmurfBase):
                     savename = f'{timestamp}_identify_bg{bias_group:02}.png'
                     plt.savefig(os.path.join(self.plot_dir, savename),
                                 bbox_inches='tight')
+                    self.pub.register_file(
+                        os.path.join(self.plot_dir, savename),
+                        'identify_bg', plot=True)
                 if not show_plot:
                     plt.close(fig)
 

--- a/scratch/jack/pub_listener.py
+++ b/scratch/jack/pub_listener.py
@@ -1,0 +1,18 @@
+import socket
+import json
+
+UDP_IP = "localhost"
+UDP_PORT = 8200
+
+sock = socket.socket(socket.AF_INET,
+                     socket.SOCK_DGRAM)
+sock.bind((UDP_IP, UDP_PORT))
+
+last_seq = None
+types = []
+
+while True:
+    _data, addr = sock.recvfrom(64000) # buffer size is 1024 bytes
+    data = json.loads(_data)
+
+    print(data)


### PR DESCRIPTION
This PR is to solve the OCS problem for how we should be storing archived pysmurf data. From the workshop, we decided that a good system would be to group together all files for a given action. For instance, if you call S.find_freq, you might naturally want all outputs and plots to be grouped together under something like `smurf_dir/find_freq_1584335008/outputs` and `smurf_dir/find_freq_1584335008/plots`.

The way this worked before was that each `register_file` call was passed a "file type" such as "mask", which was used to group files. This didn't really work since functions like `find_freq` would call other functions, and so even though you only issued one command they would multiple groups.

The `set_action` decorator solves this by making the top-level function call set the action and action timestamp, which is then used in all nested function calls. When the top-level function returns, or if an error is thrown, the action and timestamp are set to None.  

You can set the action by decorating a smurf function with `@set_action('find_freq')`, or you can use `@set_action()` which will set the action string to be the function name. 

I added the set_action decorator to a bunch of functions (probably more than we actually need). I also added the script `scratch/jack/pub_listener.py` which will listen to the publisher and resolves #56 . 

This will probably replace the "file type" system, but I'm keeping it in temporarily for backwards compatibility.