### PR TITLE
Fixes location of version_file in pysmurf package setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [versioneer]
 VCS = git
 style = pep440
-versionfile_source = python/pysmurf/_version.py
-versionfile_build = python/pysmurf/_version.py
+versionfile_source = pysmurf/_version.py
+versionfile_build = pysmurf/_version.py
 tag_prefix = v
 parentdir_prefix = pysmurf-


### PR DESCRIPTION
PR https://github.com/slaclab/pysmurf/pull/342 didn't quite fix issue https://github.com/slaclab/pysmurf/issues/341.  This PR finishes addressing issue https://github.com/slaclab/pysmurf/issues/341 ; the location of _version.py was not correctly specified in setup.cfg for the new rogue4 code directory structure.