### PR TITLE
Adding overbias_wait to noise_vs_bias

### DIFF
--- a/cfg_files/stanford/experiment_fp30_cc02-03_lbOnlyBay0.cfg
+++ b/cfg_files/stanford/experiment_fp30_cc02-03_lbOnlyBay0.cfg
@@ -77,10 +77,10 @@
 },
 
 "amplifier": {
-	     "hemt_Vg" : 0.54,
+	     "hemt_Vg" : 0.61,
 	     "bit_to_V_hemt" : 3.8592e-06,
 	     "hemt_Id_offset" : 0.941,
-	     "LNA_Vg" : -0.7575,
+	     "LNA_Vg" : -0.74,
 	     "50k_Id_offset" : 0.4963,	     
 	     # 32 if using a C02 cryostat card.  Some C01s were
 	     # kludged to provide a 50k gate voltage for ASU 50K LNAs

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -434,7 +434,7 @@ class SmurfNoiseMixin(SmurfBase):
                       channel=None, nperseg=2**13, detrend='constant',
                       fs=None, show_plot=False, cool_wait=30.,
                       psd_ylim=(10.,1000.), make_timestream_plot=False,
-                      only_overbias_once=False):
+                      only_overbias_once=False, overbias_wait=1):
         """
         This ramps the TES voltage from bias_high to bias_low and takes noise
         measurements. You can make it analyze the data and make plots with the
@@ -478,7 +478,8 @@ class SmurfNoiseMixin(SmurfBase):
                       overbias_voltage=overbias_voltage,
                       cool_wait=cool_wait,high_current_mode=high_current_mode,
                       make_timestream_plot=make_timestream_plot,
-                      only_overbias_once=only_overbias_once)
+                      only_overbias_once=only_overbias_once,
+                      overbias_wait=overbias_wait)
 
     def noise_vs_amplitude(self, band, amplitude_high=11, amplitude_low=9, step_size=1,
                            amplitudes=None,
@@ -548,9 +549,11 @@ class SmurfNoiseMixin(SmurfBase):
             assert ('bias_group' in kwargs.keys()),'Must specify bias_group.'
             # defaults
             if 'high_current_mode' not in kwargs.keys():
-                kwargs['high_current_mode']=False
+                kwargs['high_current_mode'] = False
             if 'cool_wait' not in kwargs.keys():
-                kwargs['cool_wait']=30.
+                kwargs['cool_wait'] = 30.
+            if 'overbias_wait' not in kwargs.keys():
+                kwargs['overbias_wait'] = 1
 
         if var in amplitudealiases:
             # no parameters (yet) but need to null this until we rework the analysis
@@ -581,13 +584,15 @@ class SmurfNoiseMixin(SmurfBase):
                                  high_current_mode=kwargs['high_current_mode'],
                                  cool_wait=kwargs['cool_wait'],
                                  overbias_voltage=kwargs['overbias_voltage'],
-                                 actually_overbias=actually_overbias)
+                                 actually_overbias=actually_overbias,
+                                 overbias_wait=kwargs['overbias_wait'])
                 else:
                     self.overbias_tes_all(kwargs['bias_group'], tes_bias=v,
                                  high_current_mode=kwargs['high_current_mode'],
                                  cool_wait=kwargs['cool_wait'],
                                  overbias_voltage=kwargs['overbias_voltage'],
-                                 actually_overbias=actually_overbias)
+                                 actually_overbias=actually_overbias,
+                                 overbias_wait=kwargs['overbias_wait'])
                 if only_overbias_once:
                     actually_overbias=False
 

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2662,7 +2662,7 @@ class SmurfUtilMixin(SmurfBase):
         return fiftyK_amp_Id_mA
 
 
-    def overbias_tes(self, bias_group, overbias_voltage=19.9, overbias_wait=5.,
+    def overbias_tes(self, bias_group, overbias_voltage=19.9, overbias_wait=1.,
                      tes_bias=19.9, cool_wait=20., high_current_mode=False,
                      flip_polarity=False, actually_overbias=True):
         """
@@ -2716,7 +2716,7 @@ class SmurfUtilMixin(SmurfBase):
 
         self.set_tes_bias_bipolar(bias_group, tes_bias,
             flip_polarity=flip_polarity)
-        self.log('Waiting %.2f seconds to cool' % (cool_wait), self.LOG_USER)
+        self.log(f'Waiting {coolwait:1.1f} seconds to cool', self.LOG_USER)
         time.sleep(cool_wait)
 
         self.log('Done waiting.', self.LOG_USER)

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2716,7 +2716,7 @@ class SmurfUtilMixin(SmurfBase):
 
         self.set_tes_bias_bipolar(bias_group, tes_bias,
             flip_polarity=flip_polarity)
-        self.log(f'Waiting {coolwait:1.1f} seconds to cool', self.LOG_USER)
+        self.log(f'Waiting {cool_wait:1.1f} seconds to cool', self.LOG_USER)
         time.sleep(cool_wait)
 
         self.log('Done waiting.', self.LOG_USER)


### PR DESCRIPTION
## Issue
This PR resolves #371 
This adds the optional variable `overbias_wait` to `noise_vs_bias`.

## Does this PR break any interface?
- [ ] Yes
- [x] No
