### PR TITLE
Re-enable the "enable_em22xx" flag from the top script.

### DIFF
--- a/server_scripts/cmb_eth.py
+++ b/server_scripts/cmb_eth.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
                      pv_dump_file   = args['pv_dump_file'],
                      disable_bay0   = args['disable_bay0'],
                      disable_bay1   = args['disable_bay1'],
-                     enable_pwri2c  = False, #args['enable_em22xx'],
+                     enable_pwri2c  = args['enable_em22xx'],
                      configure      = args['configure'],
                      server_port    = args['server_port'],
                      VariableGroups = VariableGroups) as root:

--- a/server_scripts/cmb_pcie.py
+++ b/server_scripts/cmb_pcie.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
                       pv_dump_file   = args['pv_dump_file'],
                       disable_bay0   = args['disable_bay0'],
                       disable_bay1   = args['disable_bay1'],
-                      enable_pwri2c  = False, #args['enable_em22xx'],
+                      enable_pwri2c  = args['enable_em22xx'],
                       pcie_rssi_lane = args['pcie_rssi_lane'],
                       pcie_dev_rssi  = args['pcie_dev_rssi'],
                       pcie_dev_data  = args['pcie_dev_data'],


### PR DESCRIPTION
The bug in the `EM22xx` device was fixed (see [ESCRYODET-614](https://jira.slac.stanford.edu/browse/ESCRYODET-614)), so we can re-enable this flag.

The [current ZIP file](https://github.com/slaclab/cryo-det/releases/download/MicrowaveMuxBpEthGen2_v0.0.3/rogue_MicrowaveMuxBpEthGen2_v0.0.3.zip) doesn't include the fixes needed for this device to work, so it won't show in the rogue tree, but the system will run normally. The only difference is that there will be this warning message in the server's log:
```
TypeError calling FpgaTopLevel: __init__() got an unexpected keyword argument 'enablePwrI2C'
This FpgaTopLevel does not support the option 'enablePwrI2C'.
Please use a pyrogue zip file which is up to date.
Staring the server without using the 'enablePwrI2C' option.
```

After the `cryo-det` repository is updated to included the necessary bug fixes (see [ESCRYODET-542](https://jira.slac.stanford.edu/browse/ESCRYODET-542)), then the `EM22xx` will be automatically enabled in C03+ carriers. In that case the tree will look like this:
![Screen Shot 2020-03-17 at 1 46 53 PM](https://user-images.githubusercontent.com/3729513/76900602-e5cb3f00-6856-11ea-95bb-5aed0567ba61.png)

I also tested that the PV names currently by pysmurf.client to interface to this device are correct:
```
cryo@smurf-srv13:/$ caget -S smurf_server_s5:AMCc:FpgaTopLevel:AmcCarrierCore:EM22xx:IOUT smurf_server_s5:AMCc:FpgaTopLevel:AmcCarrierCore:EM22xx:TEMPERATURE[{1,2}]
smurf_server_s5:AMCc:FpgaTopLevel:AmcCarrierCore:EM22xx:IOUT 2.105
smurf_server_s5:AMCc:FpgaTopLevel:AmcCarrierCore:EM22xx:TEMPERATURE[1] 34.875
smurf_server_s5:AMCc:FpgaTopLevel:AmcCarrierCore:EM22xx:TEMPERATURE[2] 33.500
```