### PR TITLE
Fixes the noise_vs_tone function. The plotting routine had a bug in it which would cause it to crash.

### DIFF
--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -1484,10 +1484,13 @@ class SmurfNoiseMixin(SmurfBase):
                     fs=fs, detrend=detrend)
                 Pxx = np.ravel(np.sqrt(Pxx))  # pA
 
-                path = os.path.join(psd_dir,
-                                    basename + '_psd_ch{:03}.txt'.format(ch))
+                path = os.path.join(psd_dir, basename + f'_psd_ch{ch:03}.txt')
                 np.savetxt(path, np.vstack((f, Pxx)))
                 self.pub.register_file(path, 'psd', format='txt')
+
+                data_path = os.path.join(psd_dir, basename +
+                    f'_data_ch{ch:03}.txt')
+                np.savetxt(data_path, phase[ch_idx])
 
             # Explicitly remove objects from memory
             del timestamp
@@ -1527,7 +1530,7 @@ class SmurfNoiseMixin(SmurfBase):
                     self.log(f'Smoothing PSDs for plotting with window of length {window_len}')
                     s = np.r_[Pxx[window_len-1:0:-1],Pxx,Pxx[-2:-window_len-1:-1]]
                     w = np.hanning(window_len)
-                    Pxx_smooth_ext = np.convolve(w/w.sum(),s,mode='valid')
+                    Pxx_smooth_ext = np.convolve(w/w.sum(), s, mode='valid')
                     ndx_add = window_len % 2
                     Pxx_smooth = Pxx_smooth_ext[(window_len//2)-1+ndx_add:-(window_len//2)]
                 else:
@@ -1540,8 +1543,8 @@ class SmurfNoiseMixin(SmurfBase):
                 ax0.set_ylim(psd_ylim)
 
                 # fit to noise model; catch error if fit is bad
-                popt,pcov,f_fit,Pxx_fit = self.analyze_psd(f,Pxx)
-                wl,n,f_knee = popt
+                popt, pcov, f_fit, Pxx_fit = self.analyze_psd(f,Pxx)
+                wl, n, f_knee = popt
                 self.log('ch. {}, tone power = {}'.format(ch,b) +
                          ', white-noise level = {:.2f}'.format(wl) +
                          ' pA/rtHz, n = {:.2f}'.format(n) +
@@ -1561,14 +1564,16 @@ class SmurfNoiseMixin(SmurfBase):
                 ax0.plot(f_fit, Pxx_fit, color=color, linestyle='--')
                 ax0.plot(f, wl + np.zeros(len(f)), color=color,
                         linestyle=':')
-                ax0.plot(f_knee,2.*wl,marker = 'o',linestyle = 'none',
+                ax0.plot(f_knee,2.*wl,marker = 'o', linestyle='none',
                         color=color)
 
-                ax1.plot(b,wl,color=color,marker='s',linestyle='none')
+                ax1.plot(b, wl, color=color, marker='s', linestyle='none')
 
                 if make_timestream_plot:
                     ax_ts = fig.add_subplot(gs[3+i, :])
-                    ax_ts.plot(phase[ch_idx], color=color)
+                    phase = np.loadtxt(os.path.join(psd_dir,
+                        basename + f'_data_ch{ch:03}.txt'))
+                    ax_ts.plot(phase, color=color)
 
             ax0.set_xlabel(r'Freq [Hz]')
             ax0.set_ylabel(r'PSD [$\mathrm{pA}/\sqrt{\mathrm{Hz}}$]')

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -330,7 +330,8 @@ class SmurfNoiseMixin(SmurfBase):
     def noise_vs_tone(self, band, tones=None, meas_time=30,
                       analyze=False, bias_group=None, lms_freq_hz=None,
                       fraction_full_scale=.72, meas_flux_ramp_amp=False,
-                      n_phi0=4, make_timestream_plot=True):
+                      n_phi0=4, make_timestream_plot=True,
+                      new_master_assignment=True):
         """ Takes timestream noise at various tone powers. Operates on one band
         at a time because it needs to retune between taking another timestream
         at a different tone power.
@@ -358,6 +359,10 @@ class SmurfNoiseMixin(SmurfBase):
             The number of phi0 to use if measuring flux ramp. Default 4.
         make_timestream_plot : bool
             Whether to make the timestream plot. Default True.
+        new_master_assignment : bool
+            Whether to make a new master channel assignemnt. This will only
+            make one for the first tone. It needs to keep the channel
+            assignment the same after that for the analysis.
         """
         timestamp = self.get_timestamp()
 
@@ -370,7 +375,11 @@ class SmurfNoiseMixin(SmurfBase):
             self.log('Measuring for tone power {}'.format(t))
 
             # Tune the band with the new drive power
-            self.tune_band_serial(band, drive=t)
+            self.tune_band_serial(band, drive=t,
+                new_master_assignment=new_master_assignment)
+
+            # all further tunings do not make new assignemnt
+            new_master_assignment = False
 
             # Start tracking
             self.tracking_setup(band, fraction_full_scale=fraction_full_scale,

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -331,7 +331,8 @@ class SmurfNoiseMixin(SmurfBase):
                       analyze=False, bias_group=None, lms_freq_hz=None,
                       fraction_full_scale=.72, meas_flux_ramp_amp=False,
                       n_phi0=4, make_timestream_plot=True,
-                      new_master_assignment=True):
+                      new_master_assignment=True, from_old_tune=False,
+                      old_tune=None):
         """ Takes timestream noise at various tone powers. Operates on one band
         at a time because it needs to retune between taking another timestream
         at a different tone power.
@@ -363,6 +364,10 @@ class SmurfNoiseMixin(SmurfBase):
             Whether to make a new master channel assignemnt. This will only
             make one for the first tone. It needs to keep the channel
             assignment the same after that for the analysis.
+        from_old_tune : bool
+            Whether to tune from an old tune
+        old_tune : str
+            The tune file if using old tune.
         """
         timestamp = self.get_timestamp()
 

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -387,7 +387,7 @@ class SmurfNoiseMixin(SmurfBase):
                 n_phi0=n_phi0)
 
             # Check
-            self.check_lock(band, lms_freq_hz=lms_freq_hz)
+            self.check_lock(band)
 
             time.sleep(2)
 

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -381,7 +381,8 @@ class SmurfNoiseMixin(SmurfBase):
 
             # Tune the band with the new drive power
             self.tune_band_serial(band, drive=t,
-                new_master_assignment=new_master_assignment)
+                new_master_assignment=new_master_assignment,
+                from_old_tune=from_old_tune, old_tune=old_tune)
 
             # all further tunings do not make new assignemnt
             new_master_assignment = False

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -368,7 +368,7 @@ class SmurfNoiseMixin(SmurfBase):
             # Start tracking
             self.tracking_setup(band, fraction_full_scale=fraction_full_scale,
                 lms_freq_hz=lms_freq_hz, meas_flux_ramp_amp=meas_flux_ramp_amp,
-                n_phi0=nphi0)
+                n_phi0=n_phi0)
 
             # Check
             self.check_lock(band, lms_freq_hz=lms_freq_hz)

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -231,30 +231,33 @@ class SmurfTuneMixin(SmurfBase):
             make_subband_plot=False, subband=None, n_scan=5,
             subband_plot_with_slow=False, window=5000, rolling_med=True,
             grad_cut=.03, freq_min=-2.5E8, freq_max=2.5E8, amp_cut=.25,
