### PR TITLE
Verify that all PRs are labeled with `bug`, `enhancement`, or `interface-change`

### DIFF
--- a/.github/workflows/verify-pr-labels.yml
+++ b/.github/workflows/verify-pr-labels.yml
@@ -1,0 +1,21 @@
+# This workflow will verify that all pull requests have at least
+# one of these labels: 'bug', 'enhancement', 'interface-change'
+# before they can be merged
+
+name: verify-pr-label-action
+
+on:
+  pull_request:
+   types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  verify_pr_labels:
+    runs-on: ubuntu-latest
+    name: Verify that the PR has a valid label
+    steps:
+    - name: Verify Pull Request Labels
+      uses: jesusvasquez333/verify-pr-label-action@v1.1.0
+      id: verify-pr-label
+      with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          valid-labels: 'bug, enhancement, interface-change'


### PR DESCRIPTION
This PR solved #321.

It adds the GitHub actions [verify-pull-request-labels](https://github.com/marketplace/actions/verify-pull-request-labels) to verify that all PRs have at least one of these labels before they can be merged: `bug`, `enhancement`, `interface-change`.

This action works around the issue I mentioned in #321 regarding checks trigger with different conditions, and instead works in the following way:
- If a PR does not have one of the valid labels, then the Github check will succeed, but it will create a pull request review, requesting for changes. This will prevent the PR to be merge until the review is addressed. 
- If a PR have at least one valid label, then the Github check will also succeed, and it will create a pull request review, approving it. This will clear the review requesting for changes from a previous failed check. 
- The action will be triggered when a pull request is open, updated, and when labels are added/removed. 

As the Github Check alway succeed, we will not have the problem I mentioned in #321. Instead, the PR will be block using normal pull request workflow.

An example scenario is:
- A PR is open, without one of the mandatory labels. The action runs and creates a PR review, requesting for changes. This will prevent the PR to be merged.
- One of the mandatory labels is added to the PR. The action will be triggered again, and will create a new PR review, approving it. This will dismiss the previous request for changes. 
- If the label is removed, it will trigger the action again, and step 1 will happen again.
- If the PR labeled correctly before opening the PR, then the first action will just crate a PR review approving it.

So, in order for this new feature to work, we will need to increase the number of `Required approving reviewers` from `1` to `2`: one review will always come from this action, and the other review will be the one needed from a real reviewer.

This PR itself will be an example of how this feature works. I'm opening the PR without any label, in order to let the action to crate the PR review, request changes. Then I will add a correct label to fix it. 