### PR TITLE
Add travis job to test documentation build for errors and warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,17 @@ jobs:
         - flake8 --count python/
 
     # Test stages
+    ## Documentation automatic build tests
+    - stage: tests
+      name: "Documentation Build Tests"
+      install:
+        # Install pysmurf
+        - pip3 install .
+      script:
+        # Try to build the documentation
+        - cd docs/
+        - make html
+
     ## Server tests
     - stage: tests
       name: "Server Tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ jobs:
       install:
         # Install pysmurf
         - pip3 install .
+        # Install sphinx
+        - pip3 install sphinx
       script:
         # Try to build the documentation
         - cd docs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
       script:
         # Try to build the documentation
         - cd docs/
-        - make html
+        - make html SPHINXOPTS="-W --keep-going -n"
 
     ## Server tests
     - stage: tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ jobs:
     - stage: tests
       name: "Documentation Build Tests"
       install:
+        # Install requirements
+        - pip3 install -r requirements.txt
         # Install pysmurf
         - pip3 install .
         # Install sphinx


### PR DESCRIPTION
## Issue
This PR resolves #387 and also resolves #382 

## Description
This PR adds a travis job under the test stage to run the sphinx documentation build and fail on errors and warnings.
## Does this PR break any interface?
- [ ] Yes
- [X] No