### PR TITLE
Add Ed and Shawn as code owner of GitHub files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 *                       @swh76 @eyyoung24
 
 # @jesusvasquez333 and @slacrherbst owns the code related
-# to the core, dockers, startup scripts, and github and travis
-# automation scrips. Only them will be requested for review.
+# to the core, dockers, startup scripts, and travis script.
+# Only them will be requested for review.
 /src/                   @jesusvasquez333 @slacrherbst
 /include/               @jesusvasquez333 @slacrherbst
 /python/pysmurf/core/   @jesusvasquez333 @slacrherbst
@@ -14,5 +14,9 @@
 /tests/                 @jesusvasquez333 @slacrherbst
 /.travis.yml            @jesusvasquez333 @slacrherbst
 /releaseGen.py          @jesusvasquez333 @slacrherbst
-/.github/               @jesusvasquez333 @slacrherbst
 /README.*.md            @jesusvasquez333 @slacrherbst
+
+# @swh76, @eyyoung24, @jesusvasquez333 and @slacrherbst owns
+# the github related scripts. 
+# All of them will be requested for review.
+/.github/               @swh76 @eyyoung24 @jesusvasquez333 @slacrherbst


### PR DESCRIPTION
This PR resolves #359 

With this PR Ed, Shawn, Ryan and I will all be code owner of the GitHub related scripts, which defined setting of the repository like for example issues and PR templates. 

I think it make sense for all of us to be owner and be able to approve PR for this section.