### PR TITLE
Setup Github workflow to auto label PR as `core` or `client`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+# Add label 'core' to any change to the core-related
+# parts of the code
+core:
+  - src/**/*                    # All C++ source file (currently contains only core code)
+  - include/**/*                # All C++ header files (currently contains only core code)
+  - python/pysmurf/*            # The files in python/pysmurf (not recursively), common to core and client
+  - python/pysmurf/core/**/*    # All python code under pysmurf/core
+  - docker/server/**/*          # The pysmurf server docker files
+  - server_scripts/**/*         # The server startup scripts
+  - tests/**/*                  # This currently contains tests only related to the core
+  - README.*.md                 # All the README.*.md files are related to the core functionality
+  - smurfConfig.cmake.in        # This file is related to the core code
+  - CMakeLists.txt              # This file is related to the core code
+
+# Add label 'client' to any change to the client-related
+# parts of the code
+client:
+  - python/pysmurf/*            # The files in python/pysmurf (not recursively), common to core and client
+  - python/pysmurf/client/**/*  # All the python code under pysmurf/client
+  - docker/client/**/*          # The pysmurf client docker files
+  - cfg_files/**/*              # All the configuration files
+  - scratch/**/*                # All the file in the scratch area
+  - docs/**/*                   # This contains documentation only for the client code

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,19 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler/blob/master/README.md
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR fixes issue #320 by setting the GitHub labeler workflow to automatically add the labels `core` or `client` depending on the section of the code the PR modifies, as defined in the `.github/labeler.yml` file

