### PR TITLE
Fix `pysmurf-client` docker image, by adding the cryo user's home directory

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-base:R1.0.0
+FROM tidair/smurf-base:R1.1.1
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.6.1
+FROM tidair/smurf-rogue:R2.6.2
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src


### PR DESCRIPTION
This PR resolves #324.

The base docker image `smurf-base` didn't contained the home directory for the cryo user. So, when the container was  running the directory `/home/cryo` didn't exit. It seems that ipython write access to the home directory for its tab complete feature to work. That was fix in this [PR](https://github.com/slaclab/smurf-base-docker/pull/2), which is available in version [tidair/smurf-base:R1.1.1](https://github.com/slaclab/smurf-base-docker/releases/tag/R1.1.1). 

This was affecting only the client docker image. However, I updated its base docker image as well to include that fix. It is available in the version [tidair/smurf-rogue:R2.6.2](https://github.com/slaclab/smurf-rogue-docker/releases/tag/R2.6.2).

In this PR I update the two base docker images to these new versions.

Jira ticket: https://jira.slac.stanford.edu/browse/ESCRYODET-630