### PR TITLE
Fixes the `noise_vs_tone` analysis script - wasn't handling channel assignment properly

### DIFF
--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -1603,15 +1603,15 @@ class SmurfNoiseMixin(SmurfBase):
                     # smooth Pxx for plotting
                     if smooth_len >= 3:
                         window_len = smooth_len
-                        self.log(f'Smoothing PSDs for plotting with window of '+
-                            f'length {window_len}')
+                        # self.log(f'Smoothing PSDs for plotting with window of '+
+                        #     f'length {window_len}')
                         s = np.r_[Pxx[window_len-1:0:-1],Pxx,Pxx[-2:-window_len-1:-1]]
                         w = np.hanning(window_len)
                         Pxx_smooth_ext = np.convolve(w/w.sum(), s, mode='valid')
                         ndx_add = window_len % 2
                         Pxx_smooth = Pxx_smooth_ext[(window_len//2)-1+ndx_add:-(window_len//2)]
                     else:
-                        self.log('No smoothing of PSDs for plotting.')
+                        # self.log('No smoothing of PSDs for plotting.')
                         Pxx_smooth = Pxx
 
                     color = cm(float(i)/len(tone))
@@ -1622,18 +1622,18 @@ class SmurfNoiseMixin(SmurfBase):
                     # fit to noise model; catch error if fit is bad
                     popt, pcov, f_fit, Pxx_fit = self.analyze_psd(f,Pxx)
                     wl, n, f_knee = popt
-                    self.log(f'ch. {ch}, tone power = {b}' +
-                             f', white-noise level = {wl:.2f}' +
-                             f' pA/rtHz, n = {n:.2f}' +
-                             f', f_knee = {f_knee:.2f} Hz')
+                    # self.log(f'ch. {ch}, tone power = {b}' +
+                    #          f', white-noise level = {wl:.2f}' +
+                    #          f' pA/rtHz, n = {n:.2f}' +
+                    #          f', f_knee = {f_knee:.2f} Hz')
 
                     # get noise estimate to summarize PSD for given bias
                     if freq_range_summary is not None:
                         freq_min,freq_max = freq_range_summary
                         noise_est = np.mean(Pxx[np.logical_and(f>=freq_min,f<=freq_max)])
-                        self.log(f'ch. {ch}, tone = {b}' +
-                                 f', mean noise between {freq_min:.3e} and ' +
-                                 f'{freq_max:.3e} Hz = {noise_est:.2f} pA/rtHz')
+                        # self.log(f'ch. {ch}, tone = {b}' +
+                        #          f', mean noise between {freq_min:.3e} and ' +
+                        #          f'{freq_max:.3e} Hz = {noise_est:.2f} pA/rtHz')
                     else:
                         noise_est = wl
                     noise_est_list.append(noise_est)
@@ -1708,6 +1708,7 @@ class SmurfNoiseMixin(SmurfBase):
                 else:
                     plot_name = f'{self.get_timestamp()}_' + plot_name
                 plot_fn = os.path.join(self.plot_dir, plot_name)
+
                 self.log(f'Saving plot to {plot_fn}')
                 plt.savefig(plot_fn,
                     bbox_inches='tight')

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -1520,6 +1520,7 @@ class SmurfNoiseMixin(SmurfBase):
             channel = np.arange(n_channel)
         elif band is not None and channel is None:
             channel = self.which_on(band)
+        channel = channel.astype(int)
 
         if fs is None:
             fs = self.fs

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -1671,13 +1671,15 @@ class SmurfNoiseMixin(SmurfBase):
             ax1.set_ylabel(f'{ylabel_summary} ' +
                 r'[$\mathrm{pA}/\sqrt{\mathrm{Hz}}$]')
 
-            bottom = max(0.95*min(noise_est_list),0.)
-            top_desired = 1.05*max(noise_est_list)
-            if psd_ylim is not None:
-                top = min(psd_ylim[1],top_desired)
-            else:
-                top = top_desired
-            ax1.set_ylim(bottom=bottom, top=top)
+            # Set the ylim based on the white noise values found
+            if len(noise_est_list) > 0:
+                bottom = max(0.95*min(noise_est_list), 0.)
+                top_desired = 1.05*max(noise_est_list)
+                if psd_ylim is not None:
+                    top = min(psd_ylim[1], top_desired)
+                else:
+                    top = top_desired
+                ax1.set_ylim(bottom=bottom, top=top)
             ax1.grid()
 
             if type(bias_group) is not int: # ie if there were more than one

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -1651,7 +1651,7 @@ class SmurfNoiseMixin(SmurfBase):
                             basename + f'_data_ch{ch:03}.txt'))
                         phase -= np.mean(phase)
                         ax_ts.plot(phase, color=color)
-                    except FileNotFoundError:
+                    except OSError:
                         self.log(f'No data found for {d} for channel {ch}')
 
             ax0.set_xlabel(r'Freq [Hz]')

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -1713,9 +1713,6 @@ class SmurfNoiseMixin(SmurfBase):
                     bbox_inches='tight')
                 plt.close()
 
-            del f
-            del Pxx
-
 
 
     def noise_svd(self, d, mask, mean_subtract=True):

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -1651,6 +1651,8 @@ class SmurfNoiseMixin(SmurfBase):
                             basename + f'_data_ch{ch:03}.txt'))
                         phase -= np.mean(phase)
                         ax_ts.plot(phase, color=color)
+                    except FileNotFoundError:
+                        self.log(f'No data found for {d} for channel {ch}')
 
             ax0.set_xlabel(r'Freq [Hz]')
             ax0.set_ylabel(r'PSD [$\mathrm{pA}/\sqrt{\mathrm{Hz}}$]')


### PR DESCRIPTION
## Issue
This PR resolves https://github.com/slaclab/pysmurf/issues/366 

## Description

This fixes the plotting routine in `noise_vs_tone`. It properly selects the correct channel from the mask file. It doesn't plot channels that are not taken.

## Does this PR break any interface?
- [ ] Yes
- [x] No