-            del_f=.005, drive=None, new_master_assignment=False, from_old_tune=False,
-            old_tune=None, pad=50, min_gap=50):
-        """
-        Tunes band using serial_gradient_descent and then serial_eta_scan.
+            del_f=.005, drive=None, new_master_assignment=False,
+            from_old_tune=False, old_tune=None, pad=50, min_gap=50):
+        """ Tunes band using serial_gradient_descent and then serial_eta_scan.
         This requires an initial guess, which this function gets by either
         loading an old tune or by using the full_band_resp.  This takes about 3
         minutes per band if there are about 150 resonators.
         This saves the results to the freq_resp dictionary.
-        Args:
-        -----
-        band (int): The band the tune
-        Opt Args:
-        ---------
-        from_old_tune (bool): Whether to use an old tuning file. This
-            will load a tuning file and use its peak frequencies as
-            a starting point for seria_gradient_descent.
-        old_tune (str): The full path to the tuning file.
-        new_master_assignment (bool): Whether to overwrite the previous
-            master_assignment list. Default is False.
-        make_plot (bool): Whether to make plots. Default is False.
-        save_plot (bool): If make_make plot is True, whether to save
-            the plots. Default is True.
-        show_plot (bool): If make_plot is True, whether to display
-            the plots to screen.
+
+        Parameters:
+        -----------
+        band : int
+            The band the tune
+        from_old_tune : bool
+            Whether to use an old tuning file. This will load a tuning file and
+            use its peak frequencies as a starting point for
+            serial_gradient_descent.
+        old_tune : str
+            The full path to the tuning file.
+        new_master_assignment : bool
+            Whether to overwrite the previous master_assignment list. Default
+            False.
+        make_plot : bool
+            Whether to make plots. Default is False.
+        save_plot : bool
+            If make_make plot is True, whether to save the plots. Default is True.
+        show_plot : bool
+            If make_plot is True, whether to display the plots to screen.
         """
         timestamp = self.get_timestamp()
         center_freq = self.get_band_center_mhz(band)
@@ -361,8 +364,8 @@ class SmurfTuneMixin(SmurfBase):
         eta = eta_mag * np.cos(np.deg2rad(eta_phase)) + \
             1.j * np.sin(np.deg2rad(eta_phase))
 
+        # Get the result twice. Pass it to the resonance dict
         chs = self.get_eta_scan_result_channel(band)
-
         chs = self.get_eta_scan_result_channel(band)
 
         for i, ch in enumerate(chs):

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -349,7 +349,6 @@ class SmurfTuneMixin(SmurfBase):
         # Find the resonator minima
         self.log('Finding resonator minima...')
         self.run_serial_gradient_descent(band, timeout=1200)
-        #self.run_serial_min_search(band)
 
         # Calculate the eta params
         self.log('Calculating eta parameters...')

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -3897,6 +3897,19 @@ class SmurfUtilMixin(SmurfBase):
         self.set_tes_bias_bipolar(bias_group, 0)
 
 
+    def get_sample_frequency(self):
+        """ Gives the data rate.
+
+        Returns:
+        --------
+        sample_frequency : float
+            The data sample rate in Hz.
+        """
+        flux_ramp_freq = self.get_flux_ramp_freq() * 1.0E3
+        downsample_factor = self.get_downsample_factor()
+
+        return flux_ramp_freq / downsample_factor
+
     def identify_bias_groups(self, probe_freq=2.5, probe_time=3,
                              probe_amp=.1,
                              bias_groups=None, make_plot=False,

--- a/scratch/eyy/test_scripts/profile_band.py
+++ b/scratch/eyy/test_scripts/profile_band.py
@@ -196,7 +196,10 @@ if __name__ == "__main__":
     parser.add_argument("--no-band-off", default=False,
                         action="store_true",
                         help="Whether to skip turning off bands")
-
+    parser.add_argument("--threading-test", default=False,
+                       action="store_true",
+                       help="Whether to run threading test")
+    
     args = parser.parse_args()
 
     #######################
@@ -359,3 +362,9 @@ if __name__ == "__main__":
 
     # Make webpage
     make_html(os.path.split(S.output_dir)[0])
+
+    if args.threading_test:
+        import threading
+        for t in threading.enumerate():
+            print(t)
+            S.log(t)


### PR DESCRIPTION
This PR resolves #353 

This PR also:
- updated the doc strings for `tune_band_serial` and `noise_vs_tone` to be consistent with numpy conventions.
- Added convenience function for sample_freq
- Adds testing threading to `profile_band.py`