### PR TITLE
Fixes readthedocs auto builds

### DIFF
--- a/docs/base.rst
+++ b/docs/base.rst
@@ -5,25 +5,25 @@ base module
 
 base_class
 ----------
-.. automodule:: pysmurf.base.base_class
+.. automodule:: pysmurf.client.base.base_class
     :members:
 
 logger
 ------
-.. automodule:: pysmurf.base.logger
+.. automodule:: pysmurf.client.base.logger
     :members:
 
 schema
 ------
-.. automodule:: pysmurf.base.schema
+.. automodule:: pysmurf.client.base.schema
     :members:
 
 smurf_config
 ------------
-.. automodule:: pysmurf.base.smurf_config
+.. automodule:: pysmurf.client.base.smurf_config
     :members:
 
 smurf_control
 -------------
-.. automodule:: pysmurf.base.smurf_control
+.. automodule:: pysmurf.client.base.smurf_control
     :members:

--- a/docs/command.rst
+++ b/docs/command.rst
@@ -5,25 +5,25 @@ command module
 
 cryo_card
 ---------
-.. automodule:: pysmurf.command.cryo_card
+.. automodule:: pysmurf.client.command.cryo_card
     :members:
 
 smurf_atca_monitor
 ------------------
-.. automodule:: pysmurf.command.smurf_atca_monitor
+.. automodule:: pysmurf.client.command.smurf_atca_monitor
     :members:
 
 smurf_cmd
 ---------
-.. automodule:: pysmurf.command.smurf_cmd
+.. automodule:: pysmurf.client.command.smurf_cmd
     :members:
 
 smurf_command
 -------------
-.. automodule:: pysmurf.command.smurf_command
+.. automodule:: pysmurf.client.command.smurf_command
     :members:
 
 sync_group
 ----------
-.. automodule:: pysmurf.command.sync_group
+.. automodule:: pysmurf.client.command.sync_group
     :members:

--- a/docs/debug.rst
+++ b/docs/debug.rst
@@ -5,10 +5,10 @@ debug module
 
 smurf_iv
 ---------
-.. automodule:: pysmurf.debug.smurf_iv
+.. automodule:: pysmurf.client.debug.smurf_iv
     :members:
 
 smurf_noise
 -----------
-.. automodule:: pysmurf.debug.smurf_noise
+.. automodule:: pysmurf.client.debug.smurf_noise
     :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,8 @@
 Welcome to pysmurf's documentation!
 ===================================
 
-Insert description of pysmurf here.
+The python control software for SMuRF. Includes scripts to do low
+level commands as well as higher level analysis.
 
 API
 ---

--- a/docs/tune.rst
+++ b/docs/tune.rst
@@ -5,5 +5,5 @@ tune module
 
 smurf_tune
 ----------
-.. automodule:: pysmurf.tune.smurf_tune
+.. automodule:: pysmurf.client.tune.smurf_tune
     :members:

--- a/docs/util.rst
+++ b/docs/util.rst
@@ -5,15 +5,15 @@ util module
 
 pub
 ---
-.. autoclass:: pysmurf.util.pub.Publisher
+.. autoclass:: pysmurf.client.util.pub.Publisher
     :members:
 
 smurf_util
 ----------
-.. automodule:: pysmurf.util.smurf_util
+.. automodule:: pysmurf.client.util.smurf_util
     :members:
 
 tools
 -----
-.. automodule:: pysmurf.util.tools
+.. automodule:: pysmurf.client.util.tools
     :members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 scipy
 pyepics
 matplotlib
+pyyaml


### PR DESCRIPTION
Adjusted paths in the docs/*.rst files to reflect change in pysmurf code directory structure in rogue 4.  Added pyyaml module to the required dependencies (imported in utils).  Autogenerated documentation can be accessed here again now - https://pysmurf.readthedocs.io/en/master/.  Fixes #349 