### PR TITLE
Resolves all sphinx_build errors and warnings, upgrades schema to 0.7.1, adds new SmurfConfigPropertiesMixin, expands documentation to include core code and user guide outline.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -271,6 +271,6 @@ def linkcode_resolve(domain, info):
         linespec = ""
 
     fn = relpath(fn, start=dirname(pysmurf_file))
-
-    return "https://github.com/slaclab/pysmurf/blob/master/numpy/%s%s" % (
+    print('here')
+    return "https://github.com/slaclab/pysmurf/blob/master/python/pysmurf/%s%s" % (
         fn, linespec)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -274,6 +274,5 @@ def linkcode_resolve(domain, info):
         linespec = ""
 
     fn = relpath(fn, start=dirname(pysmurf_file))
-    print(f'{pysmurf_git_tag}')
     return "https://github.com/slaclab/pysmurf/blob/%s/python/pysmurf/%s%s" % (
-        pysmurf_version, fn, linespec)
+        pysmurf_git_tag, fn, linespec)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -269,9 +269,7 @@ def linkcode_resolve(domain, info):
     else:
         linespec = ""
 
-    fn = relpath(fn, start=dirname(numpy.__file__))
+    fn = relpath(fn, start=dirname(pysmurf.__file__))
 
-    #return "https://github.com/numpy/numpy/blob/v%s/numpy/%s%s" % (
-    #    numpy.__version__, fn, linespec)
-    return "https://github.com/numpy/numpy/blob/master/numpy/%s%s" % (
+    return "https://github.com/slaclab/pysmurf/blob/master/numpy/%s%s" % (
         fn, linespec)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -271,6 +271,6 @@ def linkcode_resolve(domain, info):
         linespec = ""
 
     fn = relpath(fn, start=dirname(pysmurf_file))
-    print('here')
-    return "https://github.com/slaclab/pysmurf/blob/master/python/pysmurf/%s%s" % (
-        fn, linespec)
+    print(f'{pysmurf_version}')
+    return "https://github.com/slaclab/pysmurf/blob/%s/python/pysmurf/%s%s" % (
+        pysmurf_version, fn, linespec)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 
 import sys
 import os
+import re
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -20,6 +21,8 @@ import os
 from pysmurf import __version__ as pysmurf_version
 from pysmurf import __file__ as pysmurf_file
 sys.path.insert(0, os.path.abspath('..'))
+
+pysmurf_git_tag = re.sub('^v', '', os.popen('git describe --tags').read().strip())
 
 # -- Project information -----------------------------------------------------
 # General information about the project.
@@ -271,6 +274,6 @@ def linkcode_resolve(domain, info):
         linespec = ""
 
     fn = relpath(fn, start=dirname(pysmurf_file))
-    print(f'{pysmurf_version}')
+    print(f'{pysmurf_git_tag}')
     return "https://github.com/slaclab/pysmurf/blob/%s/python/pysmurf/%s%s" % (
         pysmurf_version, fn, linespec)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,18 +11,18 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
-import re
 # used for source code link resolution
 import inspect
-from os.path import relpath, dirname
+import sys
+import re
+from os.path import dirname, relpath
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-from pysmurf import __version__ as pysmurf_version
 from pysmurf import __file__ as pysmurf_file
+from pysmurf import __version__ as pysmurf_version
 sys.path.insert(0, os.path.abspath('..'))
 
 pysmurf_git_tag = re.sub('^v', '', os.popen('git describe --tags').read().strip())

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ import os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 from pysmurf import __version__ as pysmurf_version
+from pysmurf import __file__ as pysmurf_file
 sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
@@ -269,7 +270,7 @@ def linkcode_resolve(domain, info):
     else:
         linespec = ""
 
-    fn = relpath(fn, start=dirname(pysmurf.__file__))
+    fn = relpath(fn, start=dirname(pysmurf_file))
 
     return "https://github.com/slaclab/pysmurf/blob/master/numpy/%s%s" % (
         fn, linespec)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,9 @@
 import sys
 import os
 import re
+# used for source code link resolution
+import inspect
+from os.path import relpath, dirname
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -224,9 +227,6 @@ autodoc_mock_imports = ['pyrogue','smurf','rogue','CryoDet','CryoDevBoard']
 
 
 # Source code links
-import inspect
-from os.path import relpath, dirname
-
 def linkcode_resolve(domain, info):
     """
     Determine the URL corresponding to Python object

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,14 +11,14 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys
+import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.append(os.path.abspath('.'))
-sys.path.insert(0, os.path.abspath('..'))
 from pysmurf import __version__ as pysmurf_version
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 # General information about the project.
@@ -193,8 +193,8 @@ htmlhelp_basename = 'pysmurfdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'pysmurf.tex', u'pysmurf Documentation',
-   u'Edward Young', 'manual'),
+    ('index', 'pysmurf.tex', u'pysmurf Documentation',
+     u'Edward Young', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,8 @@ level commands as well as higher level analysis.
    user/installation
    user/quickstart
    user/configuration
+   user/developer
+
 
 .. toctree::
    :maxdepth: 3

--- a/docs/user/developer.rst
+++ b/docs/user/developer.rst
@@ -4,7 +4,7 @@ Developer's guide
 Writing a docstring
 -------------------
 
-``pysmurf`` docstrings should be written in the NumPy style, and
+pysmurf docstrings should be written in the NumPy style, and
 documentation should be written in the reStructuredText (reST)
 language.  See the `pandas docstring guide
 <https://pandas.pydata.org/docs/development/contributing_docstring.html>`_

--- a/docs/user/developer.rst
+++ b/docs/user/developer.rst
@@ -1,0 +1,14 @@
+Developer's guide
+=================
+
+Writing a docstring
+-------------------
+
+``pysmurf`` docstrings should be written in the NumPy style, and
+documentation should be written in the reStructuredText (reST)
+language.  See the `pandas docstring guide
+<https://pandas.pydata.org/docs/development/contributing_docstring.html>`_
+and the `numpydoc docstring guide
+<https://numpydoc.readthedocs.io/en/latest/format.html>`_ for a great
+introduction to both the NumPy docstring style and reST markup, as
+well as many examples.

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -18,7 +18,7 @@ from pysmurf.client.util.pub import Publisher
 
 from .logger import SmurfLogger
 
-class SmurfBase(object):
+class SmurfBase:
     '''
     Base class for common things
     '''
@@ -167,25 +167,25 @@ class SmurfBase(object):
 
         # Timing paths
         self.amctiming = self.amccc + 'AmcCarrierTiming:'
-        self.trigger_root =  self.amctiming + 'EvrV2CoreTriggers:'
+        self.trigger_root = self.amctiming + 'EvrV2CoreTriggers:'
         self.timing_status = self.amctiming + 'TimingFrameRx:'
 
         self.C = CryoCard(self.rtm_spi_cryo_root + 'read',
-            self.rtm_spi_cryo_root + 'write')
+                          self.rtm_spi_cryo_root + 'write')
         self.freq_resp = {}
 
         # RTM slow DAC parameters (used, e.g., for TES biasing). The
         # DACs are AD5790 chips
-        self._rtm_slow_dac_max_volt=10. # Max unipolar DAC voltage,
+        self._rtm_slow_dac_max_volt = 10. # Max unipolar DAC voltage,
                                         # in Volts
-        self._rtm_slow_dac_nbits=20
+        self._rtm_slow_dac_nbits = 20
         # x2 because _rtm_slow_dac_max_volt is the maximum *unipolar*
         # voltage.  Units of Volt/bit
-        self._rtm_slow_dac_bit_to_volt=( 2*self._rtm_slow_dac_max_volt /
-                                         ( 2**( self._rtm_slow_dac_nbits ) ) )
+        self._rtm_slow_dac_bit_to_volt = (2*self._rtm_slow_dac_max_volt/
+                                          (2**(self._rtm_slow_dac_nbits)))
 
         # LUT table length for arbitrary waveform generation
-        self._lut_table_array_length=2048
+        self._lut_table_array_length = 2048
 
     def init_log(self, verbose=0, logger=SmurfLogger, logfile=None,
                  log_timestamp=True, log_prefix=None, **kwargs):

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -13,10 +13,10 @@
 # copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-from .logger import SmurfLogger
 from pysmurf.client.command.cryo_card import CryoCard
-
 from pysmurf.client.util.pub import Publisher
+
+from .logger import SmurfLogger
 
 class SmurfBase(object):
     '''

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -60,7 +60,7 @@ class SmurfBase(object):
             Script id included with publisher messages. For example, the
             script or operation name.
         """
-        
+
         # Set up logging
         self.log = log
         if self.log is None:

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -192,8 +192,8 @@ class SmurfBase(object):
         """
         Initialize the logger from the input keyword arguments.
 
-        Arguments
-        ---------
+        Args
+        ----
         logger : logging class, optional
             Class to initialize, should be a subclass of SmurfLogger
             or equivalent.
@@ -248,12 +248,12 @@ class SmurfBase(object):
         '''
         Helper function that returns the epics path to a band.
 
-        Args:
-        -----
+        Args
+        ----
         band (int): The band to access
 
-        Returns:
-        --------
+        Returns
+        -------
         path (string) : The string to be passed to caget/caput to access
             the input band.
         '''
@@ -263,12 +263,12 @@ class SmurfBase(object):
         '''
         Helper function that returns the epics path to cryoroot.
 
-        Args:
-        -----
+        Args
+        ----
         band (int): The band to access
 
-        Returns:
-        --------
+        Returns
+        -------
         path (string) : The string to be passed to caget/caput to access
             the input band.
         '''
@@ -278,13 +278,13 @@ class SmurfBase(object):
         """
         Helper function that returns the epics path to channel root.
 
-        Args:
-        -----
+        Args
+        ----
         band (int) : The band to access
         channel (int) : The channel to access.
 
-        Returns:
-        --------
+        Returns
+        -------
         path (string) : The string to be passed to caget/caput to access
             the input band.
         """

--- a/python/pysmurf/client/base/logger.py
+++ b/python/pysmurf/client/base/logger.py
@@ -58,8 +58,8 @@ class Logger(object):
         """
         Log a message.
 
-        Arguments
-        ---------
+        Args
+        ----
         msg : string
             The message to log.
         level : int, optional

--- a/python/pysmurf/client/base/logger.py
+++ b/python/pysmurf/client/base/logger.py
@@ -8,8 +8,8 @@
 # This is adapted from spider_tools.  Originally written by
 # M. Hasselfield and ported by S. Rahlin
 #-----------------------------------------------------------------------------
-import sys
 import datetime as dt
+import sys
 
 __all__ = ['Logger', 'SmurfLogger']
 

--- a/python/pysmurf/client/base/schema.py
+++ b/python/pysmurf/client/base/schema.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """schema is a library for validating Python data structures, such as those
 obtained from config-files, forms, external services or command-line
 parsing, converted from JSON/YAML (or something else) to Python data-types."""
@@ -10,7 +9,7 @@ try:
 except ImportError:
     from contextlib2 import ExitStack
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __all__ = [
     "Schema",
     "And",
@@ -20,6 +19,7 @@ __all__ = [
     "Use",
     "Forbidden",
     "Const",
+    "Literal",
     "SchemaError",
     "SchemaWrongKeyError",
     "SchemaMissingKeyError",
@@ -274,12 +274,16 @@ class Schema(object):
     schema for the data that will be validated.
     """
 
-    def __init__(self, schema, error=None, ignore_extra_keys=False, name=None, description=None):
+    def __init__(self, schema, error=None, ignore_extra_keys=False, name=None, description=None, as_reference=False):
         self._schema = schema
         self._error = error
         self._ignore_extra_keys = ignore_extra_keys
         self._name = name
         self._description = description
+        # Ask json_schema to create a definition for this schema and use it as part of another
+        self.as_reference = as_reference
+        if as_reference and name is None:
+            raise ValueError("Schema used as reference should have a name")
 
     def __repr__(self):
         return "%s(%r)" % (self.__class__.__name__, self._schema)
@@ -291,6 +295,14 @@ class Schema(object):
     @property
     def description(self):
         return self._description
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def ignore_extra_keys(self):
+        return self._ignore_extra_keys
 
     @staticmethod
     def _dict_key_priority(s):
@@ -331,6 +343,10 @@ class Schema(object):
         s = self._schema
         e = self._error
         i = self._ignore_extra_keys
+
+        if isinstance(s, Literal):
+            s = s.schema
+
         flavor = _priority(s)
         if flavor == ITERABLE:
             data = Schema(type(s), error=e).validate(data)
@@ -435,163 +451,233 @@ class Schema(object):
             raise SchemaError(message, e)
         if s == data:
             return data
-        if isinstance(s, Literal):
-            if s.schema == data:
-                return data
         else:
             message = "%r does not match %r" % (s, data)
             message = self._prepend_schema_name(message)
             raise SchemaError(message, e.format(data) if e else None)
 
-    def json_schema(self, schema_id=None, is_main_schema=True, description=None):
+    def json_schema(self, schema_id, use_refs=False):
         """Generate a draft-07 JSON schema dict representing the Schema.
         This method can only be called when the Schema's value is a dict.
-        This method must be called with a schema_id. Calling it without one
-        is used in a recursive context for sub schemas."""
+        This method must be called with a schema_id.
 
-        def _get_type_name(python_type):
-            """Return the JSON schema name for a Python type"""
-            if python_type == str:
-                return "string"
-            elif python_type == int:
-                return "integer"
-            elif python_type == float:
-                return "number"
-            elif python_type == bool:
-                return "boolean"
-            elif python_type == list:
-                return "array"
-            return "string"
+        :param schema_id: The value of the $id on the main schema
+        :param use_refs: Enable reusing object references in the resulting JSON schema.
+                         Schemas with references are harder to read by humans, but are a lot smaller when there
+                         is a lot of reuse
+        """
 
-        Schema = self.__class__
-        s = self.schema
-        i = self._ignore_extra_keys
-        flavor = _priority(s)
+        seen = dict()  # For use_refs
+        definitions_by_name = {}
 
-        return_schema = {}
-        if description:
-            return_schema["description"] = description
+        def _json_schema(schema, is_main_schema=True, description=None, allow_reference=True):
+            Schema = self.__class__
 
-        if flavor != DICT and is_main_schema:
-            raise ValueError("The main schema must be a dict.")
-
-        if flavor == TYPE:
-            # Handle type
-            return_schema["type"] = _get_type_name(s)
-            return return_schema
-        elif flavor == ITERABLE:
-            # Handle arrays or dict schema
-
-            return_schema["type"] = "array"
-            if len(s) == 1:
-                return_schema["items"] = Schema(s[0]).json_schema(is_main_schema=False)
-            elif len(s) > 1:
-                return_schema["items"] = Schema(Or(*s)).json_schema(is_main_schema=False)
-            return return_schema
-
-        elif isinstance(s, Or):
-            # Handle Or values
-
-            # Check if we can use an enum
-            if all(priority == COMPARABLE for priority in [_priority(value) for value in s.args]):
-                # All values are simple, can use enum or const
-                if len(s.args) == 1:
-                    return_schema["const"] = s.args[0]
+            def _create_or_use_ref(return_dict):
+                """If not already seen, return the provided part of the schema unchanged.
+                If already seen, give an id to the already seen dict and return a reference to the previous part
+                of the schema instead.
+                """
+                if not use_refs or is_main_schema:
                     return return_schema
-                return_schema["enum"] = list(s.args)
-                return return_schema
 
-            # No enum, let's go with recursive calls
-            any_of_values = []
-            for or_key in s.args:
-                new_value = Schema(or_key).json_schema(is_main_schema=False)
-                if new_value not in any_of_values:
-                    any_of_values.append(new_value)
-            return_schema["anyOf"] = any_of_values
-            return return_schema
-        elif isinstance(s, And):
-            # Handle And values
-            all_of_values = []
-            for and_key in s.args:
-                new_value = Schema(and_key).json_schema(is_main_schema=False)
-                if new_value != {} and new_value not in all_of_values:
-                    all_of_values.append(new_value)
-            return_schema["allOf"] = all_of_values
-            return return_schema
-        elif flavor == COMPARABLE:
-            return_schema["const"] = s
-            return return_schema
-        elif flavor == VALIDATOR and type(s) == Regex:
-            return_schema["type"] = "string"
-            return_schema["pattern"] = s.pattern_str
-            return return_schema
+                hashed = hash(repr(sorted(return_dict.items())))
 
-        if flavor != DICT:
-            # If not handled, do not check
-            return return_schema
+                if hashed not in seen:
+                    seen[hashed] = return_dict
+                    return return_dict
+                else:
+                    id_str = "#" + str(hashed)
+                    seen[hashed]["$id"] = id_str
+                    return {"$ref": id_str}
 
-        if is_main_schema and not schema_id:
-            raise ValueError("schema_id is required.")
+            def _get_type_name(python_type):
+                """Return the JSON schema name for a Python type"""
+                if python_type == str:
+                    return "string"
+                elif python_type == int:
+                    return "integer"
+                elif python_type == float:
+                    return "number"
+                elif python_type == bool:
+                    return "boolean"
+                elif python_type == list:
+                    return "array"
+                elif python_type == dict:
+                    return "object"
+                return "string"
 
-        # Handle dict
-        required_keys = []
-        expanded_schema = {}
-        for key in s:
-            if isinstance(key, Hook):
-                continue
+            def _to_json_type(value):
+                """Attempt to convert a constant value (for "const" and "default") to a JSON serializable value"""
+                if value is None or type(value) in (str, int, float, bool, list, dict):
+                    return value
 
-            def _get_key_description(key):
-                """Get the description associated to a key (as specified in a Literal object). Return None if not a Literal"""
-                if isinstance(key, Optional):
-                    return _get_key_description(key.schema)
+                if type(value) in (tuple, set, frozenset):
+                    return list(value)
 
-                if isinstance(key, Literal):
-                    return key.description
+                if isinstance(value, Literal):
+                    return value.schema
 
-                return None
+                return str(value)
 
-            def _get_key_name(key):
-                """Get the name of a key (as specified in a Literal object). Return the key unchanged if not a Literal"""
-                if isinstance(key, Optional):
-                    return _get_key_name(key.schema)
+            def _to_schema(s, ignore_extra_keys):
+                if not isinstance(s, Schema):
+                    return Schema(s, ignore_extra_keys=ignore_extra_keys)
 
-                if isinstance(key, Literal):
-                    return key.schema
+                return s
 
-                return key
+            s = schema.schema
+            i = schema.ignore_extra_keys
+            flavor = _priority(s)
 
-            sub_schema = s[key]
-            if not isinstance(sub_schema, Schema):
-                sub_schema = Schema(s[key], ignore_extra_keys=i)
+            return_schema = {}
 
-            key_name = _get_key_name(key)
+            is_a_ref = allow_reference and schema.as_reference
+            if schema.description and not is_a_ref:
+                return_schema["description"] = schema.description
+            if description and not is_a_ref:
+                return_schema["description"] = description
 
-            if isinstance(key_name, str):
-                if not isinstance(key, Optional):
-                    required_keys.append(key_name)
-                expanded_schema[key_name] = sub_schema.json_schema(
-                    is_main_schema=False, description=_get_key_description(key)
-                )
-            elif isinstance(key_name, Or):
-                # JSON schema does not support having a key named one name or another, so we just add both options
-                # This is less strict because we cannot enforce that one or the other is required
+            if flavor != DICT and is_main_schema:
+                raise ValueError("The main schema must be a dict.")
 
-                for or_key in key_name.args:
-                    expanded_schema[_get_key_name(or_key)] = sub_schema.json_schema(
-                        is_main_schema=False, description=_get_key_description(or_key)
+            if flavor == TYPE:
+                # Handle type
+                return_schema["type"] = _get_type_name(s)
+            elif flavor == ITERABLE:
+                # Handle arrays or dict schema
+
+                return_schema["type"] = "array"
+                if len(s) == 1:
+                    return_schema["items"] = _json_schema(_to_schema(s[0], i), is_main_schema=False)
+                elif len(s) > 1:
+                    return_schema["items"] = _json_schema(Schema(Or(*s)), is_main_schema=False)
+            elif isinstance(s, Or):
+                # Handle Or values
+
+                # Check if we can use an enum
+                if all(priority == COMPARABLE for priority in [_priority(value) for value in s.args]):
+                    or_values = [str(s) if isinstance(s, Literal) else s for s in s.args]
+                    # All values are simple, can use enum or const
+                    if len(or_values) == 1:
+                        return_schema["const"] = _to_json_type(or_values[0])
+                        return return_schema
+                    return_schema["enum"] = or_values
+                else:
+                    # No enum, let's go with recursive calls
+                    any_of_values = []
+                    for or_key in s.args:
+                        new_value = _json_schema(_to_schema(or_key, i), is_main_schema=False)
+                        if new_value != {} and new_value not in any_of_values:
+                            any_of_values.append(new_value)
+                    if len(any_of_values) == 1:
+                        # Only one representable condition remains, do not put under oneOf
+                        return_schema.update(any_of_values[0])
+                    else:
+                        return_schema["anyOf"] = any_of_values
+            elif isinstance(s, And):
+                # Handle And values
+                all_of_values = []
+                for and_key in s.args:
+                    new_value = _json_schema(_to_schema(and_key, i), is_main_schema=False)
+                    if new_value != {} and new_value not in all_of_values:
+                        all_of_values.append(new_value)
+                if len(all_of_values) == 1:
+                    # Only one representable condition remains, do not put under allOf
+                    return_schema.update(all_of_values[0])
+                else:
+                    return_schema["allOf"] = all_of_values
+            elif flavor == COMPARABLE:
+                return_schema["const"] = _to_json_type(s)
+            elif flavor == VALIDATOR and type(s) == Regex:
+                return_schema["type"] = "string"
+                return_schema["pattern"] = s.pattern_str
+            else:
+                if flavor != DICT:
+                    # If not handled, do not check
+                    return return_schema
+
+                # Schema is a dict
+
+                # Check if we have to create a common definition and use as reference
+                if is_a_ref:
+                    # Generate sub schema if not already done
+                    if schema.name not in definitions_by_name:
+                        definitions_by_name[schema.name] = {}  # Avoid infinite loop
+                        definitions_by_name[schema.name] = _json_schema(
+                            schema, is_main_schema=False, allow_reference=False
+                        )
+
+                    return_schema["$ref"] = "#/definitions/" + schema.name
+                else:
+                    required_keys = []
+                    expanded_schema = {}
+                    for key in s:
+                        if isinstance(key, Hook):
+                            continue
+
+                        def _get_key_description(key):
+                            """Get the description associated to a key (as specified in a Literal object). Return None if not a Literal"""
+                            if isinstance(key, Optional):
+                                return _get_key_description(key.schema)
+
+                            if isinstance(key, Literal):
+                                return key.description
+
+                            return None
+
+                        def _get_key_name(key):
+                            """Get the name of a key (as specified in a Literal object). Return the key unchanged if not a Literal"""
+                            if isinstance(key, Optional):
+                                return _get_key_name(key.schema)
+
+                            if isinstance(key, Literal):
+                                return key.schema
+
+                            return key
+
+                        sub_schema = _to_schema(s[key], ignore_extra_keys=i)
+                        key_name = _get_key_name(key)
+
+                        if isinstance(key_name, str):
+                            if not isinstance(key, Optional):
+                                required_keys.append(key_name)
+                            expanded_schema[key_name] = _json_schema(
+                                sub_schema, is_main_schema=False, description=_get_key_description(key)
+                            )
+                            if isinstance(key, Optional) and hasattr(key, "default"):
+                                expanded_schema[key_name]["default"] = _to_json_type(key.default)
+                        elif isinstance(key_name, Or):
+                            # JSON schema does not support having a key named one name or another, so we just add both options
+                            # This is less strict because we cannot enforce that one or the other is required
+
+                            for or_key in key_name.args:
+                                expanded_schema[_get_key_name(or_key)] = _json_schema(
+                                    sub_schema, is_main_schema=False, description=_get_key_description(or_key)
+                                )
+
+                    return_schema.update(
+                        {
+                            "type": "object",
+                            "properties": expanded_schema,
+                            "required": required_keys,
+                            "additionalProperties": i,
+                        }
                     )
 
-        return_schema.update(
-            {"type": "object", "properties": expanded_schema, "required": required_keys, "additionalProperties": i}
-        )
-        if is_main_schema:
-            return_schema.update({"id": schema_id, "$schema": "http://json-schema.org/draft-07/schema#"})
-            if self._name:
-                return_schema["title"] = self._name
-        if self._description:
-            return_schema["description"] = self._description
+                if is_main_schema:
+                    return_schema.update({"$id": schema_id, "$schema": "http://json-schema.org/draft-07/schema#"})
+                    if self._name:
+                        return_schema["title"] = self._name
 
-        return return_schema
+                    if definitions_by_name:
+                        return_schema["definitions"] = {}
+                        for definition_name, definition in definitions_by_name.items():
+                            return_schema["definitions"][definition_name] = definition
+
+            return _create_or_use_ref(return_schema)
+
+        return _json_schema(self, True)
 
 
 class Optional(Schema):
@@ -611,16 +697,16 @@ class Optional(Schema):
                     '"%r" is too complex.' % (self._schema,)
                 )
             self.default = default
-            self.key = self._schema
+            self.key = str(self._schema)
 
     def __hash__(self):
         return hash(self._schema)
 
     def __eq__(self, other):
         return (
-            self.__class__ is other.__class__ and
-            getattr(self, "default", self._MARKER) == getattr(other, "default", self._MARKER) and
-            self._schema == other._schema
+            self.__class__ is other.__class__
+            and getattr(self, "default", self._MARKER) == getattr(other, "default", self._MARKER)
+            and self._schema == other._schema
         )
 
     def reset(self):
@@ -649,6 +735,12 @@ class Literal(object):
     def __init__(self, value, description=None):
         self._schema = value
         self._description = description
+
+    def __str__(self):
+        return self._schema
+
+    def __repr__(self):
+        return 'Literal("' + self.schema + '", description="' + (self.description or "") + '")'
 
     @property
     def description(self):

--- a/python/pysmurf/client/base/schema.py
+++ b/python/pysmurf/client/base/schema.py
@@ -704,9 +704,9 @@ class Optional(Schema):
 
     def __eq__(self, other):
         return (
-            self.__class__ is other.__class__
-            and getattr(self, "default", self._MARKER) == getattr(other, "default", self._MARKER)
-            and self._schema == other._schema
+            self.__class__ is other.__class__ and getattr(self,
+            "default", self._MARKER) == getattr(other, "default",
+            self._MARKER) and self._schema == other._schema
         )
 
     def reset(self):

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -13,10 +13,11 @@
 # copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-import json
 import io
-import re
+import json
 import os
+import re
+
 import numpy as np
 
 class SmurfConfig:

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -33,8 +33,6 @@ class SmurfConfig:
 
     def read_json(self, filename, comment_char='#'):
         """Reads a json config file
-
-           Args:
         """
         no_comments=[]
         with open(self.filename) as config_file:
@@ -57,7 +55,8 @@ class SmurfConfig:
     def read(self, update=False, validate_config=True):
         """Reads config file and updates the configuration.
 
-           Args:
+           Args
+           ----
               update (bool): Whether or not to update the configuration.
         """
         loaded_config=self.read_json(self.filename)
@@ -76,7 +75,8 @@ class SmurfConfig:
     def update(self, key, val):
         """Updates a single key in the config
 
-           Args:
+           Args
+           ----
               key (any): key to update in the config dictionary
               val (any): value to assign to the given key
         """
@@ -85,7 +85,8 @@ class SmurfConfig:
     def write(self, outputfile):
         """Dumps the current config to a file
 
-           Args:
+           Args
+           ----
               outputfile (str): The name of the file to save the configuration to.
         """
         ## dump current config to outputfile ##
@@ -96,7 +97,8 @@ class SmurfConfig:
     def has(self, key):
         """Reports if configuration has requested key.
 
-           Args:
+           Args
+           ----
               key (any): key to check for in configuration dictionary.
         """
 
@@ -109,7 +111,8 @@ class SmurfConfig:
         """Returns configuration entry for requested key.  Returns
            None if key not present in configuration.
 
-           Args:
+           Args
+           ----
               key (any): key whose configuration entry to retrieve.
         """
 
@@ -123,7 +126,8 @@ class SmurfConfig:
         Get the subkey value. A dumb thing that just formats strings for you.
         Will return None if it can't find stuff
 
-        Args:
+        Args
+        ----
           key (any): key in config
           subkey (any): config subkey
         """
@@ -143,7 +147,8 @@ class SmurfConfig:
         """
         More dumb wrappers for nested dictionaries.
 
-        Args:
+        Args
+        ----
           key (any): key in config
           subkey (any): config subkey
           val (any): value to write

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -112,7 +112,8 @@ class SmurfConfigPropertiesMixin(object):
         :func:`~pysmurf.client.debug.smurf_noise.analyze_noise_vs_tone`,
         :func:`~pysmurf.client.debug.smurf_iv.analyze_slow_iv`,
         :func:`~pysmurf.client.util.smurf_util.bias_bump`,
-        :func:`~pysmurf.client.util.smurf_util.identify_bias_groups`
+        :func:`~pysmurf.client.util.smurf_util.identify_bias_groups`, 
+        :func:`copy_config_to_properties`
         """
         return self._pA_per_phi0
 

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -16,8 +16,6 @@
 """Defines the SmurfConfigPropertiesMixin class.
 """
 
-from pysmurf.client.base.smurf_config import SmurfConfig as SmurfConfig
-
 class SmurfConfigPropertiesMixin(object):
     """Mixin for ???x
     """
@@ -33,18 +31,18 @@ class SmurfConfigPropertiesMixin(object):
         self._hemt_Vd_series_resistor=None
         self._hemt_Id_offset=None
         self._hemt_gate_min_voltage=None
-        self._hemt_gate_max_voltage=None        
-        
+        self._hemt_gate_max_voltage=None
+
         ## 50K LNA
         self._fiftyk_Vg=None
         self._fiftyk_dac_num=None
         self._fiftyk_bit_to_V=None
         self._fiftyk_amp_Vd_series_resistor=None
-        self._fiftyk_Id_offset=None    
-        
+        self._fiftyk_Id_offset=None
+
     def copy_config_to_properties(self,config):
         """Copy values from SmurfConfig instance to properties
-        
+
         MORE EXPLANATION HERE. USES PROPERTY SETTERS IN CASE WE EVER
         WANT TO IMPOSE ANY CONDITIONS IN THEM.
 
@@ -56,7 +54,7 @@ class SmurfConfigPropertiesMixin(object):
               :class:`~pysmurf.client.command.smurf_config_properties.SmurfConfigPropertiesMixin`
               instance.
         """
-        
+
         # Useful constants
         constant_cfg = config.get('constant')
         self.pA_per_phi0 = constant_cfg.get('pA_per_phi0')
@@ -65,7 +63,7 @@ class SmurfConfigPropertiesMixin(object):
         amp_cfg = self.config.get('amplifier')
         keys = amp_cfg.keys()
 
-        ## 4K HEMT        
+        ## 4K HEMT
         if 'hemt_Vg' in keys:
             self.hemt_Vg=amp_cfg['hemt_Vg']
         if 'bit_to_V_hemt' in keys:
@@ -77,9 +75,9 @@ class SmurfConfigPropertiesMixin(object):
         if 'hemt_gate_min_voltage' in keys:
             self.hemt_gate_min_voltage=amp_cfg['hemt_gate_min_voltage']
         if 'hemt_gate_max_voltage' in keys:
-            self.hemt_gate_max_voltage=amp_cfg['hemt_gate_max_voltage']                        
-            
-        ## 50K HEMT                    
+            self.hemt_gate_max_voltage=amp_cfg['hemt_gate_max_voltage']
+
+        ## 50K HEMT
         if 'LNA_Vg' in keys:
             self.fiftyk_Vg=amp_cfg['LNA_Vg']
         if 'dac_num_50k' in keys:
@@ -90,7 +88,7 @@ class SmurfConfigPropertiesMixin(object):
             self.fiftyk_amp_Vd_series_resistor=amp_cfg['50K_amp_Vd_series_resistor']
         if '50k_Id_offset' in keys:
             self.fiftyk_Id_offset=amp_cfg['50k_Id_offset']
-            
+
     ###########################################################################
     ## Start pA_per_phi0 property definition
 
@@ -99,21 +97,21 @@ class SmurfConfigPropertiesMixin(object):
     def pA_per_phi0(self):
         """Conversion factor between demodulated phase and TES
         current.
-        
+
         Gets or sets the conversion factor between the demodulated
         phase for every SMuRF channel and the equivalent TES current.
         Units are pA per Phi0, with Phi0 the magnetic flux quantum.
 
         See Also
         --------
-        :meth:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.take_noise_psd`,
-        :meth:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_vs_bias`,
-        :meth:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_all_vs_noise_solo`,
-        :meth:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_vs_tone`,
-        :meth:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.analyze_slow_iv`,
-        :meth:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.bias_bump`,
-        :meth:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.identify_bias_groups`, 
-        :meth:`copy_config_to_properties`
+        :func:`copy_config_to_properties`,
+        :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.take_noise_psd`,
+        :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_vs_bias`,
+        :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_all_vs_noise_solo`,
+        :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_vs_tone`,
+        :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.analyze_slow_iv`,
+        :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.bias_bump`,
+        :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.identify_bias_groups`
         """
         return self._pA_per_phi0
 
@@ -132,9 +130,14 @@ class SmurfConfigPropertiesMixin(object):
     @property
     def hemt_Vg(self):
         """4K HEMT Gate Voltage
-        
+
         Gets or sets the desired value for the 4K HEMT Gate voltage.
         Units are Volts.
+
+        See Also
+        --------
+        :func:`copy_config_to_properties`,
+        :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.set_amplifier_bias`
         """
         return self._hemt_Vg
 
@@ -153,8 +156,14 @@ class SmurfConfigPropertiesMixin(object):
     @property
     def hemt_bit_to_V(self):
         """???
-        
+
         ???
+
+        See Also
+        --------
+        :func:`copy_config_to_properties`,
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`,
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_hemt_gate_voltage`
         """
         return self._hemt_bit_to_V
 
@@ -173,8 +182,13 @@ class SmurfConfigPropertiesMixin(object):
     @property
     def hemt_Vd_series_resistor(self):
         """???
-        
+
         ???
+
+        See Also
+        --------
+        :func:`copy_config_to_properties`,
+        :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.get_hemt_drain_current`
         """
         return self._hemt_Vd_series_resistor
 
@@ -193,8 +207,13 @@ class SmurfConfigPropertiesMixin(object):
     @property
     def hemt_Id_offset(self):
         """???
-        
+
         ???
+
+        See Also
+        --------
+        :func:`copy_config_to_properties`,
+        :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.get_hemt_drain_current`
         """
         return self._hemt_Id_offset
 
@@ -213,8 +232,13 @@ class SmurfConfigPropertiesMixin(object):
     @property
     def hemt_gate_min_voltage(self):
         """???
-        
+
         ???
+
+        See Also
+        --------
+        :func:`copy_config_to_properties`,
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`
         """
         return self._hemt_gate_min_voltage
 
@@ -233,8 +257,13 @@ class SmurfConfigPropertiesMixin(object):
     @property
     def hemt_gate_max_voltage(self):
         """???
-        
+
         ???
+
+        See Also
+        --------
+        :func:`copy_config_to_properties`,
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`,
         """
         return self._hemt_gate_max_voltage
 
@@ -244,8 +273,8 @@ class SmurfConfigPropertiesMixin(object):
         self._hemt_gate_max_voltage=value
 
     ## End hemt_gate_max_voltage property definition
-    ###########################################################################            
-    
+    ###########################################################################
+
     ###########################################################################
     ## Start fiftyk_Vg property definition
 
@@ -253,7 +282,7 @@ class SmurfConfigPropertiesMixin(object):
     @property
     def fiftyk_Vg(self):
         """50K LNA Gate Voltage
-        
+
         Gets or sets the desired value for the 50K LNA Gate voltage.
         Units are Volts.
         """
@@ -265,7 +294,7 @@ class SmurfConfigPropertiesMixin(object):
         self._fiftyk_Vg=value
 
     ## End fiftyk_Vg property definition
-    ###########################################################################        
+    ###########################################################################
 
     ###########################################################################
     ## Start fiftyk_dac_num property definition
@@ -274,7 +303,7 @@ class SmurfConfigPropertiesMixin(object):
     @property
     def fiftyk_dac_num(self):
         """???
-        
+
         ???
         """
         return self._fiftyk_dac_num
@@ -294,7 +323,7 @@ class SmurfConfigPropertiesMixin(object):
     @property
     def fiftyk_bit_to_V(self):
         """???
-        
+
         ???
         """
         return self._fiftyk_bit_to_V
@@ -314,7 +343,7 @@ class SmurfConfigPropertiesMixin(object):
     @property
     def fiftyk_amp_Vd_series_resistor(self):
         """???
-        
+
         ???
         """
         return self._fiftyk_amp_Vd_series_resistor
@@ -334,7 +363,7 @@ class SmurfConfigPropertiesMixin(object):
     @property
     def fiftyk_Id_offset(self):
         """???
-        
+
         ???
         """
         return self._fiftyk_Id_offset
@@ -346,6 +375,3 @@ class SmurfConfigPropertiesMixin(object):
 
     ## End fiftyk_Id_offset property definition
     ###########################################################################
-
-    
-    

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -13,36 +13,36 @@
 # copied, modified, propagated, or distributed except according to the
 # terms contained in the LICENSE.txt file.
 # -----------------------------------------------------------------------------
-"""Defines the mixin class :class:`SmurfConfigPropertiesMixin`.
-"""
+"""Defines the mixin class :class:`SmurfConfigPropertiesMixin`."""
 
 class SmurfConfigPropertiesMixin(object):
     """Mixin for loading pysmurf configuration parameters.
 
-    Defines properties used by pysmurf that are defined in the pysmurf
-    configuration file.  More details on python properties can be
-    found in the documentation for python "Built-in Functions" [1]_.
-    
+    Defines properties used by pysmurf whose values are specified in
+    the pysmurf configuration file.  More details on python properties
+    can be found in the documentation for python "Built-in Functions"
+    [1]_.
+
     The :class:`SmurfConfigPropertiesMixin` class has only one
     function :func:`copy_config_to_properties` which can populate the
     properties from a provided
     :class:`~pysmurf.client.base.smurf_config.SmurfConfig` class
-    instance.  The :func:`copy_config_to_properties` is called once to
-    populate all of the :class:`SmurfConfigPropertiesMixin` attributes
-    by a call to the
+    instance.  :func:`copy_config_to_properties` can be called by the
+    user at any time, but it is called once to populate all of the
+    :class:`SmurfConfigPropertiesMixin` attributes by a call to the
     :func:`~pysmurf.client.base.smurf_control.SmurfControl.initialize`
     function in the
     :class:`~pysmurf.client.base.smurf_control.SmurfControl`
     constructor (unless the
-    :class:`~pysmurf.client.base.smurf_control.SmurfControl`
-    instance is not instantiated with a configuration file).
+    :class:`~pysmurf.client.base.smurf_control.SmurfControl` instance
+    is not instantiated with a configuration file).
 
-    .. warning:: 
-    	If a user changes the value of a property but then writes the
-    	internal pysmurf configuration to disk with the
-    	:func:`~pysmurf.client.base.smurf_control.SmurfControl.write_output()`
-    	function, the value written to the file will not reflect the
-    	user's change.
+    .. warning::
+        If a user changes the value of a property but then writes the
+        internal pysmurf configuration to disk with the
+        :func:`~pysmurf.client.base.smurf_control.SmurfControl.write_output()`
+        function, the value written to the file will not reflect the
+        user's change.
 
     Examples
     --------
@@ -54,7 +54,7 @@ class SmurfConfigPropertiesMixin(object):
 
     >>> S.pA_per_phi0
     9000000.0
-    
+
     and it can be set like this:
 
     >>> S.pA_per_phi0 = 9000000.0
@@ -75,9 +75,11 @@ class SmurfConfigPropertiesMixin(object):
     References
     ----------
     .. [1] https://docs.python.org/3/library/functions.html#property
+
     """
 
     def __init__(self, *args, **kwargs):
+        """SmurfConfigPropertiesMixin constructor."""
         # Constants
         self._pA_per_phi0=None
 
@@ -98,7 +100,7 @@ class SmurfConfigPropertiesMixin(object):
         self._fiftyk_Id_offset=None
 
     def copy_config_to_properties(self,config):
-        """Copy values from SmurfConfig instance to properties
+        """Copy values from SmurfConfig instance to properties.
 
         MORE EXPLANATION HERE. USES PROPERTY SETTERS IN CASE WE EVER
         WANT TO IMPOSE ANY CONDITIONS IN THEM.
@@ -110,8 +112,8 @@ class SmurfConfigPropertiesMixin(object):
               be copied into properties in this
               :class:`~pysmurf.client.command.smurf_config_properties.SmurfConfigPropertiesMixin`
               instance.
-        """
 
+        """
         # Useful constants
         constant_cfg = config.get('constant')
         self.pA_per_phi0 = constant_cfg.get('pA_per_phi0')
@@ -168,6 +170,7 @@ class SmurfConfigPropertiesMixin(object):
         :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.analyze_slow_iv`,
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.bias_bump`,
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.identify_bias_groups`
+
         """
         return self._pA_per_phi0
 
@@ -193,6 +196,7 @@ class SmurfConfigPropertiesMixin(object):
         See Also
         --------
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.set_amplifier_bias`
+
         """
         return self._hemt_Vg
 
@@ -223,6 +227,7 @@ class SmurfConfigPropertiesMixin(object):
         --------
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`,
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_hemt_gate_voltage`
+
         """
         return self._hemt_bit_to_V
 
@@ -257,6 +262,7 @@ class SmurfConfigPropertiesMixin(object):
         See Also
         --------
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.get_hemt_drain_current`
+
         """
         return self._hemt_Vd_series_resistor
 
@@ -291,6 +297,7 @@ class SmurfConfigPropertiesMixin(object):
         See Also
         --------
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.get_hemt_drain_current`
+
         """
         return self._hemt_Id_offset
 
@@ -308,7 +315,7 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def hemt_gate_min_voltage(self):
-        """4K HEMT gate voltage minimum software limit
+        """4K HEMT gate voltage minimum software limit.
 
         Gets or sets the minimum voltage the 4K HEMT gate voltage can
         be set to using the
@@ -321,6 +328,7 @@ class SmurfConfigPropertiesMixin(object):
         See Also
         --------
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`
+
         """
         return self._hemt_gate_min_voltage
 
@@ -338,7 +346,7 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def hemt_gate_max_voltage(self):
-        """4K HEMT gate voltage maximum software limit
+        """4K HEMT gate voltage maximum software limit.
 
         Gets or sets the maximum voltage the 4K HEMT gate voltage can
         be set to using the
@@ -351,6 +359,7 @@ class SmurfConfigPropertiesMixin(object):
         See Also
         --------
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`
+
         """
         return self._hemt_gate_max_voltage
 
@@ -368,7 +377,7 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def fiftyk_Vg(self):
-        """50K LNA Gate Voltage
+        """50K LNA Gate Voltage.
 
         Gets or sets the desired value for the 50K LNA Gate voltage at
         the output of the cryostat card.  Units are Volts.
@@ -376,6 +385,7 @@ class SmurfConfigPropertiesMixin(object):
         See Also
         --------
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.set_amplifier_bias`
+
         """
         return self._fiftyk_Vg
 
@@ -393,7 +403,7 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def fiftyk_dac_num(self):
-        """The RTM DAC number which is wired to the 50K LNA gate.
+        """RTM DAC number wired to the 50K LNA gate.
 
         Gets or sets the DAC number of the DAC on the RTM that is
         wired to the 50K LNA gate.  Must be an integer between 1 and
@@ -411,6 +421,7 @@ class SmurfConfigPropertiesMixin(object):
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_50k_amp_gate_voltage`,
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_50k_amp_gate_voltage`,
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_50k_amp_enable`
+
         """
         return self._fiftyk_dac_num
 
@@ -441,6 +452,7 @@ class SmurfConfigPropertiesMixin(object):
         --------
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_50k_amp_gate_voltage`,
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_50k_amp_gate_voltage`
+
         """
         return self._fiftyk_bit_to_V
 
@@ -475,6 +487,7 @@ class SmurfConfigPropertiesMixin(object):
         See Also
         --------
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.get_50k_amp_drain_current`
+
         """
         return self._fiftyk_amp_Vd_series_resistor
 
@@ -509,6 +522,7 @@ class SmurfConfigPropertiesMixin(object):
         See Also
         --------
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.get_50k_amp_drain_current`
+
         """
         return self._fiftyk_Id_offset
 

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -25,26 +25,32 @@ class SmurfConfigPropertiesMixin(object):
     
     The :class:`SmurfConfigPropertiesMixin` class has only one
     function :func:`copy_config_to_properties` which can populate the
-    properties from a provided :class:`SmurfConfig` class instance.
-    The :func:`copy_config_to_properties` is called once to populate
-    all of the :class:`SmurfConfigPropertiesMixin` attributes by a
-    call to the :func:`SmurfControl:initialize` function in the
-    :class:`SmurfControl` constructor (unless the
-    :class:`SmurfControl` instance is not instantiated with a
-    configuration file).
+    properties from a provided
+    :class:`~pysmurf.client.command.smurf_config.SmurfConfig` class
+    instance.  The :func:`copy_config_to_properties` is called once to
+    populate all of the :class:`SmurfConfigPropertiesMixin` attributes
+    by a call to the
+    :func:`~pysmurf.client.command.smurf_control.SmurfControl.initialize`
+    function in the
+    :class:`~pysmurf.client.command.smurf_control.SmurfControl`
+    constructor (unless the
+    :class:`~pysmurf.client.command.smurf_control.SmurfControl`
+    instance is not instantiated with a configuration file).
 
     .. warning:: 
     	If a user changes the value of a property but then writes the
     	internal pysmurf configuration to disk with the
-    	:func:`SmurfControl.write_output()` function, the value
-    	written to the file will not reflect the user's change.
+    	:func:`~pysmurf.client.command.smurf_control.SmurfControl.write_output()`
+    	function, the value written to the file will not reflect the
+    	user's change.
 
     Examples
     --------
     Taking the `pA_per_phi0` property as an example, if `S` is a
-    :class:`SmurfControl` class instance, once the property has been
-    set with a call to the :func:`copy_config_to_properties` routine,
-    its value can be retrieved like this:
+    :class:`~pysmurf.client.command.smurf_control.SmurfControl` class
+    instance, once the property has been set with a call to the
+    :func:`copy_config_to_properties` routine, its value can be
+    retrieved like this:
 
     >>> S.pA_per_phi0
     9000000.0

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -19,10 +19,9 @@
 class SmurfConfigPropertiesMixin(object):
     """Mixin for loading pysmurf configuration parameters.
 
-    Defines properties used by pysmurf that can be populated from a
-    pysmurf configuration file.  More details on python properties can
-    be found in the documentation for python "Build-in Functions"
-    [1]_.
+    Defines properties used by pysmurf that are defined in the pysmurf
+    configuration file.  More details on python properties can be
+    found in the documentation for python "Build-in Functions" [1]_.
     
     Besides the properties, the :class:`SmurfConfigPropertiesMixin`
     has only one function :func:`copy_config_to_properties` which can
@@ -35,11 +34,13 @@ class SmurfConfigPropertiesMixin(object):
     :class:`SmurfControl` instance is not instantiated with a
     configuration file).
 
-    .. warning:: Currently, properties values can only be loaded from
-    a :class:`SmurfConfig` instance.  For example, if a user changes
-    the value of a property but then writes the internal pysmurf
-    configuration to disk with the :func:`SmurfControl.write_output()`
-    function, the value written to the file will be the unchanged.
+    .. warning:: 
+    	Currently, properties values can only be loaded from a
+    	:class:`SmurfConfig` class instance.  For example, if a user
+    	changes the value of a property but then writes the internal
+    	pysmurf configuration to disk with the
+    	:func:`SmurfControl.write_output()` function, the value
+    	written to the file will be the unchanged.
 
     Examples
     --------
@@ -61,7 +62,8 @@ class SmurfConfigPropertiesMixin(object):
     corresponding to each property have the same name as the property
     but with an underscore preceding the property name.  E.g. the
     internal attribute corresponding to the `pA_per_phi0` property is
-    called `_pA_per_phi0`.
+    called `_pA_per_phi0`.  Users should never set or get the internal
+    attribute.
 
     See Also
     --------

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -78,6 +78,8 @@ class SmurfConfigPropertiesMixin:
 
     """
 
+    # pylint: disable=too-many-instance-attributes
+
     def __init__(self, *args, **kwargs):
         """SmurfConfigPropertiesMixin constructor."""
         # Constants

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -41,8 +41,8 @@ class SmurfConfigPropertiesMixin(object):
     configuration to disk with the :func:`SmurfControl.write_output()`
     function, the value written to the file will be the unchanged.
 
-    Examples:
-    ---------
+    Examples
+    --------
     Taking the `pA_per_phi0` property as an example, if `S` is a
     :class:`SmurfControl` class instance, once the property has been
     set with a call to the :func:`copy_config_to_properties` routine,
@@ -63,12 +63,12 @@ class SmurfConfigPropertiesMixin(object):
     internal attribute corresponding to the `pA_per_phi0` property is
     called `_pA_per_phi0`.
 
-    See Also:
-    ---------
+    See Also
+    --------
     SmurfControl.initialize
 
-    References:
-    -----------
+    References
+    ----------
     .. [1] https://docs.python.org/3/library/functions.html#property
     """
 

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -26,7 +26,7 @@ class SmurfConfigPropertiesMixin(object):
     The :class:`SmurfConfigPropertiesMixin` class has only one
     function :func:`copy_config_to_properties` which can populate the
     properties from a provided
-    :class:`~pysmurf.client.command.smurf_config.SmurfConfig` class
+    :class:`~pysmurf.client.base.smurf_config.SmurfConfig` class
     instance.  The :func:`copy_config_to_properties` is called once to
     populate all of the :class:`SmurfConfigPropertiesMixin` attributes
     by a call to the
@@ -59,14 +59,14 @@ class SmurfConfigPropertiesMixin(object):
 
     >>> S.pA_per_phi0 = 9000000.0
 
-    Each property has a corresponding attribute that the property
-    get/set operates on and which is used internally in all pysmurf
-    functions that rely on the property.  The internal attributes
-    corresponding to each property have the same name as the property
-    but with an underscore preceding the property name.  E.g. the
-    internal attribute corresponding to the `pA_per_phi0` property is
-    called `_pA_per_phi0`.  Users should never set or get the internal
-    attribute.
+    Each property has a corresponding class instance internal
+    attribute that the property get/set operates on and which is used
+    internally in all pysmurf functions that rely on the property.
+    The internal attributes corresponding to each property have the
+    same name as the property but with an underscore preceding the
+    property name.  E.g. the internal attribute corresponding to the
+    `pA_per_phi0` property is called `_pA_per_phi0`.  Users should
+    never set or get the internal attribute directly.
 
     See Also
     --------

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -17,7 +17,59 @@
 """
 
 class SmurfConfigPropertiesMixin(object):
-    """Mixin for ???x
+    """Mixin for loading pysmurf configuration parameters.
+
+    Defines properties used by pysmurf that can be populated from a
+    pysmurf configuration file.  More details on python properties can
+    be found in the documentation for python "Build-in Functions"
+    [1]_.
+    
+    Besides the properties, the :class:`SmurfConfigPropertiesMixin`
+    has only one function :func:`copy_config_to_properties` which can
+    populate the defined properties from a provided
+    :class:`SmurfConfig` class instance.  The
+    :func:`copy_config_to_properties` is called once to populate all
+    of the :class:`SmurfConfigPropertiesMixin` attributes by a call to
+    the :func:`SmurfControl:initialize` function in the
+    :class:`SmurfControl` constructor (unless the
+    :class:`SmurfControl` instance is not instantiated with a
+    configuration file).
+
+    .. warning:: Currently, properties values can only be loaded from
+    a :class:`SmurfConfig` instance.  For example, if a user changes
+    the value of a property but then writes the internal pysmurf
+    configuration to disk with the :func:`SmurfControl.write_output()`
+    function, the value written to the file will be the unchanged.
+
+    Examples:
+    ---------
+    Taking the `pA_per_phi0` property as an example, if `S` is a
+    :class:`SmurfControl` class instance, once the property has been
+    set with a call to the :func:`copy_config_to_properties` routine,
+    its value can be retrieved like this:
+
+    >>> S.pA_per_phi0
+    9000000.0
+    
+    and it can be gotten like this:
+
+    >>> S.pA_per_phi0 = 9000000.0
+
+    Each property has a corresponding attribute that the property
+    get/set operates on and which is used internally in all pysmurf
+    functions that rely on the property.  The internal attributes
+    corresponding to each property have the same name as the property
+    but with an underscore preceding the property name.  E.g. the
+    internal attribute corresponding to the `pA_per_phi0` property is
+    called `_pA_per_phi0`.
+
+    See Also:
+    ---------
+    SmurfControl.initialize
+
+    References:
+    -----------
+    .. [1] https://docs.python.org/3/library/functions.html#property
     """
 
     def __init__(self, *args, **kwargs):

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -30,24 +30,24 @@ class SmurfConfigPropertiesMixin(object):
     instance.  The :func:`copy_config_to_properties` is called once to
     populate all of the :class:`SmurfConfigPropertiesMixin` attributes
     by a call to the
-    :func:`~pysmurf.client.command.smurf_control.SmurfControl.initialize`
+    :func:`~pysmurf.client.base.smurf_control.SmurfControl.initialize`
     function in the
-    :class:`~pysmurf.client.command.smurf_control.SmurfControl`
+    :class:`~pysmurf.client.base.smurf_control.SmurfControl`
     constructor (unless the
-    :class:`~pysmurf.client.command.smurf_control.SmurfControl`
+    :class:`~pysmurf.client.base.smurf_control.SmurfControl`
     instance is not instantiated with a configuration file).
 
     .. warning:: 
     	If a user changes the value of a property but then writes the
     	internal pysmurf configuration to disk with the
-    	:func:`~pysmurf.client.command.smurf_control.SmurfControl.write_output()`
+    	:func:`~pysmurf.client.base.smurf_control.SmurfControl.write_output()`
     	function, the value written to the file will not reflect the
     	user's change.
 
     Examples
     --------
     Taking the `pA_per_phi0` property as an example, if `S` is a
-    :class:`~pysmurf.client.command.smurf_control.SmurfControl` class
+    :class:`~pysmurf.client.base.smurf_control.SmurfControl` class
     instance, once the property has been set with a call to the
     :func:`copy_config_to_properties` routine, its value can be
     retrieved like this:
@@ -55,7 +55,7 @@ class SmurfConfigPropertiesMixin(object):
     >>> S.pA_per_phi0
     9000000.0
     
-    and it can be gotten like this:
+    and it can be set like this:
 
     >>> S.pA_per_phi0 = 9000000.0
 
@@ -70,7 +70,7 @@ class SmurfConfigPropertiesMixin(object):
 
     See Also
     --------
-    SmurfControl.initialize
+    :func:`~pysmurf.client.base.smurf_control.SmurfControl.initialize`
 
     References
     ----------

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -15,7 +15,7 @@
 # -----------------------------------------------------------------------------
 """Defines the mixin class :class:`SmurfConfigPropertiesMixin`."""
 
-class SmurfConfigPropertiesMixin(object):
+class SmurfConfigPropertiesMixin:
     """Mixin for loading pysmurf configuration parameters.
 
     Defines properties used by pysmurf whose values are specified in
@@ -81,25 +81,25 @@ class SmurfConfigPropertiesMixin(object):
     def __init__(self, *args, **kwargs):
         """SmurfConfigPropertiesMixin constructor."""
         # Constants
-        self._pA_per_phi0=None
+        self._pA_per_phi0 = None
 
         # Amplifiers
         ## 4K HEMT
-        self._hemt_Vg=None
-        self._hemt_bit_to_V=None
-        self._hemt_Vd_series_resistor=None
-        self._hemt_Id_offset=None
-        self._hemt_gate_min_voltage=None
-        self._hemt_gate_max_voltage=None
+        self._hemt_Vg = None
+        self._hemt_bit_to_V = None
+        self._hemt_Vd_series_resistor = None
+        self._hemt_Id_offset = None
+        self._hemt_gate_min_voltage = None
+        self._hemt_gate_max_voltage = None
 
         ## 50K LNA
-        self._fiftyk_Vg=None
-        self._fiftyk_dac_num=None
-        self._fiftyk_bit_to_V=None
-        self._fiftyk_amp_Vd_series_resistor=None
-        self._fiftyk_Id_offset=None
+        self._fiftyk_Vg = None
+        self._fiftyk_dac_num = None
+        self._fiftyk_bit_to_V = None
+        self._fiftyk_amp_Vd_series_resistor = None
+        self._fiftyk_Id_offset = None
 
-    def copy_config_to_properties(self,config):
+    def copy_config_to_properties(self, config):
         """Copy values from SmurfConfig instance to properties.
 
         MORE EXPLANATION HERE. USES PROPERTY SETTERS IN CASE WE EVER
@@ -124,29 +124,29 @@ class SmurfConfigPropertiesMixin(object):
 
         ## 4K HEMT
         if 'hemt_Vg' in keys:
-            self.hemt_Vg=amp_cfg['hemt_Vg']
+            self.hemt_Vg = amp_cfg['hemt_Vg']
         if 'bit_to_V_hemt' in keys:
-            self.hemt_bit_to_V=amp_cfg['bit_to_V_hemt']
+            self.hemt_bit_to_V = amp_cfg['bit_to_V_hemt']
         if 'hemt_Vd_series_resistor' in keys:
-            self.hemt_Vd_series_resistor=amp_cfg['hemt_Vd_series_resistor']
+            self.hemt_Vd_series_resistor = amp_cfg['hemt_Vd_series_resistor']
         if 'hemt_Id_offset' in keys:
-            self.hemt_Id_offset=amp_cfg['hemt_Id_offset']
+            self.hemt_Id_offset = amp_cfg['hemt_Id_offset']
         if 'hemt_gate_min_voltage' in keys:
-            self.hemt_gate_min_voltage=amp_cfg['hemt_gate_min_voltage']
+            self.hemt_gate_min_voltage = amp_cfg['hemt_gate_min_voltage']
         if 'hemt_gate_max_voltage' in keys:
-            self.hemt_gate_max_voltage=amp_cfg['hemt_gate_max_voltage']
+            self.hemt_gate_max_voltage = amp_cfg['hemt_gate_max_voltage']
 
         ## 50K HEMT
         if 'LNA_Vg' in keys:
-            self.fiftyk_Vg=amp_cfg['LNA_Vg']
+            self.fiftyk_Vg = amp_cfg['LNA_Vg']
         if 'dac_num_50k' in keys:
-            self.fiftyk_dac_num=amp_cfg['dac_num_50k']
+            self.fiftyk_dac_num = amp_cfg['dac_num_50k']
         if 'bit_to_V_50k' in keys:
-            self.fiftyk_bit_to_V=amp_cfg['bit_to_V_50k']
+            self.fiftyk_bit_to_V = amp_cfg['bit_to_V_50k']
         if '50K_amp_Vd_series_resistor' in keys:
-            self.fiftyk_amp_Vd_series_resistor=amp_cfg['50K_amp_Vd_series_resistor']
+            self.fiftyk_amp_Vd_series_resistor = amp_cfg['50K_amp_Vd_series_resistor']
         if '50k_Id_offset' in keys:
-            self.fiftyk_Id_offset=amp_cfg['50k_Id_offset']
+            self.fiftyk_Id_offset = amp_cfg['50k_Id_offset']
 
     ###########################################################################
     ## Start pA_per_phi0 property definition
@@ -176,8 +176,8 @@ class SmurfConfigPropertiesMixin(object):
 
     # Setter
     @pA_per_phi0.setter
-    def pA_per_phi0(self,value):
-        self._pA_per_phi0=value
+    def pA_per_phi0(self, value):
+        self._pA_per_phi0 = value
 
     ## End pA_per_phi0 property definition
     ###########################################################################
@@ -202,8 +202,8 @@ class SmurfConfigPropertiesMixin(object):
 
     # Setter
     @hemt_Vg.setter
-    def hemt_Vg(self,value):
-        self._hemt_Vg=value
+    def hemt_Vg(self, value):
+        self._hemt_Vg = value
 
     ## End hemt_Vg property definition
     ###########################################################################
@@ -233,8 +233,8 @@ class SmurfConfigPropertiesMixin(object):
 
     # Setter
     @hemt_bit_to_V.setter
-    def hemt_bit_to_V(self,value):
-        self._hemt_bit_to_V=value
+    def hemt_bit_to_V(self, value):
+        self._hemt_bit_to_V = value
 
     ## End hemt_bit_to_V property definition
     ###########################################################################
@@ -268,8 +268,8 @@ class SmurfConfigPropertiesMixin(object):
 
     # Setter
     @hemt_Vd_series_resistor.setter
-    def hemt_Vd_series_resistor(self,value):
-        self._hemt_Vd_series_resistor=value
+    def hemt_Vd_series_resistor(self, value):
+        self._hemt_Vd_series_resistor = value
 
     ## End hemt_Vd_series_resistor property definition
     ###########################################################################
@@ -303,8 +303,8 @@ class SmurfConfigPropertiesMixin(object):
 
     # Setter
     @hemt_Id_offset.setter
-    def hemt_Id_offset(self,value):
-        self._hemt_Id_offset=value
+    def hemt_Id_offset(self, value):
+        self._hemt_Id_offset = value
 
     ## End hemt_Id_offset property definition
     ###########################################################################
@@ -334,8 +334,8 @@ class SmurfConfigPropertiesMixin(object):
 
     # Setter
     @hemt_gate_min_voltage.setter
-    def hemt_gate_min_voltage(self,value):
-        self._hemt_gate_min_voltage=value
+    def hemt_gate_min_voltage(self, value):
+        self._hemt_gate_min_voltage = value
 
     ## End hemt_gate_min_voltage property definition
     ###########################################################################
@@ -365,8 +365,8 @@ class SmurfConfigPropertiesMixin(object):
 
     # Setter
     @hemt_gate_max_voltage.setter
-    def hemt_gate_max_voltage(self,value):
-        self._hemt_gate_max_voltage=value
+    def hemt_gate_max_voltage(self, value):
+        self._hemt_gate_max_voltage = value
 
     ## End hemt_gate_max_voltage property definition
     ###########################################################################
@@ -391,8 +391,8 @@ class SmurfConfigPropertiesMixin(object):
 
     # Setter
     @fiftyk_Vg.setter
-    def fiftyk_Vg(self,value):
-        self._fiftyk_Vg=value
+    def fiftyk_Vg(self, value):
+        self._fiftyk_Vg = value
 
     ## End fiftyk_Vg property definition
     ###########################################################################
@@ -427,8 +427,8 @@ class SmurfConfigPropertiesMixin(object):
 
     # Setter
     @fiftyk_dac_num.setter
-    def fiftyk_dac_num(self,value):
-        self._fiftyk_dac_num=value
+    def fiftyk_dac_num(self, value):
+        self._fiftyk_dac_num = value
 
     ## End fiftyk_dac_num property definition
     ###########################################################################
@@ -458,8 +458,8 @@ class SmurfConfigPropertiesMixin(object):
 
     # Setter
     @fiftyk_bit_to_V.setter
-    def fiftyk_bit_to_V(self,value):
-        self._fiftyk_bit_to_V=value
+    def fiftyk_bit_to_V(self, value):
+        self._fiftyk_bit_to_V = value
 
     ## End fiftyk_bit_to_V property definition
     ###########################################################################
@@ -493,8 +493,8 @@ class SmurfConfigPropertiesMixin(object):
 
     # Setter
     @fiftyk_amp_Vd_series_resistor.setter
-    def fiftyk_amp_Vd_series_resistor(self,value):
-        self._fiftyk_amp_Vd_series_resistor=value
+    def fiftyk_amp_Vd_series_resistor(self, value):
+        self._fiftyk_amp_Vd_series_resistor = value
 
     ## End fiftyk_amp_Vd_series_resistor property definition
     ###########################################################################
@@ -528,8 +528,8 @@ class SmurfConfigPropertiesMixin(object):
 
     # Setter
     @fiftyk_Id_offset.setter
-    def fiftyk_Id_offset(self,value):
-        self._fiftyk_Id_offset=value
+    def fiftyk_Id_offset(self, value):
+        self._fiftyk_Id_offset = value
 
     ## End fiftyk_Id_offset property definition
     ###########################################################################

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -106,7 +106,7 @@ class SmurfConfigPropertiesMixin(object):
 
         See Also
         --------
-        :func:`~pysmurf.client.debug.smurf_noise.take_noise_psd`,
+        :func:`take_noise_psd`,
         :func:`~pysmurf.client.debug.smurf_noise.analyze_noise_vs_bias`,
         :func:`~pysmurf.client.debug.smurf_noise.analyze_noise_all_vs_noise_solo`,
         :func:`~pysmurf.client.debug.smurf_noise.analyze_noise_vs_tone`,

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -23,24 +23,21 @@ class SmurfConfigPropertiesMixin(object):
     configuration file.  More details on python properties can be
     found in the documentation for python "Built-in Functions" [1]_.
     
-    Besides the properties, the :class:`SmurfConfigPropertiesMixin`
-    has only one function :func:`copy_config_to_properties` which can
-    populate the defined properties from a provided
-    :class:`SmurfConfig` class instance.  The
-    :func:`copy_config_to_properties` is called once to populate all
-    of the :class:`SmurfConfigPropertiesMixin` attributes by a call to
-    the :func:`SmurfControl:initialize` function in the
+    The :class:`SmurfConfigPropertiesMixin` class has only one
+    function :func:`copy_config_to_properties` which can populate the
+    properties from a provided :class:`SmurfConfig` class instance.
+    The :func:`copy_config_to_properties` is called once to populate
+    all of the :class:`SmurfConfigPropertiesMixin` attributes by a
+    call to the :func:`SmurfControl:initialize` function in the
     :class:`SmurfControl` constructor (unless the
     :class:`SmurfControl` instance is not instantiated with a
     configuration file).
 
     .. warning:: 
-    	Currently, properties values can only be loaded from a
-    	:class:`SmurfConfig` class instance.  For example, if a user
-    	changes the value of a property but then writes the internal
-    	pysmurf configuration to disk with the
+    	If a user changes the value of a property but then writes the
+    	internal pysmurf configuration to disk with the
     	:func:`SmurfControl.write_output()` function, the value
-    	written to the file will be the unchanged.
+    	written to the file will not reflect the user's change.
 
     Examples
     --------

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -95,11 +95,12 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def pA_per_phi0(self):
-        """Demodulated phase to TES current conversion factor.
+        """Demodulated SQUID phase to TES current conversion factor.
 
         Gets or sets the conversion factor between the demodulated
-        phase for every SMuRF channel and the equivalent TES current.
-        Units are pA per Phi0, with Phi0 the magnetic flux quantum.
+        SQUID phase for every SMuRF channel and the equivalent TES
+        current.  Units are pA per Phi0, with Phi0 the magnetic flux
+        quantum.
 
         See Also
         --------
@@ -188,16 +189,15 @@ class SmurfConfigPropertiesMixin(object):
 
         The resistance of the resistor that is inline with the 4K HEMT
         amplifier drain voltage source which is used to infer the 4K
-        HEMT amplifier drain current.  This resistor is inline but
-        before the regulator that steps the main RF6.0V supply down to
-        the lower 4K HEMT drain voltage, so the current flowing
-        through this resistor includes both the drain current drawn by
-        the 4K HEMT and any additional current drawn by the DC/DC
-        regulator that steps the RF6.0V supply voltage down to the
-        lower drain voltage the cryostat card provides to the 4K HEMT.
-        The default value of 200 Ohm is the standard value loaded onto
-        cryostat card revision C02 (PC-248-103-02-C02).  The resistor
-        on that revision of the cryostat card is R44.  Units are Ohms.
+        HEMT amplifier drain current.  This resistor is inline with
+        but before the regulator that steps the main RF6.0V supply
+        down to the lower 4K HEMT drain voltage, so the current
+        flowing through this resistor includes both the drain current
+        drawn by the 4K HEMT and any additional current drawn by the
+        DC/DC regulator.  The default value of 200 Ohm is the standard
+        value loaded onto cryostat card revision C02
+        (PC-248-103-02-C02).  The resistor on that revision of the
+        cryostat card is R44.  Units are Ohms.
 
         See Also
         --------
@@ -226,13 +226,13 @@ class SmurfConfigPropertiesMixin(object):
         that steps the main RF6.0V supply down to the lower 4K HEMT
         drain voltage using an inline resistor (see
         :func:`hemt_Vd_series_resistor`), so the total measured
-        includes both the drain current drawn by the 4K HEMT and any
-        additional current drawn by the DC/DC regulator that steps the
-        RF6.0V supply voltage down to the lower drain voltage the
-        cryostat card provides to the 4K HEMT.  An accurate
-        measurement of the 4K drain current requires subtracting the
-        current drawn by that regulator.  This is the offset to
-        subtract off the measured value.  Units are milliamperes.
+        current through the series resistor includes both the drain
+        current drawn by the 4K HEMT and any additional current drawn
+        by the DC/DC regulator.  An accurate measurement of the 4K
+        amplifier drain current requires subtracting the current drawn
+        by that regulator from the measured total current.  This is
+        the offset to subtract off the measured value.  Units are
+        milliamperes.
 
         See Also
         --------
@@ -388,9 +388,19 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def fiftyk_amp_Vd_series_resistor(self):
-        """???
+        """50K amplifier drain current measurement resistor in Ohms.
 
-        ???
+        The resistance of the resistor that is inline with the 50K RF
+        amplifier drain voltage source which is used to infer the 50K
+        RF amplifier drain current.  This resistor is inline with but
+        before the regulator that steps the main RF6.0V supply down to
+        the lower 50K LNA drain voltage, so the current flowing
+        through this resistor includes both the drain current drawn by
+        the 50K RF amplifier and any additional current drawn by the
+        DC/DC regulator.  The default value of 10 Ohm is the standard
+        value loaded onto cryostat card revision C02
+        (PC-248-103-02-C02).  The resistor on that revision of the
+        cryostat card is R54.  Units are Ohms.
 
         See Also
         --------
@@ -413,9 +423,19 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def fiftyk_Id_offset(self):
-        """???
+        """50K amplifier drain current offset in mA.
 
-        ???
+        The 50K RF amplifier drain current is measured before the
+        regulator that steps the main RF6.0V supply down to the lower
+        50K RF amplifier drain voltage using an inline resistor (see
+        :func:`fiftyk_amp_Vd_series_resistor`), so the total measured
+        current through the series resistor includes both the drain
+        current drawn by the 50K RF amplifier and any additional
+        current drawn by the DC/DC regulator.  An accurate measurement
+        of the 50K amplifier drain current requires subtracting the
+        current drawn by that regulator from the measured total
+        current.  This is the offset to subtract off the measured
+        value.  Units are milliamperes.
 
         See Also
         --------

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -21,7 +21,7 @@ class SmurfConfigPropertiesMixin(object):
 
     Defines properties used by pysmurf that are defined in the pysmurf
     configuration file.  More details on python properties can be
-    found in the documentation for python "Build-in Functions" [1]_.
+    found in the documentation for python "Built-in Functions" [1]_.
     
     Besides the properties, the :class:`SmurfConfigPropertiesMixin`
     has only one function :func:`copy_config_to_properties` which can

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -104,7 +104,6 @@ class SmurfConfigPropertiesMixin(object):
 
         See Also
         --------
-        :func:`copy_config_to_properties`,
         :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.take_noise_psd`,
         :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_vs_bias`,
         :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_all_vs_noise_solo`,
@@ -136,7 +135,6 @@ class SmurfConfigPropertiesMixin(object):
 
         See Also
         --------
-        :func:`copy_config_to_properties`,
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.set_amplifier_bias`
         """
         return self._hemt_Vg
@@ -155,17 +153,17 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def hemt_bit_to_V(self):
-        """Bit to volts conversion for HEMT gate DAC.
+        """Bit to volts conversion for 4K HEMT gate DAC.
 
-        Conversion from bits (the digital value the RTM DAC is set to)
-        to Volts for the 4K amplifier gate (specified at the output of
-        the cryostat card).  An important dependency is the voltage
-        division on the cryostat card, which can be different from
-        cryostat card to cryostat card.  Units are Volts/bit.
+        Gets or sets the conversion from bits (the digital value the
+        RTM DAC is set to) to Volts for the 4K amplifier gate
+        (specified at the output of the cryostat card).  An important
+        dependency is the voltage division on the cryostat card, which
+        can be different from cryostat card to cryostat card.  Units
+        are Volts/bit.
 
         See Also
         --------
-        :func:`copy_config_to_properties`,
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`,
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_hemt_gate_voltage`
         """
@@ -187,21 +185,20 @@ class SmurfConfigPropertiesMixin(object):
     def hemt_Vd_series_resistor(self):
         """4K HEMT drain current measurement resistor in Ohms.
 
-        The resistance of the resistor that is inline with the 4K HEMT
-        amplifier drain voltage source which is used to infer the 4K
-        HEMT amplifier drain current.  This resistor is inline with
-        but before the regulator that steps the main RF6.0V supply
-        down to the lower 4K HEMT drain voltage, so the current
-        flowing through this resistor includes both the drain current
-        drawn by the 4K HEMT and any additional current drawn by the
-        DC/DC regulator.  The default value of 200 Ohm is the standard
-        value loaded onto cryostat card revision C02
+        Gets or sets the resistance of the resistor that is inline
+        with the 4K HEMT amplifier drain voltage source which is used
+        to infer the 4K HEMT amplifier drain current.  This resistor
+        is inline with but before the regulator that steps the main
+        RF6.0V supply down to the lower 4K HEMT drain voltage, so the
+        current flowing through this resistor includes both the drain
+        current drawn by the 4K HEMT and any additional current drawn
+        by the DC/DC regulator.  The default value of 200 Ohm is the
+        standard value loaded onto cryostat card revision C02
         (PC-248-103-02-C02).  The resistor on that revision of the
         cryostat card is R44.  Units are Ohms.
 
         See Also
         --------
-        :func:`copy_config_to_properties`,
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.get_hemt_drain_current`
         """
         return self._hemt_Vd_series_resistor
@@ -222,9 +219,9 @@ class SmurfConfigPropertiesMixin(object):
     def hemt_Id_offset(self):
         """4K HEMT drain current offset in mA.
 
-        The 4K HEMT drain current is measured before the regulator
-        that steps the main RF6.0V supply down to the lower 4K HEMT
-        drain voltage using an inline resistor (see
+        Gets or sets the 4K HEMT drain current is measured before the
+        regulator that steps the main RF6.0V supply down to the lower
+        4K HEMT drain voltage using an inline resistor (see
         :func:`hemt_Vd_series_resistor`), so the total measured
         current through the series resistor includes both the drain
         current drawn by the 4K HEMT and any additional current drawn
@@ -236,7 +233,6 @@ class SmurfConfigPropertiesMixin(object):
 
         See Also
         --------
-        :func:`copy_config_to_properties`,
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.get_hemt_drain_current`
         """
         return self._hemt_Id_offset
@@ -255,13 +251,18 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def hemt_gate_min_voltage(self):
-        """???
+        """4K HEMT gate voltage minimum software limit
 
-        ???
+        Gets or sets the minimum voltage the 4K HEMT gate voltage can
+        be set to using the
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`
+        function unless this software limit is overriden with the
+        boolean `override` argument of
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`.
+        Units are Volts.
 
         See Also
         --------
-        :func:`copy_config_to_properties`,
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`
         """
         return self._hemt_gate_min_voltage
@@ -280,13 +281,18 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def hemt_gate_max_voltage(self):
-        """???
+        """4K HEMT gate voltage maximum software limit
 
-        ???
+        Gets or sets the maximum voltage the 4K HEMT gate voltage can
+        be set to using the
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`
+        function unless this software limit is overriden with the
+        boolean `override` argument of
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`.
+        Units are Volts.
 
         See Also
         --------
-        :func:`copy_config_to_properties`,
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`
         """
         return self._hemt_gate_max_voltage
@@ -312,7 +318,6 @@ class SmurfConfigPropertiesMixin(object):
 
         See Also
         --------
-        :func:`copy_config_to_properties`,
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.set_amplifier_bias`
         """
         return self._fiftyk_Vg
@@ -331,13 +336,21 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def fiftyk_dac_num(self):
-        """???
+        """The RTM DAC number which is wired to the 50K LNA gate.
 
-        ???
+        Gets or sets the DAC number of the DAC on the RTM that is
+        wired to the 50K LNA gate.  Must be an integer between 1 and
+        32, at least for RTM main board revision C01
+        (PC-379-396-32-C01).  The DAC number corresponds to the number
+        on the RTM schematic (e.g. see the nets named DAC1,...,DAC32.
+        The connection between an RTM DAC and the 50K LNA gate is made
+        on the cryostat card.  The default RTM DAC that's wired to the
+        50K LNA gate for cryostat card revision C02
+        (PC-248-103-02-C02) is DAC32 (if JMP4 on the cryostat card is
+        populated correctly).
 
         See Also
         --------
-        :func:`copy_config_to_properties`,
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_50k_amp_gate_voltage`,
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_50k_amp_gate_voltage`,
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_50k_amp_enable`
@@ -358,17 +371,17 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def fiftyk_bit_to_V(self):
-        """Bit to volts conversion for 50K amplifier gate DAC.
+        """Bit to volts conversion for 50K LNA gate DAC.
 
-        Conversion from bits (the digital value the RTM DAC is set to)
-        to Volts for the 50K amplifier gate (specified at the output
-        of the cryostat card).  An important dependency is the voltage
-        division on the cryostat card, which can be different from
-        cryostat card to cryostat card.  Units are Volts/bit.
+        Gets or set the conversion from bits (the digital value the
+        RTM DAC is set to) to Volts for the 50K LNA gate (specified at
+        the output of the cryostat card).  An important dependency is
+        the voltage division on the cryostat card, which can be
+        different from cryostat card to cryostat card.  Units are
+        Volts/bit.
 
         See Also
         --------
-        :func:`copy_config_to_properties`,
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_50k_amp_gate_voltage`,
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_50k_amp_gate_voltage`
         """
@@ -388,23 +401,22 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def fiftyk_amp_Vd_series_resistor(self):
-        """50K amplifier drain current measurement resistor in Ohms.
+        """50K LNA drain current measurement resistor in Ohms.
 
-        The resistance of the resistor that is inline with the 50K RF
-        amplifier drain voltage source which is used to infer the 50K
-        RF amplifier drain current.  This resistor is inline with but
-        before the regulator that steps the main RF6.0V supply down to
-        the lower 50K LNA drain voltage, so the current flowing
-        through this resistor includes both the drain current drawn by
-        the 50K RF amplifier and any additional current drawn by the
-        DC/DC regulator.  The default value of 10 Ohm is the standard
-        value loaded onto cryostat card revision C02
+        Gets or sets the resistance of the resistor that is inline
+        with the 50K LNA drain voltage source which is used to infer
+        the 50K RF amplifier drain current.  This resistor is inline
+        with but before the regulator that steps the main RF6.0V
+        supply down to the lower 50K LNA drain voltage, so the current
+        flowing through this resistor includes both the drain current
+        drawn by the 50K RF amplifier and any additional current drawn
+        by the DC/DC regulator.  The default value of 10 Ohm is the
+        standard value loaded onto cryostat card revision C02
         (PC-248-103-02-C02).  The resistor on that revision of the
         cryostat card is R54.  Units are Ohms.
 
         See Also
         --------
-        :func:`copy_config_to_properties`,
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.get_50k_amp_drain_current`
         """
         return self._fiftyk_amp_Vd_series_resistor
@@ -425,21 +437,20 @@ class SmurfConfigPropertiesMixin(object):
     def fiftyk_Id_offset(self):
         """50K amplifier drain current offset in mA.
 
-        The 50K RF amplifier drain current is measured before the
-        regulator that steps the main RF6.0V supply down to the lower
-        50K RF amplifier drain voltage using an inline resistor (see
-        :func:`fiftyk_amp_Vd_series_resistor`), so the total measured
-        current through the series resistor includes both the drain
-        current drawn by the 50K RF amplifier and any additional
-        current drawn by the DC/DC regulator.  An accurate measurement
-        of the 50K amplifier drain current requires subtracting the
-        current drawn by that regulator from the measured total
-        current.  This is the offset to subtract off the measured
-        value.  Units are milliamperes.
+        Gets or sets the 50K RF amplifier drain current is measured
+        before the regulator that steps the main RF6.0V supply down to
+        the lower 50K RF amplifier drain voltage using an inline
+        resistor (see :func:`fiftyk_amp_Vd_series_resistor`), so the
+        total measured current through the series resistor includes
+        both the drain current drawn by the 50K RF amplifier and any
+        additional current drawn by the DC/DC regulator.  An accurate
+        measurement of the 50K amplifier drain current requires
+        subtracting the current drawn by that regulator from the
+        measured total current.  This is the offset to subtract off
+        the measured value.  Units are milliamperes.
 
         See Also
         --------
-        :func:`copy_config_to_properties`,
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.get_50k_amp_drain_current`
         """
         return self._fiftyk_Id_offset

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -106,14 +106,14 @@ class SmurfConfigPropertiesMixin(object):
 
         See Also
         --------
-        :func:`take_noise_psd`,
-        :func:`~pysmurf.client.debug.smurf_noise.analyze_noise_vs_bias`,
-        :func:`~pysmurf.client.debug.smurf_noise.analyze_noise_all_vs_noise_solo`,
-        :func:`~pysmurf.client.debug.smurf_noise.analyze_noise_vs_tone`,
-        :func:`~pysmurf.client.debug.smurf_iv.analyze_slow_iv`,
-        :func:`~pysmurf.client.util.smurf_util.bias_bump`,
-        :func:`~pysmurf.client.util.smurf_util.identify_bias_groups`, 
-        :func:`copy_config_to_properties`
+        :meth:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.take_noise_psd`,
+        :meth:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_vs_bias`,
+        :meth:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_all_vs_noise_solo`,
+        :meth:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_vs_tone`,
+        :meth:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.analyze_slow_iv`,
+        :meth:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.bias_bump`,
+        :meth:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.identify_bias_groups`, 
+        :meth:`copy_config_to_properties`
         """
         return self._pA_per_phi0
 

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -13,7 +13,7 @@
 # copied, modified, propagated, or distributed except according to the
 # terms contained in the LICENSE.txt file.
 # -----------------------------------------------------------------------------
-"""Defines the SmurfConfigPropertiesMixin class.
+"""Defines the mixin class :class:`SmurfConfigPropertiesMixin`.
 """
 
 class SmurfConfigPropertiesMixin(object):
@@ -95,8 +95,7 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def pA_per_phi0(self):
-        """Conversion factor between demodulated phase and TES
-        current.
+        """Demodulated phase to TES current conversion factor.
 
         Gets or sets the conversion factor between the demodulated
         phase for every SMuRF channel and the equivalent TES current.
@@ -129,10 +128,10 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def hemt_Vg(self):
-        """4K HEMT Gate Voltage
+        """4K HEMT gate voltage in volts.
 
-        Gets or sets the desired value for the 4K HEMT Gate voltage.
-        Units are Volts.
+        Gets or sets the desired value for the 4K HEMT gate voltage at
+        the output of the cryostat card.  Units are Volts.
 
         See Also
         --------
@@ -155,9 +154,13 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def hemt_bit_to_V(self):
-        """???
+        """Bit to volts conversion for HEMT gate DAC.
 
-        ???
+        Conversion from bits (the digital value the RTM DAC is set to)
+        to Volts for the 4K amplifier gate (specified at the output of
+        the cryostat card).  An important dependency is the voltage
+        division on the cryostat card, which can be different from
+        cryostat card to cryostat card.  Units are Volts/bit.
 
         See Also
         --------
@@ -181,9 +184,20 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def hemt_Vd_series_resistor(self):
-        """???
+        """4K HEMT drain current measurement resistor in Ohms.
 
-        ???
+        The resistance of the resistor that is inline with the 4K HEMT
+        amplifier drain voltage source which is used to infer the 4K
+        HEMT amplifier drain current.  This resistor is inline but
+        before the regulator that steps the main RF6.0V supply down to
+        the lower 4K HEMT drain voltage, so the current flowing
+        through this resistor includes both the drain current drawn by
+        the 4K HEMT and any additional current drawn by the DC/DC
+        regulator that steps the RF6.0V supply voltage down to the
+        lower drain voltage the cryostat card provides to the 4K HEMT.
+        The default value of 200 Ohm is the standard value loaded onto
+        cryostat card revision C02 (PC-248-103-02-C02).  The resistor
+        on that revision of the cryostat card is R44.  Units are Ohms.
 
         See Also
         --------
@@ -206,9 +220,19 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def hemt_Id_offset(self):
-        """???
+        """4K HEMT drain current offset in mA.
 
-        ???
+        The 4K HEMT drain current is measured before the regulator
+        that steps the main RF6.0V supply down to the lower 4K HEMT
+        drain voltage using an inline resistor (see
+        :func:`hemt_Vd_series_resistor`), so the total measured
+        includes both the drain current drawn by the 4K HEMT and any
+        additional current drawn by the DC/DC regulator that steps the
+        RF6.0V supply voltage down to the lower drain voltage the
+        cryostat card provides to the 4K HEMT.  An accurate
+        measurement of the 4K drain current requires subtracting the
+        current drawn by that regulator.  This is the offset to
+        subtract off the measured value.  Units are milliamperes.
 
         See Also
         --------
@@ -263,7 +287,7 @@ class SmurfConfigPropertiesMixin(object):
         See Also
         --------
         :func:`copy_config_to_properties`,
-        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`,
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_hemt_gate_voltage`
         """
         return self._hemt_gate_max_voltage
 
@@ -283,8 +307,13 @@ class SmurfConfigPropertiesMixin(object):
     def fiftyk_Vg(self):
         """50K LNA Gate Voltage
 
-        Gets or sets the desired value for the 50K LNA Gate voltage.
-        Units are Volts.
+        Gets or sets the desired value for the 50K LNA Gate voltage at
+        the output of the cryostat card.  Units are Volts.
+
+        See Also
+        --------
+        :func:`copy_config_to_properties`,
+        :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.set_amplifier_bias`
         """
         return self._fiftyk_Vg
 
@@ -305,6 +334,13 @@ class SmurfConfigPropertiesMixin(object):
         """???
 
         ???
+
+        See Also
+        --------
+        :func:`copy_config_to_properties`,
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_50k_amp_gate_voltage`,
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_50k_amp_gate_voltage`,
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_50k_amp_enable`
         """
         return self._fiftyk_dac_num
 
@@ -322,9 +358,19 @@ class SmurfConfigPropertiesMixin(object):
     # Getter
     @property
     def fiftyk_bit_to_V(self):
-        """???
+        """Bit to volts conversion for 50K amplifier gate DAC.
 
-        ???
+        Conversion from bits (the digital value the RTM DAC is set to)
+        to Volts for the 50K amplifier gate (specified at the output
+        of the cryostat card).  An important dependency is the voltage
+        division on the cryostat card, which can be different from
+        cryostat card to cryostat card.  Units are Volts/bit.
+
+        See Also
+        --------
+        :func:`copy_config_to_properties`,
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_50k_amp_gate_voltage`,
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_50k_amp_gate_voltage`
         """
         return self._fiftyk_bit_to_V
 
@@ -345,6 +391,11 @@ class SmurfConfigPropertiesMixin(object):
         """???
 
         ???
+
+        See Also
+        --------
+        :func:`copy_config_to_properties`,
+        :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.get_50k_amp_drain_current`
         """
         return self._fiftyk_amp_Vd_series_resistor
 
@@ -365,6 +416,11 @@ class SmurfConfigPropertiesMixin(object):
         """???
 
         ???
+
+        See Also
+        --------
+        :func:`copy_config_to_properties`,
+        :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.get_50k_amp_drain_current`
         """
         return self._fiftyk_Id_offset
 

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -32,8 +32,8 @@ class SmurfControl(SmurfCommandMixin,
         SmurfAtcaMonitorMixin, SmurfUtilMixin, SmurfTuneMixin,
         SmurfNoiseMixin, SmurfIVMixin,
         SmurfConfigPropertiesMixin):
-    
-    """Base class for controlling SMuRF. 
+
+    """Base class for controlling SMuRF.
 
     Loads all the mixins.  NEED LONGER DESCRIPTION OF THE SMURF
     CONTROL CLASS HERE.  Inherits from the following mixins:
@@ -241,7 +241,7 @@ class SmurfControl(SmurfCommandMixin,
         # Populate SmurfConfigPropertiesMixin properties with values
         # from loaded pysmurf configuration file.
         self.copy_config_to_properties(self.config)
-        
+
         # Mapping from attenuator numbers to bands
         att_cfg = self.config.get('attenuator')
         keys = att_cfg.keys()

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -15,18 +15,20 @@
 #-----------------------------------------------------------------------------
 """Defines the SmurfControl class.
 """
-import numpy as np
+import glob
 import os
 import time
-import glob
-from pysmurf.client.command.smurf_command import SmurfCommandMixin as SmurfCommandMixin
-from pysmurf.client.command.smurf_atca_monitor import SmurfAtcaMonitorMixin as SmurfAtcaMonitorMixin
-from pysmurf.client.util.smurf_util import SmurfUtilMixin as SmurfUtilMixin
-from pysmurf.client.tune.smurf_tune import SmurfTuneMixin as SmurfTuneMixin
-from pysmurf.client.debug.smurf_noise import SmurfNoiseMixin as SmurfNoiseMixin
-from pysmurf.client.debug.smurf_iv import SmurfIVMixin as SmurfIVMixin
+
+import numpy as np
+
 from pysmurf.client.base.smurf_config import SmurfConfig as SmurfConfig
 from pysmurf.client.base.smurf_config_properties import SmurfConfigPropertiesMixin as SmurfConfigPropertiesMixin
+from pysmurf.client.command.smurf_atca_monitor import SmurfAtcaMonitorMixin as SmurfAtcaMonitorMixin
+from pysmurf.client.command.smurf_command import SmurfCommandMixin as SmurfCommandMixin
+from pysmurf.client.debug.smurf_iv import SmurfIVMixin as SmurfIVMixin
+from pysmurf.client.debug.smurf_noise import SmurfNoiseMixin as SmurfNoiseMixin
+from pysmurf.client.tune.smurf_tune import SmurfTuneMixin as SmurfTuneMixin
+from pysmurf.client.util.smurf_util import SmurfUtilMixin as SmurfUtilMixin
 
 class SmurfControl(SmurfCommandMixin,
         SmurfAtcaMonitorMixin, SmurfUtilMixin, SmurfTuneMixin,

--- a/python/pysmurf/client/command/cryo_card.py
+++ b/python/pysmurf/client/command/cryo_card.py
@@ -103,8 +103,8 @@ class CryoCard():
         """
         Write the power supply enable signals.
 
-        Arguments
-        ---------
+        Args
+        ----
         enables (int): 2-bit number to set the power supplies enables.
            Bit 0 set the enable for HEMT power supply.
            Bit 1 set the enable for 50k power supply.
@@ -121,13 +121,13 @@ class CryoCard():
         """
         Read the power supply enable signals.
 
-        Arguments
-        ---------
+        Args
+        ----
         None
 
 
-        Return
-        ------
+        Returns
+        -------
         enables (int): 2-bit number with the status of the power supplies enables.
            Bit 0 for the HEMT power supply.
            Bit 1 for the 50k power supply.
@@ -141,12 +141,12 @@ class CryoCard():
         """
         Read the AC/DC mode relays readback status
 
-        Arguments
-        ---------
+        Args
+        ----
         None
 
-        Return
-        ------
+        Returns
+        -------
         status (int): 2-bit number with the readback relay status
             Bit 0: Status of FRN_RLY
             Bit 1: Status of FRP_RLY

--- a/python/pysmurf/client/command/smurf_atca_monitor.py
+++ b/python/pysmurf/client/command/smurf_atca_monitor.py
@@ -24,7 +24,7 @@ class SmurfAtcaMonitorMixin(SmurfBase):
         """
         Writes all current ATCA monitor values to a yml file.
 
-        Args:
+        Args
         ----
         val (str) : The path (including file name) to write the yml file to.
         """

--- a/python/pysmurf/client/command/smurf_cmd.py
+++ b/python/pysmurf/client/command/smurf_cmd.py
@@ -115,9 +115,10 @@ def acq_n_frames(S, num_rows, num_rows_reported, data_rate,
     """
     Sends the amount of data requested by the user in units of n_frames.
 
-    Args:
-    -----
-    n_frames (int); The number of frames to keep data streaming on.
+    Args
+    ----
+    n_frames : int
+        The number of frames to keep data streaming on.
     """
     start_acq(S, num_rows, num_rows_reported, data_rate, row_len)
     make_runfile(S.output_dir, num_rows=num_rows, data_rate=data_rate,

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -117,9 +117,10 @@ class SmurfCommandMixin(SmurfBase):
         new_epics_root (str) : Temporarily replaces current epics root with
             a new one.
 
-        Returns:
-        --------
-        ret : The requested value
+        Returns
+        -------
+        ret : str
+            The requested value
         """
         if new_epics_root is not None:
             self.log('Temporarily using new epics root: {}'.format(new_epics_root))
@@ -161,7 +162,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_rogue_version(self, as_str=True, **kwargs):
         """
-        Returns the rogue version
+        Returns
+        -------
+        ret : str
+            The rogue version
         """
         ret = self._caget(self.amcc + self._rogue_version,
                           **kwargs)
@@ -171,9 +175,12 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_enable(self, **kwargs):
         """
-        Returns the status of the global poll bit epics_root:AMCc:enable.
-        If False, pyrogue is not currently polling the server. PVs will
-        not be updating.
+        Returns
+        -------
+        str
+            The status of the global poll bit epics_root:AMCc:enable.
+            If False, pyrogue is not currently polling the server. PVs
+            will not be updating.
         """
         return self._caget(self.epics_root + self._global_poll_enable,
                            enable_poll=False, disable_poll=False, **kwargs)
@@ -193,9 +200,10 @@ class SmurfCommandMixin(SmurfBase):
            pulls the number of sub bands from the first band in the
            list of bands specified in the experiment.cfg.
 
-        Returns:
-        --------
-        n_subbands (int): The number of subbands in the band
+        Returns
+        -------
+        int
+            The number of subbands in the band.
         """
         if self.offline:
             return 128
@@ -224,9 +232,10 @@ class SmurfCommandMixin(SmurfBase):
            pulls the number of channels from the first band in the
            list of bands specified in the experiment.cfg.
 
-        Returns:
-        --------
-        n_channels (int): The number of channels in the band
+        Returns
+        -------
+        int
+            The number of channels in the band.
         """
         if self.offline:
             return 512  # Hard coded offline mode 512
@@ -254,14 +263,10 @@ class SmurfCommandMixin(SmurfBase):
            from the first band in the list of bands specified in the
            experiment.cfg.
 
-        Returns:
-        --------
-        n_processed_channels (int): The number of processed channels
-           in the band.  Right now, there's not any way to determine
-           this from exposed pyrogue variables, so for now, assuming
-           only the center 104 sub-bands are processed ; so 104
-           channels if there's 128 channels (as in X-ray), or 416
-           channels if there's 512 channels total (as in CMB).
+        Returns
+        -------
+        n_processed_channels : int
+            The number of processed channels in the band.
         """
         n_channels=self.get_number_channels(band)
 
@@ -573,9 +578,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Returns the tone file path that's currently being used for this bay.
 
-        Args:
+        Args
         ----
-        bay (int) : Which AMC bay (0 or 1).
+        bay : int
+            Which AMC bay (0 or 1).
         """
 
         ret=self._caget(self.dac_sig_gen.format(bay) + self._tone_file_path,**kwargs)
@@ -687,12 +693,15 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_eta_scan_freq(self, band, **kwargs):
         """
-        Args:
-        -----
-        band (int): The band to count
+        Args
+        ----
+        band : int
+            The band to count.
 
-        Returns:
-        freq (int) : The frequency of the scan
+        Returns
+        -------
+        freq : int
+            The frequency of the scan.
         """
         return self._caget(self._cryo_root(band) + self._eta_scan_freqs,
             **kwargs)
@@ -719,9 +728,10 @@ class SmurfCommandMixin(SmurfBase):
         -----
         band (int) : The band to set
 
-        Returns:
-        --------
-        amp (int) : The eta scan amplitude
+        Returns
+        -------
+        amp : int
+            The eta scan amplitude.
         """
         return self._caget(self._cryo_root(band) + self._eta_scan_amplitude,
             **kwargs)
@@ -748,9 +758,10 @@ class SmurfCommandMixin(SmurfBase):
         -----
         band (int) : The band to set
 
-        Returns:
-        --------
-        chan (int) : The channel that is being eta scanned
+        Returns
+        -------
+        chan : int
+            The channel that is being eta scanned.
         """
         return self._caget(self._cryo_root(band) + self._eta_scan_channel,
             **kwargs)
@@ -779,10 +790,11 @@ class SmurfCommandMixin(SmurfBase):
         -----
         band (int) : The band to set
 
-        Returns:
-        --------
-        eta_scan_averages (int) : The number of frequency error averages taken
-        at each point of the etaScan.
+        Returns
+        -------
+        eta_scan_averages : int
+            The number of frequency error averages taken at each point
+            of the etaScan.
         """
         return self._caget(self._cryo_root(band) + self._eta_scan_averages,
             **kwargs)
@@ -808,9 +820,10 @@ class SmurfCommandMixin(SmurfBase):
         -----
         band (int) : The band being eta scanned
 
-        Returns:
-        --------
-        dwell (int) : The time to dwell during an eta scan.
+        Returns
+        -------
+        dwell : int
+            The time to dwell during an eta scan.
         """
         return self._caget(self._cryo_root(band) + self._eta_scan_dwell,
             **kwargs)
@@ -836,9 +849,10 @@ class SmurfCommandMixin(SmurfBase):
         -----
         band (int) : The band that is being checked
 
-        Returns:
-        --------
-        status (int) : Whether the band is eta scanning.
+        Returns
+        -------
+        status : int
+            Whether the band is eta scanning.
         """
         return self._caget(self._cryo_root(band) + self._run_eta_scan, **kwargs)
 
@@ -853,9 +867,10 @@ class SmurfCommandMixin(SmurfBase):
         band (int) : The to get eta scans
         count (int) : The number of samples to read
 
-        Returns:
-        --------
-        resp (float array) : THe real component of the most recent eta scan
+        Returns
+        -------
+        resp : float array)
+            The real component of the most recent eta scan
         """
         return self._caget(self._cryo_root(band) + self._eta_scan_results_real,
             count=count, **kwargs)
@@ -871,9 +886,10 @@ class SmurfCommandMixin(SmurfBase):
         band (int) : The to get eta scans
         count (int) : The number of samples to read
 
-        Returns:
-        --------
-        resp (float array) : THe imaginary component of the most recent eta scan
+        Returns
+        -------
+        resp : float array
+            The imaginary component of the most recent eta scan
         """
         return self._caget(self._cryo_root(band) + self._eta_scan_results_imag,
             count=count, **kwargs)
@@ -908,9 +924,10 @@ class SmurfCommandMixin(SmurfBase):
         -----
         band (int) : The band to search.
 
-        Returns:
-        --------
-        amplitudes (array) : The tone amplitudes
+        Returns
+        -------
+        amplitudes : array
+            The tone amplitudes.
         """
         return self._caget(self._cryo_root(band) + self._amplitude_scale_array,
             **kwargs)
@@ -949,9 +966,10 @@ class SmurfCommandMixin(SmurfBase):
         -----
         band (int) : The band to search.
 
-        Returns:
-        --------
-        fb_on (boolean array) : An array of whether the feedback is on or off.
+        Returns
+        -------
+        fb_on : bool array
+            An array of whether the feedback is on or off.
         """
         return self._caget(self._cryo_root(band) + self._feedback_enable_array,
             **kwargs)
@@ -1607,10 +1625,10 @@ class SmurfCommandMixin(SmurfBase):
            pulls the channel frequency from the first band in the
            list of bands specified in the experiment.cfg.
 
-        Returns:
-        --------
-        channel_frequency_mhz (float): The rate at which channels in
-           this band are processed.
+        Returns
+        -------
+        channel_frequency_mhz : float
+            The rate at which channels in this band are processed.
         """
 
         if band is None:
@@ -1639,10 +1657,10 @@ class SmurfCommandMixin(SmurfBase):
            pulls the digitizer frequency from the first band in the
            list of bands specified in the experiment.cfg.
 
-        Returns:
-        --------
-        digitizer_frequency_mhz (float): The digitizer frequency for
-           this band in MHz.
+        Returns
+        -------
+        digitizer_frequency_mhz : float
+            The digitizer frequency for this band in MHz.
         """
         if self.offline:
             return 614.4
@@ -1981,8 +1999,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_fpga_uptime(self, **kwargs):
         """
-        Returns:
-        uptime (float) : The FPGA uptime
+        Returns
+        -------
+        uptime : float
+            The FPGA uptime.
         """
         return self._caget(self.axi_version + self._fpga_uptime, **kwargs)
 
@@ -1990,8 +2010,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_fpga_version(self, **kwargs):
         """
-        Returns:
-        version (str) : The FPGA version
+        Returns
+        -------
+        version : str
+            The FPGA version.
         """
         return self._caget(self.axi_version + self._fpga_version, **kwargs)
 
@@ -1999,8 +2021,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_fpga_git_hash(self, **kwargs):
         """
-        Returns:
-        git_hash (str) : The git hash of the FPGA
+        Returns
+        -------
+        git_hash : str
+            The git hash of the FPGA.
         """
         gitHash=self._caget(self.axi_version + self._fpga_git_hash, **kwargs)
         return ''.join([str(s, encoding='UTF-8') for s in gitHash])
@@ -2009,8 +2033,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_fpga_git_hash_short(self, **kwargs):
         """
-        Returns:
-        git_hash_short (str) : The short git hash of the FPGA
+        Returns
+        -------
+        git_hash_short : str
+            The short git hash of the FPGA.
         """
         gitHashShort=self._caget(self.axi_version + self._fpga_git_hash_short, **kwargs)
         return ''.join([str(s, encoding='UTF-8') for s in gitHashShort])
@@ -2020,8 +2046,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_fpga_build_stamp(self, **kwargs):
         """
-        Returns:
-        build_stamp (str) : The FPGA build stamp
+        Returns
+        -------
+        build_stamp : str
+            The FPGA build stamp.
         """
         return self._caget(self.axi_version + self._fpga_build_stamp, **kwargs)
 
@@ -2774,9 +2802,10 @@ class SmurfCommandMixin(SmurfBase):
                     outside of the valid range is provided (must be
                     within [1,32]), will assert.
 
-        Returns:
-        --------
-        val (int) : The DacCtrlReg setting for the requested DAC.
+        Returns
+        -------
+        val : int
+            The DacCtrlReg setting for the requested DAC.
         """
         assert (dac in range(1,33)),'dac must be an integer and in [1,32]'
 
@@ -2816,10 +2845,11 @@ class SmurfCommandMixin(SmurfBase):
         individually using the get_rtm_slow_dac_enable function
         (single versus multiple transactions).
 
-        Returns:
-        --------
-        val (int array) : An array containing the DacCtrlReg settings
-                          for all of the slow RTM DACs.
+        Returns
+        -------
+        val : int array
+            An array containing the DacCtrlReg settings for all of the
+            slow RTM DACs.
         """
         return self._caget(self.rtm_spi_max_root +
                            self._rtm_slow_dac_enable_array, **kwargs)
@@ -2866,11 +2896,12 @@ class SmurfCommandMixin(SmurfBase):
                     outside of the valid range is provided (must be
                     within [1,32]), will assert.
 
-        Returns:
-        --------
-        val (int) : The data register setting for the requested DAC,
-                    in DAC units.  The data register sets the output
-                    voltage of the DAC.
+        Returns
+        -------
+        val : int
+            The data register setting for the requested DAC, in DAC
+            units.  The data register sets the output voltage of the
+            DAC.
         """
         assert (dac in range(1,33)),'dac must be an integer and in [1,32]'
         return self._caget(self.rtm_spi_max_root +
@@ -2916,11 +2947,11 @@ class SmurfCommandMixin(SmurfBase):
         DACs.  The value in these registers set the output voltages of
         the DACs.
 
-        Returns:
-        -----
-        array (int array): Size (32,) array of DAC values, in DAC
-                           units.  The value of these registers set
-                           the output voltages of the DACs.
+        Returns
+        -------
+        array : int array
+            Size (32,) array of DAC values, in DAC units.  The value
+            of these registers set the output voltages of the DACs.
         """
         return self._caget(self.rtm_spi_max_root + self._rtm_slow_dac_data_array,
             **kwargs)
@@ -2950,9 +2981,10 @@ class SmurfCommandMixin(SmurfBase):
                     outside of the valid range is provided (must be
                     within [1,32]), will assert.
 
-        Returns:
-        --------
-        val (float) : The DAC voltage in volts.
+        Returns
+        -------
+        val : float
+            The DAC voltage in volts.
         """
         assert (dac in range(1,33)),'dac must be an integer and in [1,32]'
         return self._rtm_slow_dac_bit_to_volt * self.get_rtm_slow_dac_data(dac, **kwargs)
@@ -2982,10 +3014,10 @@ class SmurfCommandMixin(SmurfBase):
         get_rtm_slow_dac_volt function (single versus multiple
         transactions).
 
-        Returns:
-        -----
-        volt_array (float array): Size (32,) array of DAC values in
-                                  volts.
+        Returns
+        -------
+        volt_array : float array
+            Size (32,) array of DAC values in volts.
         """
         return self._rtm_slow_dac_bit_to_volt * self.get_rtm_slow_dac_data_array(**kwargs)
 
@@ -3287,14 +3319,15 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the datafile that streaming data is written to.
 
-        Returns:
-        --------
-        datafile (str or length 300 int array): The name of the datafile
-
         Opt Args:
         ---------
         as_string (bool): The output data returns as a string. If False, the
             input data must be a length 300 character int. Default True.
+
+        Returns
+        -------
+        datafile : str or length 300 int array
+            The name of the datafile.
         """
         datafile = self._caget(self.streaming_root + self._stream_datafile,
             **kwargs)
@@ -3319,9 +3352,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the streaming file status. 1 is streaming, 0 is not.
 
-        Returns:
-        --------
-        val (int): The streaming status.
+        Returns
+        -------
+        val : int
+            The streaming status.
         """
         return self._caget(self.streaming_root + self._streaming_file_open,
             **kwargs)
@@ -3333,9 +3367,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the slot number of the crate that the carrier is installed into.
 
-        Returns:
-        --------
-        val (int): The slot number of the crate that the carrier is installed into.
+        Returns
+        -------
+        val : int
+            The slot number of the crate that the carrier is installed into.
         """
         return self._caget(self.amc_carrier_bsi + self._slot_number, **kwargs)
 
@@ -3346,9 +3381,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the crate id.
 
-        Returns:
-        --------
-        val (int): The crate id.
+        Returns
+        -------
+        val : int
+            The crate id.
         """
         return self._caget(self.amc_carrier_bsi + self._crate_id, **kwargs)
 
@@ -3362,9 +3398,10 @@ class SmurfCommandMixin(SmurfBase):
         Gets the temperature of the UltraScale+ FPGA.  Returns float32,
         the temperature in degrees Celsius.
 
-        Returns:
-        --------
-        val (float): The UltraScale+ FPGA temperature in degrees Celsius.
+        Returns
+        -------
+        val : float
+            The UltraScale+ FPGA temperature in degrees Celsius.
         """
         return self._caget(self.epics_root + self.fpga_root + self._fpga_temperature, **kwargs)
 
@@ -3372,9 +3409,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_fpga_vccint(self, **kwargs):
         """
-        Returns:
-        --------
-        val (float): The UltraScale+ FPGA VccInt in Volts.
+        Returns
+        -------
+        val : float
+            The UltraScale+ FPGA VccInt in Volts.
         """
         return self._caget(self.epics_root + self.fpga_root + self._fpga_vccint, **kwargs)
 
@@ -3382,9 +3420,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_fpga_vccaux(self, **kwargs):
         """
-        Returns:
-        --------
-        val (float): The UltraScale+ FPGA VccAux in Volts.
+        Returns
+        -------
+        val : float
+            The UltraScale+ FPGA VccAux in Volts.
         """
         return self._caget(self.epics_root + self.fpga_root + self._fpga_vccaux, **kwargs)
 
@@ -3392,9 +3431,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_fpga_vccbram(self, **kwargs):
         """
-        Returns:
-        --------
-        val (float): The UltraScale+ FPGA VccBram in Volts.
+        Returns
+        -------
+        val : float
+            The UltraScale+ FPGA VccBram in Volts.
         """
         return self._caget(self.epics_root + self.fpga_root + self._fpga_vccbram, **kwargs)
 
@@ -3403,9 +3443,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_regulator_iout(self, **kwargs):
         """
-        Returns:
-        --------
-        value (float): Regulator current in amperes.
+        Returns
+        -------
+        value : float
+            Regulator current in amperes.
         """
         return self._caget(self.regulator + self._regulator_iout, **kwargs)
 
@@ -3413,9 +3454,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_regulator_temp1(self, **kwargs):
         """
-        Returns:
-        --------
-        value (float): Regulator PT temperature in C.
+        Returns
+        -------
+        value : float
+            Regulator PT temperature in C.
         """
         return self._caget(self.regulator + self._regulator_temp1, **kwargs)
 
@@ -3423,18 +3465,20 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_regulator_temp2(self, **kwargs):
         """
-        Returns:
-        --------
-        value (float): A regulator CTRL temperature in C.
+        Returns
+        -------
+        value : float
+            A regulator CTRL temperature in C.
         """
         return self._caget(self.regulator + self._regulator_temp2, **kwargs)
 
     # Cryo card comands
     def get_cryo_card_temp(self, enable_poll=False, disable_poll=False):
         """
-        Returns:
-        --------
-        temp (float): Temperature of the cryostat card in Celsius
+        Returns
+        -------
+        temp : float
+            Temperature of the cryostat card in Celsius.
         """
         if enable_poll:
             epics.caput(self.epics_root + self._global_poll_enable, True)
@@ -3449,9 +3493,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_cryo_card_hemt_bias(self, enable_poll=False, disable_poll=False):
         """
-        Returns:
-        --------
-        bias (float): The HEMT bias in volts
+        Returns
+        -------
+        bias : float
+            The HEMT bias in volts.
         """
         if enable_poll:
             epics.caput(self.epics_root + self._global_poll_enable, True)
@@ -3465,9 +3510,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_cryo_card_50k_bias(self, enable_poll=False, disable_poll=False):
         """
-        Returns:
-        --------
-        bias (float): The 50K bias in volts
+        Returns
+        -------
+        bias : float
+            The 50K bias in volts.
         """
         if enable_poll:
             epics.caput(self.epics_root + self._global_poll_enable, True)
@@ -3481,18 +3527,20 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_cryo_card_cycle_count(self, enable_poll=False, disable_poll=False):
         """
-        Returns:
-        --------
-        cycle_count (float): The cycle count
+        Returns
+        -------
+        cycle_count : float
+            The cycle count.
         """
         self.log('Not doing anything because not implement in cryo_card.py')
         # return self.C.read_cycle_count()
 
     def get_cryo_card_relays(self, enable_poll=False, disable_poll=False):
         """
-        Returns:
-        --------
-        relays (hex): The cryo card relays value
+        Returns
+        -------
+        relays : hex
+            The cryo card relays value.
         """
         if enable_poll:
             epics.caput(self.epics_root + self._global_poll_enable, True)
@@ -3571,9 +3619,6 @@ class SmurfCommandMixin(SmurfBase):
         Args:
         -----
         enable (bool): Power supply enable (True = enable, False = disable)
-        Returns:
-        --------
-        None
         """
         if write_log:
             self.log('Writing HEMT PS enable using cryo_card object '+
@@ -3598,9 +3643,6 @@ class SmurfCommandMixin(SmurfBase):
         Args:
         -----
         enable (bool): Power supply enable (True = enable, False = disable)
-        Returns:
-        --------
-        None
         """
         if write_log:
             self.log('Writing 50k PS enable using cryo_card object '+
@@ -3638,10 +3680,6 @@ class SmurfCommandMixin(SmurfBase):
          3 = both on
 
         Defaults to enable = 3, ie turn on both power supplies
-
-        Returns:
-        -----
-        None
         """
         if write_log:
             self.log('Writing Cryocard PS enable using cryo_card ' +
@@ -3652,19 +3690,21 @@ class SmurfCommandMixin(SmurfBase):
         """
         Read the cryo card power supply enable signals
 
-        Returns:
-        -----
-        enables (int): 2-bit number with status of the power supplies enables
-         Bit 0 for HEMT supply
-         Bit 1 for 50K supply
-         Bit == 1 means enabled
-         Bit == 0 means disabled
+        Returns
+        -------
+        enables : int
+            2-bit number with status of the power supplies enables
 
-         therefore:
-         0 = all off
-         1 = 50K on, HEMT off
-         2 = HEMT on, 50K off
-         3 = both on
+            Bit 0 for HEMT supply
+            Bit 1 for 50K supply
+            Bit == 1 means enabled
+            Bit == 0 means disabled
+        
+            therefore:
+            0 = all off
+            1 = 50K on, HEMT off
+            2 = HEMT on, 50K off
+            3 = both on
         """
         en_value = self.C.read_ps_en()
         return en_value
@@ -3674,12 +3714,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Get the cryo card HEMT power supply enable.
 
-        Args:
-        -----
-        None
-        Returns:
-        --------
-        enable (bool): Power supply enable (True = enable, False = disable)
+        Returns
+        -------
+        enable : bool
+            Power supply enable (True = enable, False = disable).
         """
 
         # Read the power supply enable word and extract the status of bit 0
@@ -3691,12 +3729,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set the cryo card HEMT power supply enable.
 
-        Args:
-        -----
-        None
-        Returns:
-        --------
-        enable (bool): Power supply enable (True = enable, False = disable)
+        Returns
+        -------
+        enable : bool
+            Power supply enable (True = enable, False = disable).
         """
 
         # Read the power supply enable word and extract the status of bit 1
@@ -3712,10 +3748,11 @@ class SmurfCommandMixin(SmurfBase):
         -----
         None
 
-        Returns:
-        --------
-        mode(str): return string describing the operation mode. If the relays readback
-        don't match, then the string 'ERROR' is returned.
+        Returns
+        -------
+        mode : str
+            String describing the operation mode. If the relays
+            readback don't match, then the string 'ERROR' is returned.
         """
 
         # Read the relays status

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -2202,7 +2202,7 @@ class SmurfCommandMixin(SmurfBase):
         val : int
             What val to set.
         convert : bool, optional, default True
-            Convert the output from a string of hex values to an int.        
+            Convert the output from a string of hex values to an int.
         """
         if convert:
             val = self.int_to_hex_string(val)
@@ -2932,7 +2932,7 @@ class SmurfCommandMixin(SmurfBase):
 
         Args
         ----
-        val : int array 
+        val : int array
             Length 32, addresses the DACs in DAC ordering.  If
             provided array is not length 32, asserts.
         """

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -130,7 +130,7 @@ class SmurfCommandMixin(SmurfBase):
 
         Returns
         -------
-        str
+        ret : str
             The requested value.
         """
         if new_epics_root is not None:
@@ -172,7 +172,8 @@ class SmurfCommandMixin(SmurfBase):
     _rogue_version = 'RogueVersion'
 
     def get_rogue_version(self, as_str=True, **kwargs):
-        """
+        """Get rogue version
+
         Returns
         -------
         ret : str
@@ -1441,9 +1442,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Trigger reset delay, set such that the ramp resets at the flux ramp glitch.  2.4 MHz ticks.
 
-        Args:
-        -----
-        band (int) : Which band.
+        Args
+        ----
+        band : int
+            Which band.
         """
         self._caput(self._band_root(band) + self._trigger_reset_delay, val, **kwargs)
 
@@ -1451,9 +1453,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Trigger reset delay, set such that the ramp resets at the flux ramp glitch.  2.4 MHz ticks.
 
-        Args:
-        -----
-        band (int) : Which band.
+        Args
+        ----
+        band : int
+            Which band.
         """
         return self._caget(self._band_root(band) + self._trigger_reset_delay, **kwargs)
 
@@ -1464,9 +1467,10 @@ class SmurfCommandMixin(SmurfBase):
         The flux ramp DAC value at which to start applying feedback in each flux ramp cycle.
         In 2.4 MHz ticks.
 
-        Args:
-        -----
-        band (int) : Which band.
+        Args
+        ----
+        band : int
+            Which band.
         """
         self._caput(self._band_root(band) + self._feedback_start, val, **kwargs)
 
@@ -1475,9 +1479,10 @@ class SmurfCommandMixin(SmurfBase):
         The flux ramp DAC value at which to start applying feedback in each flux ramp cycle.
         In 2.4 MHz ticks.
 
-        Args:
-        -----
-        band (int) : Which band.
+        Args
+        ----
+        band : int
+            Which band.
         """
         return self._caget(self._band_root(band) + self._feedback_start, **kwargs)
 
@@ -1488,9 +1493,10 @@ class SmurfCommandMixin(SmurfBase):
         The flux ramp DAC value at which to stop applying feedback in each flux ramp cycle.
         In 2.4 MHz ticks.
 
-        Args:
-        -----
-        band (int) : Which band.
+        Args
+        ----
+        band : int
+            Which band.
         """
         self._caput(self._band_root(band) + self._feedback_end, val, **kwargs)
 
@@ -1499,9 +1505,10 @@ class SmurfCommandMixin(SmurfBase):
         The flux ramp DAC value at which to stop applying feedback in each flux ramp cycle.
         In 2.4 MHz ticks.
 
-        Args:
-        -----
-        band (int) : Which band.
+        Args
+        ----
+        band : int
+            Which band.
         """
         return self._caget(self._band_root(band) + self._feedback_end, **kwargs)
 
@@ -1658,16 +1665,17 @@ class SmurfCommandMixin(SmurfBase):
         Returns the channel frequency in MHz.  The channel frequency
         is the rate at which channels are processed.
 
-        Optional Args:
-        --------------
-        band (int): Which band.  Default is None.  If none specified,
-           assumes all bands have the same channel frequency, and
-           pulls the channel frequency from the first band in the
-           list of bands specified in the experiment.cfg.
+        Args
+        ----
+        band : int or None, optional, default None
+           Which band.  If None, assumes all bands have the same
+           channel frequency, and pulls the channel frequency from the
+           first band in the list of bands specified in the
+           experiment.cfg.
 
         Returns
         -------
-        channel_frequency_mhz : float
+        float
             The rate at which channels in this band are processed.
         """
 
@@ -1690,16 +1698,17 @@ class SmurfCommandMixin(SmurfBase):
         """
         Returns the digitizer frequency in MHz.
 
-        Optional Args:
-        --------------
-        band (int): Which band.  Default is None.  If none specified,
-           assumes all bands have the same digitizer frequency, and
-           pulls the digitizer frequency from the first band in the
-           list of bands specified in the experiment.cfg.
+        Args
+        ----
+        band : int or None, optional, default None
+           Which band.  If None, assumes all bands have the same
+           channel frequency, and pulls the channel frequency from the
+           first band in the list of bands specified in the
+           experiment.cfg.
 
         Returns
         -------
-        digitizer_frequency_mhz : float
+        float
             The digitizer frequency for this band in MHz.
         """
         if self.offline:
@@ -1831,9 +1840,10 @@ class SmurfCommandMixin(SmurfBase):
         Assumes LB is plugged into bay 0,  corresponding to bands [0,1,2,3] and that
         HB is plugged into bay 1, corresponding to bands [4,5,6,7].
 
-        Args:
-        -----
-        b (int): Band number.
+        Args
+        ----
+        b : int
+            Band number.
         """
         if b in [0,1,2,3]:
             bay=0
@@ -1851,10 +1861,12 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set the upconverter attenuator
 
-        Args:
-        -----
-        b (int): The band number.
-        val (int): The attenuator value
+        Args
+        ----
+        b : int
+            The band number.
+        val : int
+            The attenuator value.
         """
         att = self.band_to_att(b)
         bay = self.band_to_bay(b)
@@ -1865,9 +1877,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Get the upconverter attenuator value
 
-        Args:
-        -----
-        b (int): The band number.
+        Args
+        ----
+        b : int
+            The band number.
         """
         att = self.band_to_att(b)
         bay = self.band_to_bay(b)
@@ -1881,10 +1894,12 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set the down-converter attenuator
 
-        Args:
-        -----
-        b (int): The band number.
-        val (int): The attenuator value
+        Args
+        ----
+        b : int
+            The band number.
+        val : int
+            The attenuator value
         """
         att = self.band_to_att(b)
         bay = self.band_to_bay(b)
@@ -1895,9 +1910,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Get the down-converter attenuator value
 
-        Args:
-        -----
-        b (int): The band number.
+        Args
+        ----
+        b : int
+            The band number.
         """
         att = self.band_to_att(b)
         bay = self.band_to_bay(b)
@@ -1920,10 +1936,12 @@ class SmurfCommandMixin(SmurfBase):
         """
         Get temperature of the DAC in celsius
 
-        Args:
-        -----
-        bay (int): Which bay [0 or 1].
-        dac (int): Which DAC no. [0 or 1].
+        Args
+        ----
+        bay : int
+            Which bay [0 or 1].
+        dac : int
+            Which DAC no. [0 or 1].
         """
         return self._caget(self.dac_root.format(bay,dac) + self._dac_temp, **kwargs)
 
@@ -1933,11 +1951,14 @@ class SmurfCommandMixin(SmurfBase):
         """
         Enables DAC
 
-        Args:
-        -----
-        bay (int): Which bay [0 or 1].
-        dac (int): Which DAC no. [0 or 1].
-        val (int): Value to set the DAC enable register to [0 or 1].
+        Args
+        ----
+        bay : int
+            Which bay [0 or 1].
+        dac : int
+            Which DAC no. [0 or 1].
+        val : int
+            Value to set the DAC enable register to [0 or 1].
         """
         self._caput(self.dac_root.format(bay,dac) + self._dac_enable, val, **kwargs)
 
@@ -1945,10 +1966,12 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets enable status of DAC
 
-        Args:
-        -----
-        bay (int): Which bay [0 or 1].
-        dac (int): Which DAC no. [0 or 1].
+        Args
+        ----
+        bay : int
+            Which bay [0 or 1].
+        dac : int
+            Which DAC no. [0 or 1].
         """
         return self._caget(self.dac_root.format(bay,dac) + self._dac_enable, **kwargs)
 
@@ -1974,11 +1997,14 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set DAC JesdRstN
 
-        Args:
-        -----
-        bay (int): Which bay [0 or 1].
-        dac (int): Which DAC no. [0 or 1].
-        val (int): Value to set JesdRstN to [0 or 1].
+        Args
+        ----
+        bay : int
+            Which bay [0 or 1].
+        dac : int
+            Which DAC no. [0 or 1].
+        val : int
+            Value to set JesdRstN to [0 or 1].
         """
         self._caput(self.dac_root.format(bay,dac) + self._jesd_reset_n, val, **kwargs)
 
@@ -2255,9 +2281,10 @@ class SmurfCommandMixin(SmurfBase):
         Sets the output path for the StreamDataWriter. This is what is
         used for take_debug_data.
 
-        Args:
-        -----
-        datafile_path (str) : The full path for the output.
+        Args
+        ----
+        datafile_path : str
+            The full path for the output.
         """
         self._caput(self.stream_data_writer_root + self._data_file,
             datafile_path, **kwargs)
@@ -2267,14 +2294,15 @@ class SmurfCommandMixin(SmurfBase):
         Gets the output path for the StreamDataWriter. This is what is
         used for take_debug_data.
 
-        Opt Args:
-        ---------
-        as_str (bool) : Whether to return the data as a string. Default
-            is True.
-
-        Ret:
+        Args
         ----
-        datafile_path (str) : The full path for the output.
+        as_str : bool, optional, default True
+            Whether to return the data as a string.
+
+        Returns
+        -------
+        ret : str
+            The full path for the output.
         """
         ret=self._caget(self.stream_data_writer_root +
                         self._data_file, **kwargs)
@@ -2372,15 +2400,16 @@ class SmurfCommandMixin(SmurfBase):
         is less than 2048 entries, the table is padded on the end with
         the value in the pad argument.
 
-        Args:
-        -----
-        arr (int array): Array of values to load into LUT table.  Each
-                         entry must be an integer and in [0,2^20).
-
-        Opt Args:
-        -----
-        pad (int): Value to pad end of array with if provided array's
-                   length is less than 2048.  Default is 0.
+        Args
+        ----
+        reg : int
+            LUT table index in [0,1].
+        arr : int array
+            Array of values to load into LUT table.  Each entry must
+            be an integer and in [0,2^20).
+        pad : int, optional, default 0
+            Value to pad end of array with if provided array's length
+            is less than 2048.  Default is 0.
         """
         # cast as numpy array
         lut_arr=np.pad(arr[:self._lut_table_array_length],
@@ -2451,10 +2480,11 @@ class SmurfCommandMixin(SmurfBase):
         repeats, otherwise if =0, waveform in LUT tables is only
         broadcast once on software trigger.
 
-        Args:
-        -----
-        val (int): Whether or not arbitrary waveform generation is
-                   continuous on software trigger.  Must be in [0,1].
+        Args
+        ----
+        val : int
+            Whether or not arbitrary waveform generation is continuous
+            on software trigger.  Must be in [0,1].
         """
         assert (val in range(2)), 'val must be in [0,1]'
         self._caput(self.rtm_lut_ctrl +
@@ -2470,11 +2500,11 @@ class SmurfCommandMixin(SmurfBase):
         RTM DACs.  This will cause the RTM to play the LUT tables only
         once.
 
-        Args:
-        -----
-        continuous (bool): Whether or not to continously broadcast the
-                           arbitrary waveform on software trigger.
-                           Default False.
+        Args
+        ----
+        continuous : bool, optional, default False
+            Whether or not to continously broadcast the arbitrary
+            waveform on software trigger.
         """
         if continuous is True:
             self.set_rtm_arb_waveform_continuous(1)
@@ -2523,10 +2553,11 @@ class SmurfCommandMixin(SmurfBase):
         Arbitrary waveforms are written to the slow RTM DACs with time
         between samples TimerSize*6.4ns.
 
-        Args:
-        -----
-        val (int): The value to set TimerSize to.  Must be an integer
-                   in [0,2**24).
+        Args
+        ----
+        val : int
+            The value to set TimerSize to.  Must be an integer in
+            [0,2**24).
         """
         assert (val in range(2**24)), 'reg must be in [0,16777216)'
         self._caput(self.rtm_lut_ctrl +
@@ -2556,10 +2587,11 @@ class SmurfCommandMixin(SmurfBase):
         11-bit number (must be in [0,2048), because that's the maximum
         length of the LUT tables that store the waveforms.
 
-        Args:
-        -----
-        val (int): The value to set MaxAddr to.  Must be an integer
-                   in [0,2048).
+        Args
+        ----
+        val : int
+            The value to set MaxAddr to.  Must be an integer in
+            [0,2048).
         """
         assert (val in range(2**11)), 'reg must be in [0,2048)'
         self._caput(self.rtm_lut_ctrl +
@@ -2588,13 +2620,12 @@ class SmurfCommandMixin(SmurfBase):
         Sets the enable for generation of arbitrary waveforms on the
         RTM slow DACs.
 
-        Args:
-        -----
-        val (int): The value to set enable to.
-           EnableCh = 0x0 is disable
-           0x1 is Addr[0]
-           0x2 is Addr[1]
-           0x3 is Addr[0] and Addr[1]
+        Args
+        ----
+        val : int
+            The value to set enable to.  EnableCh = 0x0 is disable,
+            0x1 is Addr[0], 0x2 is Addr[1], and 0x3 is Addr[0] and
+            Addr[1]
         """
         assert (val in range(4)), 'reg must be in [0,1,2,3]'
         self._caput(self.rtm_lut_ctrl +
@@ -2617,9 +2648,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_cpld_reset(self, val, **kwargs):
         """
-        Args:
-        -----
-        val (int) : Set to 1 for a cpld reset
+        Args
+        ----
+        val : int
+            Set to 1 for a cpld reset.
         """
         self._caput(self.rtm_cryo_det_root + self._cpld_reset, val, **kwargs)
 
@@ -2817,12 +2849,14 @@ class SmurfCommandMixin(SmurfBase):
         enable for normal operation, which only needs to be done once
         for each DAC in a boot session.
 
-        Args:
-        -----
-        dac (int) : Which DAC to command.  1-indexed.  If a DAC index
-                    outside of the valid range is provided (must be
-                    within [1,32]), will assert.
-        val (int) : Value to set the DAC enable to.
+        Args
+        ----
+        dac : int
+            Which DAC to command.  1-indexed.  If a DAC index outside
+            of the valid range is provided (must be within [1,32]),
+            will assert.
+        val : int
+            Value to set the DAC enable to.
         """
         assert (dac in range(1,33)),'dac must be an integer and in [1,32]'
 
@@ -2836,11 +2870,12 @@ class SmurfCommandMixin(SmurfBase):
         AD5790 analog output configuration for the requested DAC
         number.  Should be set to 0x2 in normal operation.
 
-        Args:
-        -----
-        dac (int) : Which DAC to query.  1-indexed.  If a DAC index
-                    outside of the valid range is provided (must be
-                    within [1,32]), will assert.
+        Args
+        ----
+        dac : int
+            Which DAC to query.  1-indexed.  If a DAC index outside of
+            the valid range is provided (must be within [1,32]), will
+            assert.
 
         Returns
         -------
@@ -2864,11 +2899,11 @@ class SmurfCommandMixin(SmurfBase):
         the set_rtm_slow_dac_enable function (single versus multiple
         transactions).
 
-        Args:
-        -----
-        val (int array): length 32, addresses the DACs in DAC
-                         ordering.  If provided array is not length
-                         32, asserts.
+        Args
+        ----
+        val : int array 
+            Length 32, addresses the DACs in DAC ordering.  If
+            provided array is not length 32, asserts.
         """
         assert (len(val)==32),'len(val) must be 32, the number of DACs in hardware.'
         self._caput(self.rtm_spi_max_root +
@@ -2901,15 +2936,16 @@ class SmurfCommandMixin(SmurfBase):
         Sets the data register for the requested DAC, which sets the
         output voltage of the DAC.
 
-        Args:
-        -----
-        dac (int) : Which DAC to command.  1-indexed.  If a DAC index
-                    outside of the valid range is provided (must be
-                    within [1,32]), will assert.
-        val (int) : The DAC voltage to set in DAC units.  Must be in
-                    [-2^19,2^19).  If requested value is less
-                    (greater) than -2^19 (2^19-1), sets DAC to -2^19
-                    (2^19-1).
+        Args
+        ----
+        dac : int
+            Which DAC to command.  1-indexed.  If a DAC index outside
+            of the valid range is provided (must be within [1,32]),
+            will assert.
+        val : int
+            The DAC voltage to set in DAC units.  Must be in
+            [-2^19,2^19).  If requested value is less (greater) than
+            -2^19 (2^19-1), sets DAC to -2^19 (2^19-1).
         """
         assert (dac in range(1,33)),'dac must be an integer and in [1,32]'
 
@@ -2930,15 +2966,16 @@ class SmurfCommandMixin(SmurfBase):
         Gets the value in the data register for the requested DAC,
         which sets the output voltage of the DAC.
 
-        Args:
-        -----
-        dac (int) : Which DAC to command.  1-indexed.  If a DAC index
-                    outside of the valid range is provided (must be
-                    within [1,32]), will assert.
+        Args
+        ----
+        dac : int
+            Which DAC to command.  1-indexed.  If a DAC index outside
+            of the valid range is provided (must be within [1,32]),
+            will assert.
 
         Returns
         -------
-        val : int
+        int
             The data register setting for the requested DAC, in DAC
             units.  The data register sets the output voltage of the
             DAC.
@@ -2955,15 +2992,14 @@ class SmurfCommandMixin(SmurfBase):
         Sets the data registers for all 32 DACs, which sets their
         output voltages.  Must provide all 32 values.
 
-        Args:
-        -----
-        val (int array): The DAC voltages to set in DAC units.  Each
-                         element of the array must Must be in
-                         [-2^19,2^19).  If a requested value is less
-                         (greater) than -2^19 (2^19-1), sets that DAC
-                         to -2^19 (2^19-1).  (32,) in DAC units.  If
-                         provided array is not 32 elements long,
-                         asserts.
+        Args
+        ----
+        val : int array
+            The DAC voltages to set in DAC units.  Each element of the
+            array must Must be in [-2^19,2^19).  If a requested value
+            is less (greater) than -2^19 (2^19-1), sets that DAC to
+            -2^19 (2^19-1).  (32,) in DAC units.  If provided array is
+            not 32 elements long, asserts.
         """
         assert (len(val)==32),'len(val) must be 32, the number of DACs in hardware.'
 
@@ -3000,12 +3036,14 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the output voltage for the requested DAC.
 
-        Args:
-        -----
-        dac (int) : Which DAC to command.  1-indexed.  If a DAC index
-                    outside of the valid range is provided (must be
-                    within [1,32]), will assert.
-        val (int) : The DAC voltage to set in volts.
+        Args
+        ----
+        dac : int
+            Which DAC to command.  1-indexed.  If a DAC index outside
+            of the valid range is provided (must be within [1,32]),
+            will assert.
+        val : int
+            The DAC voltage to set in volts.
         """
         assert (dac in range(1,33)),'dac must be an integer and in [1,32]'
         self.set_rtm_slow_dac_data(dac, val/self._rtm_slow_dac_bit_to_volt, **kwargs)
@@ -3015,15 +3053,16 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the current output voltage for the requested DAC.
 
-        Args:
-        -----
-        dac (int) : Which DAC to query.  1-indexed.  If a DAC index
-                    outside of the valid range is provided (must be
-                    within [1,32]), will assert.
+        Args
+        ----
+        dac : int
+            Which DAC to query.  1-indexed.  If a DAC index outside of
+            the valid range is provided (must be within [1,32]), will
+            assert.
 
         Returns
         -------
-        val : float
+        float
             The DAC voltage in volts.
         """
         assert (dac in range(1,33)),'dac must be an integer and in [1,32]'
@@ -3036,11 +3075,12 @@ class SmurfCommandMixin(SmurfBase):
         each DAC individually using the set_rtm_slow_dac_volt
         function (single versus multiple transactions).
 
-        Args:
-        -----
-        val (float array): TES biases to set for each DAC in
-                           Volts. Expects an array of size (32,).  If
-                           provided array is not 32 elements, asserts.
+        Args
+        ----
+        val : float array
+            TES biases to set for each DAC in Volts. Expects an array
+            of size (32,).  If provided array is not 32 elements,
+            asserts.
         """
         assert (len(val)==32),'len(val) must be 32, the number of DACs in hardware.'
         int_val = np.array(np.array(val) / self._rtm_slow_dac_bit_to_volt, dtype=int)
@@ -3065,14 +3105,14 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the 50K amplifier gate votlage.
 
-        Args:
-        -----
-        voltage (float) : The amplifier gate voltage between 0 and -1.
-
-        Opt Args:
-        ---------
-        override (bool) : Whether to override the software limit on the gate
-            voltage. This allows you to go outside the range of 0 and -1.
+        Args
+        ----
+        voltage : float
+            The amplifier gate voltage between 0 and -1.
+        override : bool, optional, default False
+            Whether to override the software limit on the gate
+            voltage. This allows you to go outside the range of 0 and
+            -1.
         """
         if (voltage > 0 or voltage < -1.) and not override:
             self.log('Voltage must be between -1 and 0. Doing nothing.')
@@ -3090,9 +3130,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the 50K amp bit to 2 for enable and 0 for disable.
 
-        Opt Args:
-        ---------
-        disable (bool) : Disable the 50K amplifier. Default False.
+        Args
+        ----
+        disable : bool, optional, default False
+            Disable the 50K amplifier.
         """
         if disable:
             self.set_rtm_slow_dac_enable(self._fiftyk_dac_num, 0, **kwargs)
@@ -3261,13 +3302,14 @@ class SmurfCommandMixin(SmurfBase):
     # I think...
     _hemt_v_enable = 'HemtBiasDacCtrlRegCh[33]'
 
-    def set_hemt_enable(self, disable=False, zero_gate=False, **kwargs):
+    def set_hemt_enable(self, disable=False, **kwargs):
         """
         Sets bit to 2 for enable and 0 for disable.
 
-        Opt Args:
-        ---------
-        disable (bool): If True, sets the bit to 0.
+        Args
+        ----
+        disable : bool, optional, default False
+            If True, sets the HEMT enable bit to 0.
         """
         if disable:
             self._caput(self.rtm_spi_max_root + self._hemt_v_enable, 0,
@@ -3280,15 +3322,13 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the HEMT gate voltage in units of volts.
 
-        Args:
-        -----
-        voltage (float): The voltage applied to the HEMT gate. Must be between
-            0 and .75.
-
-        Opt Args:
-        ---------
-        override (bool): Override thee limits on HEMT gate voltage. Default
-            False.
+        Args
+        ----
+        voltage : float
+            The voltage applied to the HEMT gate. Must be between 0
+            and .75.
+        override bool, optional, default False
+            Override thee limits on HEMT gate voltage.
         """
         self.set_hemt_enable()
         if (voltage > self._hemt_gate_max_voltage or voltage <
@@ -3309,13 +3349,12 @@ class SmurfCommandMixin(SmurfBase):
         There is a hardcoded maximum value. If exceeded, no voltage is set. This
         check can be ignored using the override optional argument.
 
-        Args:
-        -----
-        val (int) : The voltage in bits
-
-        Optional Args:
-        --------------
-        override (bool) : Allows exceeding the hardcoded limit. Default False.
+        Args
+        ----
+        val : int
+            The voltage in bits.
+        override : bool, optional, default False
+            Allows exceeding the hardcoded limit. Default False.
         """
         if val > 350E3 and not override:
             self.log('Input voltage too high. Not doing anything.' +
@@ -3341,14 +3380,13 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the datafile to write streaming data
 
-        Args:
-        -----
-        datafile (str or length 300 int array): The name of the datafile
-
-        Opt Args:
-        ---------
-        as_string (bool): The input data is a string. If False, the input
-            data must be a length 300 character int. Default True.
+        Args
+        ----
+        datafile : str or length 300 int array
+            The name of the datafile.
+        as_string : bool, optional, default True
+            The input data is a string. If False, the input data must
+            be a length 300 character int.
         """
         if as_string:
             datafile = [ord(x) for x in datafile]
@@ -3362,10 +3400,11 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the datafile that streaming data is written to.
 
-        Opt Args:
-        ---------
-        as_string (bool): The output data returns as a string. If False, the
-            input data must be a length 300 character int. Default True.
+        Args
+        ----
+        as_string : bool, optional, default True
+            The output data returns as a string. If False, the input
+            data must be a length 300 character int.
 
         Returns
         -------
@@ -3384,9 +3423,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the streaming file open. 1 for streaming on. 0 for streaming off.
 
-        Args:
-        -----
-        val (int): The streaming status
+        Args
+        ----
+        val : int
+            The streaming status.
         """
         self._caput(self.streaming_root + self._streaming_file_open, val,
             **kwargs)
@@ -3599,10 +3639,12 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets a single cryo card relay to the value provided
 
-        Args:
-        -----
-        bitPosition (int): Which bit to set.  Must be in [0-16].
-        oneOrZero (int): What value to set the bit to.  Must be either 0 or 1.
+        Args
+        ----
+        bitPosition : int
+            Which bit to set.  Must be in [0-16].
+        oneOrZero : int
+            What value to set the bit to.  Must be either 0 or 1.
         """
         assert (bitPosition in range(17)), 'bitPosition must be in [0,...,16]'
         assert (oneOrZero in [0,1]), 'oneOrZero must be either 0 or 1'
@@ -3619,9 +3661,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the cryo card relays
 
-        Args:
-        -----
-        relays (hex): The cryo card relays
+        Args
+        ----
+        relays : hex
+            The cryo card relays
         """
         if write_log:
             self.log('Writing relay using cryo_card object. {}'.format(relay))
@@ -3640,9 +3683,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Delatches the cryo card for a bit.
 
-        Args:
-        -----
-        bit (int): The bit to temporarily delatch
+        Args
+        ----
+        bit : int
+            The bit to temporarily delatch.
         """
         if enable_poll:
             epics.caput(self.epics_root + self._global_poll_enable, True)
@@ -3659,9 +3703,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set the cryo card HEMT power supply enable.
 
-        Args:
-        -----
-        enable (bool): Power supply enable (True = enable, False = disable)
+        Args
+        ----
+        enable : bool
+            Power supply enable (True = enable, False = disable).
         """
         if write_log:
             self.log('Writing HEMT PS enable using cryo_card object '+
@@ -3683,9 +3728,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set the cryo card 50k power supply enable.
 
-        Args:
-        -----
-        enable (bool): Power supply enable (True = enable, False = disable)
+        Args
+        ----
+        enable : bool
+            Power supply enable (True = enable, False = disable).
         """
         if write_log:
             self.log('Writing 50k PS enable using cryo_card object '+
@@ -3708,21 +3754,22 @@ class SmurfCommandMixin(SmurfBase):
         Write the cryo card power supply enables. Can use this to set both
         power supplies at once rather than setting them individually
 
-        Args:
-        -----
-        enables (int): 2-bit number with status of the power supplies enables
-         Bit 0 for HEMT supply
-         Bit 1 for 50K supply
-         Bit == 1 means enabled
-         Bit == 0 means disabled
+        Args
+        ----
+        enables : int, optional, default 3
+            2-bit number with status of the power supplies enables
+            Bit 0 for HEMT supply
+            Bit 1 for 50K supply
+            Bit == 1 means enabled
+            Bit == 0 means disabled
 
-         therefore:
-         0 = all off
-         1 = 50K on, HEMT off
-         2 = HEMT on, 50K off
-         3 = both on
+            therefore:
+            0 = all off
+            1 = 50K on, HEMT off
+            2 = HEMT on, 50K off
+            3 = both on
 
-        Defaults to enable = 3, ie turn on both power supplies
+            Default (enable=3) turns on both power supplies.
         """
         if write_log:
             self.log('Writing Cryocard PS enable using cryo_card ' +
@@ -3786,10 +3833,6 @@ class SmurfCommandMixin(SmurfBase):
     def get_cryo_card_ac_dc_mode(self):
         """
         Get the operation mode, AC or DC, based on the readback of the relays.
-
-        Args:
-        -----
-        None
 
         Returns
         -------
@@ -3927,10 +3970,12 @@ class SmurfCommandMixin(SmurfBase):
         """
         Toggles the physical reset line to DAC. Set to 1 then 0
 
-        Args:
-        -----
-        bay (int): Which bay [0 or 1].
-        dac (int): Which DAC no. [0 or 1].
+        Args
+        ----
+        bay : int
+            Which bay [0 or 1].
+        dac : int
+            Which DAC no. [0 or 1].
         """
         self._caput(self.DBG.format(bay) + self._dac_reset.format(dac), val,
                     **kwargs)
@@ -3939,10 +3984,12 @@ class SmurfCommandMixin(SmurfBase):
         """
         Reads the physical reset DAC register.  Will be either 0 or 1.
 
-        Args:
-        -----
-        bay (int): Which bay [0 or 1].
-        dac (int): Which DAC no. [0 or 1].
+        Args
+        ----
+        bay : int
+            Which bay [0 or 1].
+        dac : int
+            Which DAC no. [0 or 1].
         """
         return self._caget(self.DBG.format(bay) + self._dac_reset.format(dac),
                            **kwargs)
@@ -4030,9 +4077,10 @@ class SmurfCommandMixin(SmurfBase):
         Sets the mcetransmit debug bit. If 1, the debugger will
         print to the pyrogue screen.
 
-        Args:
-        -----
-        val (int): 0 or 1 for the debug bit
+        Args
+        ----
+        val : int
+            0 or 1 for the debug bit.
         """
         self._caput(self.epics_root + self._mcetransmit_debug, val,
                     **kwargs)
@@ -4045,9 +4093,10 @@ class SmurfCommandMixin(SmurfBase):
         must be incrementing if you are attempting to stream
         data.
 
-        Ret:
-        ----
-        frame_count (int) : The frame count number
+        Returns
+        -------
+        int
+            The frame count number
         """
         return self._caget(self.frame_rx_stats + self._frame_count,
                     **kwargs)
@@ -4058,10 +4107,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the size of the frame going into the smurf processor.
 
-        Ret:
-        ----
-        frame_size (int) : The size of the data frame into the
-            smurf processor.
+        Returns
+        -------
+        int
+            The size of the data frame into the smurf processor.
         """
         return self._caget(self.frame_rx_stats + self._frame_size,
                            **kwargs)
@@ -4091,9 +4140,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set the smurf processor channel mask.
 
-        Args:
-        -----
-        mask (list): the channel mask.
+        Args
+        ----
+        mask : list
+            The channel mask.
         """
         self._caput(self.smurf_processor + self._channel_mask,
                 mask, **kwargs)
@@ -4103,9 +4153,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the smuf processor channel mask.
 
-        Ret:
-        ----
-        mask (list) ; the channel mask
+        Returns
+        -------
+        mask : list
+            The channel mask.
         """
         return self._caget(self.smurf_processor + self._channel_mask,
             **kwargs)
@@ -4138,9 +4189,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set the smurf processor filter A coefficients.
 
-        Args:
-        -----
-        coef (list): the filter A coefficients.
+        Args
+        ----
+        coef : list
+            The filter A coefficients.
         """
         self._caput(self.smurf_processor + self._filter_a, coef, **kwargs)
 
@@ -4149,9 +4201,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the smurf processor filter A coefficients.
 
-        Ret:
-        -----
-        coef (list): the filter A coefficients.
+        Returns
+        -------
+        coef : list
+            The filter A coefficients.
         """
         if self.offline:  # FIX ME - STUPPID HARDCODE
             return np.array([ 1., -3.74145562,  5.25726624, -3.28776591, 0.77203984])
@@ -4164,9 +4217,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set the smurf processor filter B coefficients.
 
-        Args:
-        -----
-        coef (list): the filter B coefficients.
+        Args
+        ----
+        coef : list
+            The filter B coefficients.
         """
         self._caput(self.smurf_processor + self._filter_b, coef, **kwargs)
 
@@ -4175,9 +4229,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Get the smurf processor filter B coefficients.
 
-        Ret:
-        -----
-        coef (list): the filter B coefficients.
+        Returns
+        -------
+        coef : list
+            The filter B coefficients.
         """
         if self.offline:
             return np.array([5.28396689e-06, 2.11358676e-05, 3.17038014e-05,
@@ -4191,9 +4246,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set the smurf processor filter order.
 
-        Args:
-        -----
-        order (int): the filter order.
+        Args
+        ----
+        int
+            The filter order.
         """
         self._caput(self.smurf_processor + self._filter_order,
                 order, **kwargs)
@@ -4202,9 +4258,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Get the smurf processor filter order.
 
-        Args:
-        -----
-        order (int): the filter order.
+        Args
+        ----
+        int
+            The filter order.
         """
         return self._caget(self.smurf_processor + self._filter_order, **kwargs)
 
@@ -4215,9 +4272,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set the smurf processor filter gain.
 
-        Args:
-        -----
-        gain (float): the filter gain.
+        Args
+        ----
+        float
+            The filter gain.
         """
         self._caput(self.smurf_processor + self._filter_gain, gain, **kwargs)
 
@@ -4226,9 +4284,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Get the smurf processor filter gain.
 
-        Ret:
-        -----
-        gain (float): the filter gain.
+        Returns
+        -------
+        float
+            The filter gain.
         """
         return self._caget(self.smurf_processor + self._filter_gain, **kwargs)
 
@@ -4239,9 +4298,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set the smurf processor down-sampling factor.
 
-        Args:
-        -----
-        factor (int): the down-sampling factor.
+        Args
+        ----
+        int
+            The down-sampling factor.
         """
         self._caput(self.smurf_processor + self._downsampler_factor, factor,
             **kwargs)
@@ -4251,9 +4311,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Get the smurf processor down-sampling factor.
 
-        Ret:
-        -----
-        factor (int): the down-sampling factor.
+        Returns
+        -------
+        int
+            The down-sampling factor.
         """
         if self.offline:  # FIX ME - STUPID HARD CODE
             return 20
@@ -4268,9 +4329,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         If Disable is set to True, then the downsampling filter is off.
 
-        Args:
-        -----
-        disable_status (bool) : The status of the Disable bit.
+        Args
+        ----
+        bool
+            The status of the Disable bit.
         """
         self._caput(self.smurf_processor + self._filter_disable,
                     disable_status, **kwargs)
@@ -4279,9 +4341,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         If Disable is set to True, then the downsampling filter is off.
 
-        Ret:
-        ----
-        disable_status (bool) : The status of the Disable bit.
+        Returns
+        -------
+        bool
+            The status of the Disable bit.
         """
         return self._caget(self.smurf_processor + self._filter_disable,
                            **kwargs)
@@ -4293,9 +4356,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set the data file name.
 
-        Args:
-        -----
-        name (str): The file name.
+        Args
+        ----
+        str
+            The file name.
         """
         self._caput(self.smurf_processor + self._data_file_name, name, **kwargs)
 
@@ -4304,9 +4368,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Set the data file name.
 
-        Ret:
-        -----
-        name (str): The file name.
+        Returns
+        -------
+        str
+            The file name.
         """
         return self._caget(self.smurf_processor + self._data_file_name,
             **kwargs)
@@ -4351,10 +4416,11 @@ class SmurfCommandMixin(SmurfBase):
         to write to disk/stream. Payload size must be larger than
         the number of channels going into the channel mapper
 
-        Ret:
-        ----
-        payload_size (int) : The number of channels written to disk.
-            This is independent of the number of active channels.
+        Returns
+        -------
+        int
+            The number of channels written to disk.  This is
+            independent of the number of active channels.
         """
         return self._caget(self.channel_mapper + self._payload_size,
                            **kwargs)
@@ -4366,10 +4432,11 @@ class SmurfCommandMixin(SmurfBase):
         to write to disk/stream. Payload size must be larger than
         the number of channels going into the channel mapper
 
-        Args:
-        -----
-        payload_size (int) : The number of channels written to disk.
-            This is independent of the number of active channels.
+        Args
+        ----
+        int
+            The number of channels written to disk.  This is
+            independent of the number of active channels.
         """
         self._caput(self.channel_mapper + self._payload_size,
                     payload_size, **kwargs)

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -3742,7 +3742,7 @@ class SmurfCommandMixin(SmurfBase):
             Bit 1 for 50K supply
             Bit == 1 means enabled
             Bit == 0 means disabled
-        
+
             therefore:
             0 = all off
             1 = 50K on, HEMT off

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -34,27 +34,32 @@ class SmurfCommandMixin(SmurfBase):
         """
         Wrapper around pyrogue lcaput. Puts variables into epics
 
-        Args:
-        -----
-        cmd : The pyrogue command to be executed. Input as a string
-        val: The value to put into epics
-
-        Optional Args:
-        --------------
-        write_log (bool) : Whether to log the data or not. Default False
-        log_level (int):
-        execute (bool) : Whether to actually execute the command. Defualt True.
-        wait_before (int) : If not None, the number of seconds to wait before
-            issuing the command
-        wait_after (int) : If not None, the number of seconds to wait after
-            issuing the command
-        wait_done (bool) : Wait for the command to be finished before returning.
-            Default True.
-        enable_poll (bool) : Allows requests of all PVs. Default False.
-        disable_poll (bool) : Disables requests of all PVs after issueing command.
-            Default False.
-        new_epics_root (str) : Temporarily replaces current epics root with
-            a new one.
+        Args
+        ----
+        cmd : str
+            The pyrogue command to be executed.
+        val: any
+            The value to put into epics
+        write_log : bool, optional, default False
+            Whether to log the data or not.
+        execute : bool, optional, default True
+            Whether to actually execute the command.
+        wait_before : int, optional, default None
+            If not None, the number of seconds to wait before issuing
+            the command.
+        wait_after : int, optional, default None
+            If not None, the number of seconds to wait after issuing
+            the command.
+        wait_done : bool, optional, default True
+            Wait for the command to be finished before returning.
+        log_level : int, optional, default 0
+            Log level.
+        enable_poll : bool, optional, default False
+            Allows requests of all PVs.
+        disable_poll : bool, optional, default False
+            Disables requests of all PVs after issueing command.
+        new_epics_root : str, optional, default None
+            Temporarily replaces current epics root with a new one.
         """
         if new_epics_root is not None:
             self.log('Temporarily using new epics root: {}'.format(new_epics_root))
@@ -102,25 +107,31 @@ class SmurfCommandMixin(SmurfBase):
         """
         Wrapper around pyrogue lcaget. Gets variables from epics
 
-        Args:
-        -----
-        cmd : The pyrogue command to be exectued. Input as a string
-
-        Opt Args:
-        ---------
-        write_log : Whether to log the data or not. Default False
-        execute : Whether to actually execute the command. Defualt True.
-        count (int or None) : number of elements to return for array data
-        enable_poll (bool) : Allows requests of all PVs. Default False.
-        disable_poll (bool) : Disables requests of all PVs after issueing command.
-            Default False.
-        new_epics_root (str) : Temporarily replaces current epics root with
-            a new one.
+        Args
+        ----
+        cmd : str
+            The pyrogue command to be exectued.
+        write_log : bool, optional, default False
+            Whether to log the data or not.
+        execute : bool, optional, default True
+            Whether to actually execute the command.
+        count : int or None, optional, default None
+            Number of elements to return for array data.
+        log_level : int, optional, default 0
+            Log level.
+        enable_poll : bool, optional, default False
+            Allows requests of all PVs.
+        disable_poll : bool, optional, default False
+            Disables requests of all PVs after issueing command.
+        new_epics_root : str or None, optional, default None
+            Temporarily replaces current epics root with a new one.
+        yml : str or None, optional, default None
+            If not None, yaml file to parse for the result.
 
         Returns
         -------
-        ret : str
-            The requested value
+        str
+            The requested value.
         """
         if new_epics_root is not None:
             self.log('Temporarily using new epics root: {}'.format(new_epics_root))
@@ -193,12 +204,13 @@ class SmurfCommandMixin(SmurfBase):
         Returns the number of subbands in a band.
         To do - possibly hide this function.
 
-        Optional Args:
-        --------------
-        band (int): Which band.  Default is None.  If none specified,
-           assumes all bands have the same number of sub bands, and
-           pulls the number of sub bands from the first band in the
-           list of bands specified in the experiment.cfg.
+        Args
+        ----
+        band : int or None, optional, default None
+            Which band.  If None, assumes all bands have the same
+            number of sub bands, and pulls the number of sub bands
+            from the first band in the list of bands specified in the
+            experiment.cfg.
 
         Returns
         -------
@@ -225,12 +237,13 @@ class SmurfCommandMixin(SmurfBase):
         """
         Returns the number of channels in a band.
 
-        Optional Args:
-        --------------
-        band (int): Which band.  Default is None.  If none specified,
-           assumes all bands have the same number of channels, and
-           pulls the number of channels from the first band in the
-           list of bands specified in the experiment.cfg.
+        Args
+        ----
+        band : int or None, optional, default None
+            Which band.  If None, assumes all bands have the same
+            number of channels, and pulls the number of channels from
+            the first band in the list of bands specified in the
+            experiment.cfg.
 
         Returns
         -------
@@ -254,14 +267,13 @@ class SmurfCommandMixin(SmurfBase):
         """
         Returns the number of processed channels in a band.
 
-        Optional Args:
-        --------------
-        band (int): Which band.  Default is None.  The number of
-           channels processed per band depends on the total number of
-           channels.  If none specified, assumes all bands have the
-           same number of channels, and pulls the number of channels
-           from the first band in the list of bands specified in the
-           experiment.cfg.
+        Args
+        ----
+        band : int or None, optional, default None
+            Which band.  If None, assumes all bands have the same
+            number of channels, and pulls the number of channels from
+            the first band in the list of bands specified in the
+            experiment.cfg.
 
         Returns
         -------
@@ -437,15 +449,14 @@ class SmurfCommandMixin(SmurfBase):
         already be tuned close to the resontor dip. Use
         run_serial_gradient_descent to get it.
 
-        Args:
-        ----_
-        band (int) : The band to eta scan
-
-        Opt Args:
-        --------
-        sync_group (bool) : Whether to use the sync group to monitor
-            the PV. Defauult is True.
-        timeout (float) : The maximum amount of time to wait for the PV.
+        Args
+        ----
+        band  : int
+            The band to eta scan.
+        sync_group : bool, optional, default True
+            Whether to use the sync group to monitor the PV.
+        timeout : float, optional, default 240
+            The maximum amount of time to wait for the PV.
         """
 
         # need flux ramp off for this - enforce
@@ -470,15 +481,14 @@ class SmurfCommandMixin(SmurfBase):
         Does a brute force search for the resonator minima. Starts at
         the currently set frequency.
 
-        Args:
+        Args
         ----
-        band (int) : The band the min search
-
-        Opt Args:
-        --------
-        sync_group (bool) : Whether to use the sync group to monitor
-            the PV. Defauult is True.
-        timeout (float) : The maximum amount of time to wait for the PV.
+        band : int
+            The band the min search.
+        sync_group : bool, optional, default True
+            Whether to use the sync group to monitor the PV.
+        timeout : float, optional, default 240
+            The maximum amount of time to wait for the PV.
         """
         triggerPV = self._cryo_root(band) + self._run_serial_min_search
         monitorPV = self._cryo_root(band) + self._eta_scan_in_progress
@@ -497,16 +507,14 @@ class SmurfCommandMixin(SmurfBase):
         """
         Does a gradient descent search for the minimum.
 
-
-        Args:
+        Args
         ----
-        band (int) : The band the min search
-
-        Opt Args:
-        --------
-        sync_group (bool) : Whether to use the sync group to monitor
-            the PV. Defauult is True.
-        timeout (float) : The maximum amount of time to wait for the PV.
+        band : int
+            The band to run serial gradient descent on.
+        sync_group : bool, optional, default True
+            Whether to use the sync group to monitor the PV.
+        timeout : float, optional, default 240
+            The maximum amount of time to wait for the PV.
         """
 
         # need flux ramp off for this - enforce
@@ -527,11 +535,13 @@ class SmurfCommandMixin(SmurfBase):
 
     def sel_ext_ref(self, bay, **kwargs):
         """
-        Selects this bay to trigger off of external reference (through front panel)
+        Selects this bay to trigger off of external reference (through
+        front panel)
 
-        Args:
+        Args
         ----
-        bay (int) : which bay to set to ext ref.  Either 0 or 1.
+        bay : int
+            Which bay to set to ext ref.  Either 0 or 1.
         """
         assert (bay in [0,1]),'bay must be an integer and in [0,1]'
         triggerPV=self.microwave_mux_core.format(bay) + self._selextref
@@ -546,9 +556,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Dumps all PyRogue state variables to a yml file.
 
-        Args:
+        Args
         ----
-        val (str) : The path (including file name) to write the yml file to.
+        val : str
+            The path (including file name) to write the yml file to.
         """
         self._caput(self.epics_root + self._savestate,
                     val, **kwargs)
@@ -563,9 +574,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Writes the current (un-masked) PyRogue settings to a yml file.
 
-        Args:
+        Args
         ----
-        val (str) : The path (including file name) to write the yml file to.
+        val : str
+            The path (including file name) to write the yml file to.
         """
         self._caput(self.epics_root + self._saveconfig,
                     val, **kwargs)
@@ -595,10 +607,12 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the tone file path for this bay.
 
-        Args:
+        Args
         ----
-        bay (int) : Which AMC bay (0 or 1).
-        val (str) : Path (including csv file name) to tone file.
+        bay : int
+            Which AMC bay (0 or 1).
+        val : str
+            Path (including csv file name) to tone file.
         """
         # make sure file exists before setting
 
@@ -616,15 +630,14 @@ class SmurfCommandMixin(SmurfBase):
         """
         Loads tone file specified in tone_file_path.
 
-        Args:
+        Args
         ----
-        bay (int) : Which AMC bay (0 or 1).
-
-        Optional Args:
-        --------------
-        val (str) : Path (including csv file name) to tone file.  If
-                    none provided, assumes something valid has already
-                    been loaded into DacSigGen[#]:CsvFilePath
+        bay : int
+            Which AMC bay (0 or 1).
+        val : str or None, optional, default None
+            Path (including csv file name) to tone file.  If none
+            provided, assumes something valid has already been loaded
+            into DacSigGen[#]:CsvFilePath
         """
 
         # Set tone file path if provided.
@@ -682,10 +695,12 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the frequency to do the eta scan
 
-        Args:
-        -----
-        band (int) : The band to count
-        val (int) :  The frequency to scan
+        Args
+        ----
+        band : int
+            The band to count.
+        val : int
+            The frequency to scan.
         """
         self._caput(self._cryo_root(band) + self._eta_scan_freqs, val,
             **kwargs)
@@ -712,10 +727,12 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the amplitude of the eta scan.
 
-        Args:
-        -----
-        band (int) : The band to set
-        val (in) : The eta scan amplitude. Typical value is 9 to 11.
+        Args
+        ----
+        band : int
+            The band to set.
+        val : int
+            The eta scan amplitude. Typical value is 9 to 11.
         """
         self._caput(self._cryo_root(band) + self._eta_scan_amplitude, val,
             **kwargs)
@@ -724,9 +741,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the amplitude of the eta scan.
 
-        Args:
-        -----
-        band (int) : The band to set
+        Args
+        ----
+        band : int
+            The band to set.
 
         Returns
         -------
@@ -742,10 +760,12 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the channel to eta scan.
 
-        Args:
-        -----
-        band (int) : The band to set
-        val (int) : The channel to set
+        Args
+        ----
+        band : int
+            The band to set.
+        val : int
+            The channel to set.
         """
         self._caput(self._cryo_root(band) + self._eta_scan_channel, val,
             **kwargs)
@@ -754,9 +774,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the channel to eta scan.
 
-        Args:
-        -----
-        band (int) : The band to set
+        Args
+        ----
+        band : int
+            The band to set.
 
         Returns
         -------
@@ -773,10 +794,12 @@ class SmurfCommandMixin(SmurfBase):
         Sets the number of frequency error averages to take at each point of
         the etaScan.
 
-        Args:
-        -----
-        band (int) : The band to set
-        val (int) : The channel to set
+        Args
+        ----
+        band : int
+            The band to set.
+        val : int
+            The channel to set.
         """
         self._caput(self._cryo_root(band) + self._eta_scan_averages, val,
             **kwargs)
@@ -786,13 +809,14 @@ class SmurfCommandMixin(SmurfBase):
         Gets the number of frequency error averages taken at each point of
         the etaScan.
 
-        Args:
-        -----
-        band (int) : The band to set
+        Args
+        ----
+        band : int
+            The band to set.
 
         Returns
         -------
-        eta_scan_averages : int
+        int
             The number of frequency error averages taken at each point
             of the etaScan.
         """
@@ -805,10 +829,12 @@ class SmurfCommandMixin(SmurfBase):
         """
         Swets how long to dwell while eta scanning.
 
-        Args:
-        -----
-        band (int) : The band to eta scan.
-        val (int) : The time to dwell
+        Args
+        ----
+        band : int
+            The band to eta scan.
+        val : int
+            The time to dwell.
         """
         self._caput(self._cryo_root(band) + self._eta_scan_dwell, val, **kwargs)
 
@@ -816,9 +842,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets how long to dwell
 
-        Args:
-        -----
-        band (int) : The band being eta scanned
+        Args
+        ----
+        band : int
+            The band being eta scanned.
 
         Returns
         -------
@@ -834,10 +861,12 @@ class SmurfCommandMixin(SmurfBase):
         """
         Runs the eta scan. Set the channel using set_eta_scan_channel()
 
-        Args:
-        -----
-        band (int) : The band to eta scan.
-        val (bool) : Start the eta scan.
+        Args
+        ----
+        band : int
+            The band to eta scan.
+        val : bool
+            Start the eta scan.
         """
         self._caput(self._cryo_root(band) + self._run_eta_scan, val, **kwargs)
 
@@ -845,9 +874,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the status of eta scan.
 
-        Args:
-        -----
-        band (int) : The band that is being checked
+        Args
+        ----
+        band : int
+            The band that is being checked.
 
         Returns
         -------
@@ -862,15 +892,17 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the real component of the eta scan.
 
-        Args:
-        -----
-        band (int) : The to get eta scans
-        count (int) : The number of samples to read
+        Args
+        ----
+        band : int
+            The to get eta scans.
+        count : int
+            The number of samples to read.
 
         Returns
         -------
-        resp : float array)
-            The real component of the most recent eta scan
+        resp : float array
+            The real component of the most recent eta scan.
         """
         return self._caget(self._cryo_root(band) + self._eta_scan_results_real,
             count=count, **kwargs)
@@ -881,15 +913,17 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the imaginary component of the eta scan.
 
-        Args:
-        -----
-        band (int) : The to get eta scans
-        count (int) : The number of samples to read
+        Args
+        ----
+        band : int
+            The to get eta scans.
+        count : int
+            The number of samples to read.
 
         Returns
         -------
         resp : float array
-            The imaginary component of the most recent eta scan
+            The imaginary component of the most recent eta scan.
         """
         return self._caget(self._cryo_root(band) + self._eta_scan_results_imag,
             count=count, **kwargs)
@@ -920,9 +954,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the array of amplitudes
 
-        Args:
-        -----
-        band (int) : The band to search.
+        Args
+        ----
+        band : int
+            The band to search.
 
         Returns
         -------
@@ -938,10 +973,12 @@ class SmurfCommandMixin(SmurfBase):
         a more convenient wrapper for set_amplitude_scale_array to only change
         the channels that are on.
 
-        Args:
-        -----
-        band (int): the band to change
-        drive (int): tone power to change to
+        Args
+        ----
+        band : int
+            The band to change.
+        drive : int
+            Tone power to change to.
         """
 
         old_amp = self.get_amplitude_scale_array(band, **kwargs)
@@ -962,9 +999,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Gets the array of feedbacks enables
 
-        Args:
-        -----
-        band (int) : The band to search.
+        Args
+        ----
+        band : int
+            The band to search.
 
         Returns
         -------
@@ -980,9 +1018,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the singleChannelReadout bit.
 
-        Args:
-        -----
-        band (int): The band to set to single channel readout
+        Args
+        ----
+        band : int
+            The band to set to single channel readout.
         """
         self._caput(self._band_root(band) + self._single_channel_readout, val,
             **kwargs)
@@ -1000,9 +1039,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the singleChannelReadout2 bit.
 
-        Args:
-        -----
-        band (int): The band to set to single channel readout
+        Args
+        ----
+        band : int
+            The band to set to single channel readout.
         """
         self._caput(self._band_root(band) + self._single_channel_readout2, val,
             **kwargs)

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -2153,14 +2153,17 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_waveform_start_addr(self, bay, engine, val, convert=True, **kwargs):
         """
-        bay=Which bay.
-        engine=Which waveform engine.
-        val=What value to set.
-
-        Optional Arg:
-        -------------
-        convert (bool) : Convert the output from a string of hex values to an
-            int. Default (True)
+        Args
+        ----
+        bay : int
+            Which bay.
+        engine : int
+            Which waveform engine.
+        val : int or str
+            What value to set.
+        convert : bool, optional, default True
+            Convert the input from an integer to a string of hex
+            values before setting.
         """
         if convert:
             val = self.int_to_hex_string(val)
@@ -2169,13 +2172,14 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_waveform_start_addr(self, bay, engine, convert=True, **kwargs):
         """
-        bay=Which bay.
-        engine=Which waveform engine.
-
-        Optional Arg:
-        -------------
-        convert (bool) : Convert the output from a string of hex values to an
-            int. Default (True)
+        Args
+        ----
+        bay : int
+            Which bay.
+        engine : int
+            Which waveform engine.
+        convert : bool, optional, default True
+            Convert the output from a string of hex values to an int.
         """
 
         val = self._caget(self.waveform_engine_buffers_root.format(bay) +
@@ -2189,14 +2193,16 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_waveform_end_addr(self, bay, engine, val, convert=True, **kwargs):
         """
-        bay=Which bay.
-        engine=Which waveform engine.
-        val=What value to set.
-
-        Optional Arg:
-        -------------
-        convert (bool) : Convert the output from a string of hex values to an
-            int. Default (True)
+        Args
+        ----
+        bay : int
+            Which bay.
+        engine : int
+            Which waveform engine.
+        val : int
+            What val to set.
+        convert : bool, optional, default True
+            Convert the output from a string of hex values to an int.        
         """
         if convert:
             val = self.int_to_hex_string(val)
@@ -2205,13 +2211,20 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_waveform_end_addr(self, bay, engine, convert=True, **kwargs):
         """
-        bay=Which bay.
-        engine=Which waveform engine.
+        Args
+        ----
+        bay : int
+            Which bay.
+        engine : int
+            Which waveform engine.
+        convert : bool, optional, default True
+            Convert the output from a string of hex values to an int.
 
-        Optional Arg:
-        -------------
-        convert (bool) : Convert the output from a string of hex values to an
-            int. Default (True)
+        Returns
+        -------
+        val : str or int
+            Waveform end address (a string of hex values if convert is
+            False, otherwise an integer if convert is True).
         """
         val = self._caget(self.waveform_engine_buffers_root.format(bay) +
             self._end_addr.format(engine), **kwargs)
@@ -2224,14 +2237,16 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_waveform_wr_addr(self, bay, engine, val, convert=True, **kwargs):
         """
-        bay=Which bay.
-        engine=Which waveform engine.
-        val=What val to set.
-
-        Optional Arg:
-        -------------
-        convert (bool) : Convert the output from a string of hex values to an
-            int. Default (True)
+        Args
+        ----
+        bay : int
+            Which bay.
+        engine : int
+            Which waveform engine.
+        val : int
+            What val to set.
+        convert : bool, optional, default True
+            Convert the output from a string of hex values to an int.
         """
         if convert:
             val = self.int_to_hex_string(val)
@@ -2240,13 +2255,20 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_waveform_wr_addr(self, bay, engine, convert=True, **kwargs):
         """
-        bay=Which bay.
-        engine=Which waveform engine.
+        Args
+        ----
+        bay : int
+            Which bay.
+        engine : int
+            Which waveform engine.
+        convert : bool, optional, default True
+            Convert the output from a string of hex values to an int.
 
-        Optional Arg:
-        -------------
-        convert (bool) : Convert the output from a string of hex values to an
-            int. Default (True)
+        Returns
+        -------
+        val : str or int
+            Waveform end address (a string of hex values if convert is
+            False, otherwise an integer if convert is True).
         """
         val = self._caget(self.waveform_engine_buffers_root.format(bay) +
             self._wr_addr.format(engine), **kwargs)
@@ -2259,17 +2281,26 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_waveform_empty(self, bay, engine, val, **kwargs):
         """
-        bay=Which bay.
-        engine=Which waveform engine.
-        val=What value to set.
+        Args
+        ----
+        bay : int
+            Which bay.
+        engine : int
+            Which waveform engine.
+        val : int
+            What val to set.
         """
         self._caput(self.waveform_engine_buffers_root.format(bay) +
             self._empty.format(engine), **kwargs)
 
     def get_waveform_empty(self, bay, engine, **kwargs):
         """
-        bay=Which bay.
-        engine=Which waveform engine.
+        Args
+        ----
+        bay : int
+            Which bay.
+        engine : int
+            Which waveform engine.
         """
         return self._caget(self.waveform_engine_buffers_root.format(bay) +
             self._empty.format(engine), **kwargs)

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -169,30 +169,44 @@ class SmurfIVMixin(SmurfBase):
         hold at the bias_low point at the end, so different bias groups
         may have different length ramps.
 
-        Args:
-        -----
-        bias_high_array (float array): (n_bias_groups,) array of voltage biases, in
-          bias group order
-        Opt Args:
-        -----
-        bias_low_array (float array): (n_bias_groups,) array of voltage biases, in
-          bias group order. Defaults to whatever is currently set
-        wait_time (float): Time to wait at each commanded bias value.
-            Default 0.1
-        bias_step (float): Interval size to step the commanded voltage bias.
-          Default 0.1
-        show_plot (bool): whether to show plots. Default False.
-        make_plot (bool): whether to generate plots. Default True.
-        analyze (bool): whether to analyze the data. Default True.
-        save_plot (bool): whether to save generated plots. Default True.
-        channels (int array): which channels to analyze. Default to anything
-          that exceeds phase_excursion_min
-        overbias_voltage (float): value in V at which to overbias. If None,
-          won't overbias. If value is set, uses high current mode.
-        overbias_wait (float): if overbiasing, time to hold the overbiased
-          voltage in high current mode
-        phase_excursion_min (float): minimum change in phase to be analyzed,
-          defined as abs(phase_max - phase_min). Default 1, units radians.
+        Args
+        ----
+        bias_high_array : float array)
+            (n_bias_groups,) array of voltage biases, in bias group
+            order
+
+        bias_low_array : float array or None, optional, default None
+            (n_bias_groups,) array of voltage biases, in bias group
+            order. Defaults to whatever is currently set.
+        wait_time : float, optional, default 0.1
+            Time in seconds to wait at each commanded bias value.
+        bias_step : float, optional, default 0.1
+            Interval size to step the commanded voltage bias in volts.
+        show_plot : bool, optional, default False
+            Whether to show plots.
+        analyze : bool, optional, default True
+            Whether to analyze the data.
+        make_plot : bool, optional, default True
+            Whether to generate plots.
+        save_plot : bool, optional, default True
+            Whether to save generated plots.
+        channels : int array or None, optional, default None
+            Which channels to analyze. Default to anything.  that
+            exceeds phase_excursion_min.
+        overbias_voltage : float or None, optional, default None
+            Value in volts at which to overbias. If None, won't
+            overbias. If value is set, uses high current mode.
+        overbias_wait : float, optional, default 1.0
+            If overbiasing, time to hold the overbiased voltage in
+            high current mode.
+        phase_excursion_min : float, optional, default 1.0
+            Minimum change in phase to be analyzed, defined as
+            abs(phase_max - phase_min). Units radians.
+
+        Returns
+        -------
+        path : str
+            ???
         """
 
         original_biases = self.get_tes_bias_bipolar_array()
@@ -287,31 +301,49 @@ class SmurfIVMixin(SmurfBase):
         """
         Function to analyze a load curve from its raw file. Can be used to
           analyze IV's/generate plots separately from issuing commands.
-        Args:
-        -----
-        fn_iv_raw_data (str): *_iv_raw_data.npy file to analyze
-        Opt Args:
-        ---------
-        make_plot (bool): Defaults True. Usually this is the slowest part.
-        show_plot (bool): Defaults False.
-        save_plot (bool): Defaults True.
-        plotname_append (string): Appended to the default plot filename. Default ''.
-        phase_excursion_min (float): abs(max - min) of phase in radians. Analysis
-          ignores any channels without this phase excursion. Default 3.
-        grid_on (bool): Whether to draw the grid on the PR plot. Defaults False
-          Defaults true.
-        R_op_target (float): Target operating resistance. Function will
-          generate a histogram indicating bias voltage needed to achieve
-          this value.
-        channel (int array): Which channels to analyze. Defaults to all
-          the channels that are on and exceed phase_excursion_min
-        data_path (str) : The full path to the data. This is used for offline mode
-          where the data was copied to a new directory. The directory is usually
-          loaded from the .npy file, and this overwrites it.
-        plot_dir (str) : The full path to the plot directory. This is usually
-            loaded with the input numpy dictionary. This overwrites this.
-        bias_line_resistance (float) : The resistance of the bias lines in Ohms.
-            Default is None.
+
+        Args
+        ----
+        fn_iv_raw_data : str
+            *_iv_raw_data.npy file to analyze.
+
+        make_plot : bool, optional, default True
+            Whether or not to make plots.  Usually this is the slowest
+            part.
+        show_plot : bool, optional, default False
+            Whether or not to show plots.
+        save_plot : bool, optional, default True
+            Whether or not to save plots.
+        plotname_append : str, optional, default ''
+            Appended to the default plot filename.
+        phase_excursion_min : float, optional, default 3.0
+            abs(max - min) of phase in radians. Analysis ignores any
+            channels without this phase excursion.
+        grid_on : bool, optional, default False
+            Whether to draw the grid on the PR plot.
+        R_op_target : float, optional, default 0.007
+            Target operating resistance. Function will generate a
+            histogram indicating bias voltage needed to achieve this
+            value.
+        pA_per_phi0 : float or None, optional, default None
+            The conversion for phi0 to pA. If None, attempts to read
+            it from the config file.
+        channel : int array or None, optional, default None
+            Which channels to analyze. Defaults to all the channels
+            that are on and exceed phase_excursion_min.
+        band : int or None, optional, default None
+            ???
+        datafile : str or None, optional, default None
+            The full path to the data. This is used for offline mode
+            where the data was copied to a new directory. The
+            directory is usually loaded from the .npy file, and this
+            overwrites it.
+        plot_dir : str or None, optional, default None
+            The full path to the plot directory. This is usually
+            loaded with the input numpy dictionary. This overwrites
+            this.
+        bias_line_resistance : float or None, optional, default None
+            The resistance of the bias lines in Ohms.
         """
         self.log('Analyzing from file: {}'.format(fn_iv_raw_data))
 

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -1036,20 +1036,23 @@ class SmurfIVMixin(SmurfBase):
         Estimate optical efficiency between two sets of load curves. Returns
           per-channel plots and a histogram.
 
-        Args:
-        -----
-        iv_fn_hot (str): timestamp/filename of load curve taken at higher temp
-        iv_fn_cold (str): timestamp/filename of load curve taken at cooler temp
-
-        Opt Args:
-        ---------
-        t_hot (float): temperature in K of hotter load curve. Defaults to 293.
-        t_cold (float): temperature in K of cooler load curve. Defaults to 77.
-        channels (int array): which channels to analyze. Defaults to the ones
-          populated in the colder load curve
-        dPdT_lim(len 2 tuple): min, max allowed values for dPdT. If calculated
-          val is outside this range, channel is excluded from histogram and
-          added to outliers. Defaults to min=0pW/K, max=0.5pW/K.
+        Args
+        ----
+        iv_fn_hot : str
+            Timestamp/filename of load curve taken at higher temp.
+        iv_fn_cold : str
+            Timestamp/filename of load curve taken at cooler temp.
+        t_hot : float, optional, default 293.0
+            Temperature in K of hotter load curve.
+        t_cold : float, optional, default 77.0
+            Temperature in K of cooler load curve.
+        channels : int array or None, optional, default None
+            Which channels to analyze. If None, defaults to the ones
+            populated in the colder load curve.
+        dPdT_lim : len 2 tuple, optional, default (0.0, 0.5)
+            Min, max allowed values for dPdT. If calculated val is
+            outside this range, channel is excluded from histogram and
+            added to outliers. Units are pW/K.
         """
         ivs_hot = np.load(iv_fn_hot).item()
         ivs_cold = np.load(iv_fn_cold).item()
@@ -1157,28 +1160,33 @@ class SmurfIVMixin(SmurfBase):
         identify_bias_group first (or manually input which channels are in
         which bias group), otherwise this doesn't know how to group things.
 
-        Args:
-        -----
-        iv_file (str) : Full path to an IV file.
-
-        Opt Args:
-        ---------
-        target_r_frac (float) : The target fractional resistance.
-            Default 0.5
-        normal_resistance (bool) : The expected normal resistance.
-            This is used for eliminating bad (non-transitioning)
-            TESs. This is only used if not None. Default is None.
-        normal_resisttance_frac (float) : The fractional deviation
-            from the input normal_resistance that the normal
-            resistance can deviate to be considered a good TES.
-        make_plot (bool) : Whether to make the plot. Default True.
-        show_plot (bool) : Whether to show the plot. Default False.
-        save_plot (bool) : Whether to save the plot. Default True.
-
-        Ret:
+        Args
         ----
-        target (float array) : An array of size n_bias_groups with the target
-            bias voltage for each group.
+        iv_file : str
+            Full path to an IV file.
+
+        target_r_frac : float, optional, default 0.5
+            The target fractional resistance.
+        normal_resistance : float or None, optional, default None
+            The expected normal resistance.  This is used for
+            eliminating bad (non-transitioning) TESs. This is only
+            used if not None.
+        normal_resistance_frac : float, optional, default 0.25
+            The fractional deviation from the input normal_resistance
+            that the normal resistance can deviate to be considered a
+            good TES.
+        show_plot : bool, optional, default False
+            Whether to show the plot.
+        save_plot : bool, optional, default True
+            Whether to save the plot.
+        make_plot : bool, optional, default True
+            Whether to make the plot.
+
+        Returns
+        -------
+        target : float array
+            An array of size n_bias_groups with the target bias
+            voltage for each group.
         """
         # Load IV summary file and raw dat file
         iv = np.load(iv_file, allow_pickle=True).item()

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -62,7 +62,7 @@ class SmurfIVMixin(SmurfBase):
             Whether to make plots.
         save_plot : bool, optional, default True
             Whether to save the plot.
-        plotname_append : str, optional, default '' 
+        plotname_append : str, optional, default ''
             Appended to the default plot filename.
         channels : int array or None, optional, default None
             A list of channels to make plots.

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -29,53 +29,56 @@ class SmurfIVMixin(SmurfBase):
                     make_plot=True, save_plot=True, plotname_append='',
                     channels=None, band=None, high_current_mode=True,
                     overbias_voltage=8., grid_on=True, phase_excursion_min=3.):
-        """ Steps the TES bias down slowly. Starts at bias_high to bias_low with
-        step size bias_step. Waits wait_time between changing steps. If this
-        analyzes the data, the outputs are stored to output_dir.
+        """Takes a slow IV
 
-        Parameters:
-        -----------
-        bias_groups : np array
-            which bias groups to take the IV on. defaults to the groups in the
-            config file
-        wait_time : float
-            The amount of time between changing TES biases in seconds. Default
-            .1 sec.
-        bias :float array
+        Steps the TES bias down slowly. Starts at bias_high to
+        bias_low with step size bias_step. Waits wait_time between
+        changing steps. If this analyzes the data, the outputs are
+        stored to output_dir.
+
+        Args
+        ----
+        bias_groups : numpy.ndarray or None, optional, default None
+            Which bias groups to take the IV on. If None, defaults to
+            the groups in the config file.
+        wait_time : float, optional, default 0.1
+            The amount of time between changing TES biases in seconds.
+        bias : float array or None, optional, default None
             A float array of bias values. Must go high to low.
-        bias_high :int
-            The maximum TES bias in volts. Default 19.9
-        bias_low :int
-            The minimum TES bias in volts. Default 0
-        bias_step :int
-            The step size in volts. Default .1
-        overbias_wait : float
-            The time to stay in the overbiased state in seconds. The default
-            is 2 sec.
-        cool_wait : float
-            The time to stay in the low current state after overbiasing before
-            taking the IV.
-        make_plot : bool
-            Whether to make plots. Default True
-        save_plot : bool
-            Whether to save the plot. Default True.
-        plotname_append : string
-            Appended to the default plot filename. Default ''.
-        channels : int array
-            A list of channels to make plots
-        band : int array
-            The bands to analyze
-        high_current_mode : bool
+        bias_high : float, optional, default 1.5
+            The maximum TES bias in volts.
+        bias_low : float, optional, default 0
+            The minimum TES bias in volts.
+        bias_step : float, optional, default 0.005
+            The step size in volts.
+        show_plot : bool, optional, default False
+            Whether to show plots.
+        overbias_wait : float, optional, default 2.0
+            The time to stay in the overbiased state in seconds.
+        cool_wait : float, optional, default 30.0
+            The time to stay in the low current state after
+            overbiasing before taking the IV.
+        make_plot : bool, optional, default True
+            Whether to make plots.
+        save_plot : bool, optional, default True
+            Whether to save the plot.
+        plotname_append : str, optional, default '' 
+            Appended to the default plot filename.
+        channels : int array or None, optional, default None
+            A list of channels to make plots.
+        band : int array or None, optional, default None
+            The bands to analyze.
+        high_current_mode : bool, optional, default True
             The current mode to take the IV in.
-        overbias_voltage : float
+        overbias_voltage : float, optional, default 8.0
             The voltage to set the TES bias in the overbias stage.
-        grid_on : bool
-            Grids on plotting. This is Aris fault.
-        phase_excursion_min : float
+        grid_on : bool, optional, default True
+            Grids on plotting. This is Ari's fault.
+        phase_excursion_min : float, optional, default 3.0
             The minimum phase excursion required for making plots.
 
-        Returns:
-        --------
+        Returns
+        -------
         output_path : str
             Full path to IV analyzed file.
         """

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -304,8 +304,7 @@ class SmurfIVMixin(SmurfBase):
         Args
         ----
         fn_iv_raw_data : str
-            *_iv_raw_data.npy file to analyze.
-
+            ``*_iv_raw_data.npy`` file to analyze.
         make_plot : bool, optional, default True
             Whether or not to make plots.  Usually this is the slowest
             part.
@@ -952,7 +951,7 @@ class SmurfIVMixin(SmurfBase):
         Args
         ----
         fn_plc_raw_data : str
-            *_plc_raw_data.npy file to analyze
+            ``*_plc_raw_data.npy`` file to analyze
         make_plot : bool, optional, default True
             Whether to make plots.  This is slow.
         show_plot : bool, optional, default False

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -285,7 +285,6 @@ class SmurfIVMixin(SmurfBase):
         if analyze:
             self.analyze_plc_from_file(fn_plc_raw_data, make_plot=make_plot,
                 show_plot=show_plot, save_plot=save_plot, R_sh=self.R_sh,
-                high_current_mode=self.high_current_mode_bool,
                 phase_excursion_min=phase_excursion_min, channels=channels)
 
 
@@ -571,40 +570,65 @@ class SmurfIVMixin(SmurfBase):
         """
         Analyzes the IV curve taken with slow_iv()
 
-        Args:
-        -----
-        v_bias (float array): The commanded bias in voltage. Length n_steps
-        resp (float array): The TES phase response in radians. Of length
-            n_pts (not the same as n_steps).
-        make_plot (bool) : Whether to make the plot. Default is True.
-        show_plot (bool) : Whether to show the plot. Default is False.
-        save_plot (bool) : Whether to save the plot. Default is True.
-        basename (str) : The basename of the IV plot. If None, uses the current
-            timestamp. Default is None.
-        band (int) : The 500 MHz band the data was taken in. This is only for
-            plotting . Default None.
-        channel (int) : The SMuRF channel. Only used for plotting. Default
-            is None.
-        R_sh (int) : The shunt resistance in ohms. If not supplied, will try
-            to read from config file.
-        plot_dir (str) : Path to the plot directory where plots are to be saved.
-            If None, uses self.plot_dir. Default is None.
-        high_current_mode (bool) : Whether the data was taken in high current
-            mode. This is important for knowing what current actually enters
-            the cryostat.
-        grid_on (bool) : Whether to plot with grids on. Default is False.
-        pA_per_phi0 (float) : The conversion for phi0 to pA. If None, attempts
-            to read it from the config file. Default is None.
-        bias_line_resistance (float) : The resistance of the bias lines in
-            Ohms. If None, reads from config. Default is None.
-        plotname_append (str) : An optional string to append the plot names.
+        Args
+        ----
+        v_bias : float array
+            The commanded bias in voltage. Length n_steps.
+        resp : float array
+            The TES phase response in radians. Of length n_pts (not
+            the same as n_steps).
 
-        Returns:
-        --------
-        R (float array):
-        R_n (float):
-        idx (int array):
-        R_sh (float): Shunt resistance
+        make_plot : bool, optional, default True
+            Whether to make the plot.
+        show_plot : bool, optional, default False
+            Whether to show the plot.
+        save_plot : bool, optional, default True
+            Whether to save the plot.
+        basename : str or None, optional, default None
+            The basename of the IV plot. If None, uses the current
+            timestamp.
+        band : int or None, optional, default None
+            The 500 MHz band the data was taken in. This is only for
+            plotting.
+        channel : int or None, optional, default None
+            The SMuRF channel. Only used for plotting.
+        R_sh : float or None, optional, default None
+            The shunt resistance in ohms. If not supplied, will try to
+            read from config file.
+        plot_dir : str or None, optional, default None
+            Path to the plot directory where plots are to be saved.
+            If None, uses self.plot_dir.
+        high_current_mode : bool, optional, default False
+            Whether the data was taken in high current mode. This is
+            important for knowing what current actually enters the
+            cryostat.
+        bias group : ??? or None, optional, default None
+            ???
+        grid_on : bool, optional, default False
+            Whether to plot with grids on.
+        R_op_target : float, optional, default 0.007
+            ???
+        pA_per_phi0 : float or None, optional, default None
+            The conversion for phi0 to pA. If None, attempts to read
+            it from the config file.
+        bias_line_resistance : float or None, optional, default None
+            The resistance of the bias lines in Ohms. If None, reads
+            from config.
+        plotname_append : str, optional, default ''
+            An optional string to append the plot names.
+        **kwargs : ???
+            ???
+
+        Returns
+        -------
+        R : float array
+            ???
+        R_n : float
+            ???
+        idx : int array
+            ???
+        R_sh : float
+            Shunt resistance.
         """
         v_bias = np.abs(v_bias)
 
@@ -917,30 +941,32 @@ class SmurfIVMixin(SmurfBase):
 
         return iv_dict
 
-    def analyze_plc_from_file(self, fn_plc_raw_data, make_plot=True, show_plot=False,
-            save_plot=True, R_sh=None, high_current_mode=None, phase_excursion_min=1.,
-            channels=None):
+    def analyze_plc_from_file(self, fn_plc_raw_data, make_plot=True,
+            show_plot=False, save_plot=True, R_sh=None,
+            phase_excursion_min=1., channels=None):
         """
-        Function to analyze a partial load curve from its raw file. Basically
-        the same as the slow_iv analysis but without fitting the superconducting
-        branch.
+        Function to analyze a partial load curve from its raw
+        file. Basically the same as the slow_iv analysis but without
+        fitting the superconducting branch.
 
-        Args:
-        -----
-        fn_plc_raw_data (str): *_plc_raw_data.npy file to analyze
-
-        Opt Args:
-        -----
-        make_plot (bool): Defaults True. This is slow.
-        show_plot (bool): Defaults False.
-        save_plot (bool): Defaults True.
-        R_sh (float): shunt resistance; defaults to the value in the config file
-        high_current_mode (bool): Whether to perform analysis assuming that commanded
-          voltages were in high current mode. Defaults to the value in the config file.
-        phase_excursion_min (float): abs(max-min) of phase in radian. Analysis will
-          ignore any channels that do not meet this criterion. Default 1.
-        channels (int array): which channels to analyze. Defaults to all channels that
-          are on and exceed phase_excursion_min
+        Args
+        ----
+        fn_plc_raw_data : str
+            *_plc_raw_data.npy file to analyze
+        make_plot : bool, optional, default True
+            Whether to make plots.  This is slow.
+        show_plot : bool, optional, default False
+            Whether to show plots.
+        save_plot : bool, optional, default True
+            Whether to save plots.
+        R_sh : float or None, optional, default None
+            Shunt resistance; defaults to the value in the config file.
+        phase_excursion_min : float, optional, default 1.0
+            abs(max-min) of phase in radian. Analysis will
+            ignore any channels that do not meet this criterion.
+        channels : int array or None, optional, default None
+            Which channels to analyze. Defaults to all channels that
+            are on and exceed phase_excursion_min.
         """
 
         self.log('Analyzing plc from file: {}'.format(fn_plc_raw_data))

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -47,41 +47,53 @@ class SmurfNoiseMixin(SmurfBase):
 
         Args:
         -----
-        meas_time (float): The amount of time to observe in seconds.
+        meas_time : float
+            The amount of time to observe in seconds.
 
-        Opt Args:
-        ---------
-        channel (int array): The channels to plot. Note that this script always
-            takes data on all the channels. This only sets the ones to plot.
-            If None, plots all channels that are on. Default is None.
-        nperseg (int): The number of elements per segment in the PSD. Default
-            2**12.
-        detrend (str): Extends the scipy.signal.welch detrend. Default is
-            'constant'
-        fs (float): Sample frequency. If None, reads it in. Default is None.
-        low_freq (float array):
-        high_freq (float array):
-        make_channel_plot (bool): Whether to make the individual channel
-            plots. Default is True.
-        make_summary_plot (bool): Whether to make the summary plots. Default
-            is True.
-        save_data (bool): Whether to save the band averaged data as a text file.
-            Default is False.
-        plotname_append (string): Appended to the default plot filename. Default ''.
-        show_plot (bool): Show the plot on the screen. Default False.
-        datefile (str): if data has already been taken, can point to a file to
+        channel : int array or None, optional, default None
+            The channels to plot. Note that this script always takes
+            data on all the channels. This only sets the ones to plot.
+            If None, plots all channels that are on.
+        nperseg : int, optional, default 2**12
+            The number of elements per segment in the PSD.
+        detrend : str, optional, default 'constant'
+            Extends the scipy.signal.welch detrend.
+        fs : float or None, optional, default None
+            Sample frequency. If None, reads it in.
+        low_freq : numpy.ndarray, optional, default numpy.array([0.1,1.0])
+        high_freq : numpy.ndarray, optional, default numpy.array([1.0,10.0])
+        make_channel_plot : bool, optional, default True
+            Whether to make the individual channel plots.
+        make_summary_plot : bool, optional, default True
+            Whether to make the summary plots.
+        save_data : bool, optional, default False
+            Whether to save the band averaged data as a text file.
+        show_plot : bool, optional, default False
+            Show the plot on the screen.
+        grid_on : bool, optional, default False
+            ???
+        datafile : str or None, optional, default None
+            If data has already been taken, can point to a file to
             bypass data taking and just analyze.
-        downsample_factor (int): The datarate is the flux ramp rate divided by
-            the downsample_factor.
-        write_log (bool) : Whether to write to the log file (or the screen
-            if the logfile is not defined). Default is True.
-        reset_unwrapper (bool) : Whether to reset the unwrapper before
-            taking data.
-        reset_filter (bool) : Whether to reset the filter before taking data.
+        downsample_factor : int or None, optional, default None
+            The datarate is the flux ramp rate divided by the
+            downsample_factor.
+        write_log : bool, optional, default True
+            Whether to write to the log file (or the screen if the
+            logfile is not defined).
+        reset_filter : bool, optional, default True
+            Whether to reset the filter before taking data.
+        reset_unwrapper : bool, optional, default True
+            Whether to reset the unwrapper before taking data.
+        return_noise_params : bool, optional, default False
+            ???
+        plotname_append : str, optional, default ''
+            Appended to the default plot filename.
 
-        Ret:
-        ----
-        datafile (str) : The full path to the raw data.
+        Returns
+        -------
+        datafile : str
+             The full path to the raw data.
         """
         if datafile is None:
             datafile = self.take_stream_data(meas_time,
@@ -311,15 +323,15 @@ class SmurfNoiseMixin(SmurfBase):
         """
         Turns off channels with noise level above a cutoff.
 
-        Args:
-        -----
-        band (int): The band to search
-        noise (float array): The noise floors. Presumably calculated
-            using take_noise_psd.
-
-        Optional Args:
-        --------------
-        cutoff (float) : The value to cut at in the same units as noise.
+        Args
+        ----
+        band : int
+            The band to search
+        noise : float array
+            The noise floors. Presumably calculated using
+            take_noise_psd.
+        cutoff : float, optional, default 150.0
+            The value to cut at in the same units as noise.
         """
         n_channel = self.get_number_channels(band)
         for ch in np.arange(n_channel):
@@ -333,40 +345,41 @@ class SmurfNoiseMixin(SmurfBase):
                       n_phi0=4, make_timestream_plot=True,
                       new_master_assignment=True, from_old_tune=False,
                       old_tune=None):
-        """ Takes timestream noise at various tone powers. Operates on one band
-        at a time because it needs to retune between taking another timestream
-        at a different tone power.
+        """Takes timestream noise at various tone powers. 
 
-        Parameters:
-        -----------
+        Operates on one band at a time because it needs to retune
+        between taking another timestream at a different tone power.
+
+        Args
+        ----
         band : int
             The 500 MHz band to run
-        tones : int array
-            The tone amplitudes. If None, uses np.arange(10,15). Default is None.
-        meas_time : int
-            The measurement time per tone power in seconds. Default 30.
-        analyze : bool
+        tones : int array or None, optional, default None
+            The tone amplitudes. If None, uses np.arange(10,15).
+        meas_time : float, optional, default 30.0
+            The measurement time per tone power in seconds.
+        analyze : bool, optional, default False
             Whether to analyze the data.
-        bias_group : int array
-            The bias groups to analyze
-        lms_freq_hz : float
-            The tracking frequency in Hz. If None, measures the tracking
-            frequency. Default is None.
-        fraction_full_scale : float
+        bias_group : int array or None, optional, default None
+            The bias groups to analyze.
+        lms_freq_hz : float or None, optional, default None
+            The tracking frequency in Hz. If None, measures the
+            tracking frequency.
+        fraction_full_scale : float, optional, default 0.72
             The amplitude of the flux ramp.
-        meas_flux_ramp_amp :bool
+        meas_flux_ramp_amp : bool or None, optional, default False
             Whether to measure the flux ramp amplitude.
-        n_phi0 : float
-            The number of phi0 to use if measuring flux ramp. Default 4.
-        make_timestream_plot : bool
-            Whether to make the timestream plot. Default True.
-        new_master_assignment : bool
-            Whether to make a new master channel assignemnt. This will only
-            make one for the first tone. It needs to keep the channel
-            assignment the same after that for the analysis.
-        from_old_tune : bool
-            Whether to tune from an old tune
-        old_tune : str
+        n_phi0 : float, optional, default 4.0
+            The number of phi0 to use if measuring flux ramp.
+        make_timestream_plot : bool, optional, default True
+            Whether to make the timestream plot.
+        new_master_assignment : bool, optional, default True
+            Whether to make a new master channel assignemnt. This will
+            only make one for the first tone. It needs to keep the
+            channel assignment the same after that for the analysis.
+        from_old_tune : bool, optional, default False
+            Whether to tune from an old tune.
+        old_tune : str or None, optional, default None
             The tune file if using old tune.
         """
         timestamp = self.get_timestamp()
@@ -650,13 +663,15 @@ class SmurfNoiseMixin(SmurfBase):
         For, e.g., noise_vs_bias, the list of datafiles is recorded in a txt file.
         This function simply extracts those filenames and returns them as a list.
 
-        Args:
-        -----
-        fn_datafiles (str): full path to txt containing names of data files
-
-        Ret:
+        Args
         ----
-        datafiles (list): strings of data-file names.
+        fn_datafiles : str
+            Full path to txt containing names of data files.
+
+        Returns
+        -------
+        datafiles : list of str
+            Strings of data-file names.
         '''
         datafiles = []
         f_datafiles = open(fn_datafiles,'r')
@@ -667,17 +682,19 @@ class SmurfNoiseMixin(SmurfBase):
 
     def get_biases_from_file(self, fn_biases, dtype=float):
         '''
-        For, e.g., noise_vs_bias, the list of commanded bias voltages is
-        recorded in a txt file. This function simply extracts those values and
-        returns them as a list.
+        For, e.g., noise_vs_bias, the list of commanded bias voltages
+        is recorded in a txt file. This function simply extracts those
+        values and returns them as a list.
 
-        Args:
-        -----
-        fn_biases (str): full path to txt containing list of bias voltages
-
-        Ret:
+        Args
         ----
-        biases (list): floats of commanded bias voltages
+        fn_biases : str
+            Full path to txt containing list of bias voltages.
+
+        Returns
+        -------
+        biases : list of float
+            Floats of commanded bias voltages.
         '''
         biases = []
         f_biases = open(fn_biases,'r')
@@ -696,20 +713,21 @@ class SmurfNoiseMixin(SmurfBase):
         Takes IV data and extracts responsivities as a function of commanded
         bias voltage.
 
-        Args:
-        -----
-        iv_data_filename (str): filename of output of IV analysis
-        band (int): band from which to extract responsivities
-
-        Opt Args:
-        ---------
-        high_current_mode (bool): whether or not to return the IV bias
-            voltages so that they look like the IV was taken in high-current
-            mode.
-
-        Ret:
+        Args
         ----
-        iv_band_data (dict): dictionary with IV information for band
+        iv_data_filename : str
+            Filename of output of IV analysis.
+        band : int
+            Band from which to extract responsivities.
+
+        high_current_mode : bool, optional, default False
+            Whether or not to return the IV bias voltages so that they
+            look like the IV was taken in high-current mode.
+
+        Returns
+        -------
+        iv_band_data : dict
+            Dictionary with IV information for band.
         '''
         self.log(f'Extracting IV data from {iv_data_filename}')
         iv_data = np.load(iv_data_filename, allow_pickle=True).item()
@@ -728,15 +746,19 @@ class SmurfNoiseMixin(SmurfBase):
         """
         Convenience function for getting the responsivitiy from the IV data.
 
-        Args:
-        -----
-        iv_band_data (dict) : The IV dictionary
-        ch (int) : The channel to extract the data from.
-
-        Ret:
+        Args
         ----
-        v_bias (float) : The bias voltage
-        si (float) : The responsivity
+        iv_band_data : dict
+            The IV dictionary.
+        ch : int
+            The channel to extract the data from.
+
+        Returns
+        -------
+        v_bias : float
+            The bias voltage.
+        si : float
+            The responsivity.
         """
         return iv_band_data[ch]['v_bias'], iv_band_data[ch]['si']
 
@@ -744,19 +766,20 @@ class SmurfNoiseMixin(SmurfBase):
     def NEI_to_NEP(self, iv_band_data, ch, v_bias):
         '''
         Takes NEI in pA/rtHz and converts to NEP in aW/rtHz.
-        Parameters
-        ----------
-        si_dict (dict): dictionary indexed by channel number; each entry is
-                        an array of responsivities in uV^-1.
-        iv_bias_array (array): array of commanded bias voltages from the IV
-                               curve from which si was estimated. The length
-                               of iv_bias_array is one greater than that of
-                               each element of si_dict.
-        v_bias (float): commanded bias voltage at which to estimate NEP
-        Pxx (array): NEI in pA/rtHz
+
+        Args
+        ----
+        iv_band_data : dict
+            The IV dictionary.
+        ch : int
+            The channel to extract the data from.
+        v_bias : float
+            Commanded bias voltage at which to estimate NEP.
+
         Returns
         -------
-        1/si (float): noise-equivalent power in aW/rtHz
+        float
+            Noise-equivalent power in aW/rtHz.
         '''
         v_bias_array,si_array = self.get_si_data(iv_band_data, ch)
         si = np.interp(v_bias, v_bias_array[:-1], si_array)
@@ -1368,19 +1391,22 @@ class SmurfNoiseMixin(SmurfBase):
         return popt, pcov, f_fit, Pxx_fit
 
 
-    def noise_all_vs_noise_solo(self, band, meas_time=10):
+    def noise_all_vs_noise_solo(self, band, meas_time=10.0):
         """
         Measures the noise with all the resonators on, then measures
         every channel individually.
 
-        Args:
-        -----
-        band (int) : The band number
+        Args
+        ----
+        band : int
+            The band number.
+        meas_time : float, optional, default 10.0
+            The measurement time per resonator in seconds.
 
-        Opt Args:
-        ---------
-        meas_time (float) : The measurement time per resonator in
-            seconds. Default is 10.
+        Returns
+        -------
+        ret : ???
+            ???
         """
         timestamp = self.get_timestamp()
 
@@ -1412,10 +1438,23 @@ class SmurfNoiseMixin(SmurfBase):
     def analyze_noise_all_vs_noise_solo(self, ret, fs=None, nperseg=2**10,
             make_channel_plot=False):
         """
-        analyzes the data from noise_all_vs_noise_solo
-        Args:
-        -----
-        ret (dict) : The returned values from noise_all_vs_noise_solo.
+        Analyzes the data from noise_all_vs_noise_solo
+        
+        Args
+        ----
+        ret : dict
+            The returned values from noise_all_vs_noise_solo.
+        fs : float or None, optional, default None
+            ???
+        nperseg : int, optional, defualt 2**10
+            ???
+        make_channel_plot : bool, optional, default False
+            ???
+        
+        Returns
+        -------
+        wl_diff : ???
+            ???
         """
         if fs is None:
             fs = self.fs

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -688,7 +688,7 @@ class SmurfNoiseMixin(SmurfBase):
 
 
     def get_datafiles_from_file(self, fn_datafiles):
-        '''
+        """
         For, e.g., noise_vs_bias, the list of datafiles is recorded in a txt file.
         This function simply extracts those filenames and returns them as a list.
 
@@ -701,7 +701,7 @@ class SmurfNoiseMixin(SmurfBase):
         -------
         datafiles : list of str
             Strings of data-file names.
-        '''
+        """
         datafiles = []
         f_datafiles = open(fn_datafiles,'r')
         for line in f_datafiles:
@@ -710,7 +710,7 @@ class SmurfNoiseMixin(SmurfBase):
 
 
     def get_biases_from_file(self, fn_biases, dtype=float):
-        '''
+        """
         For, e.g., noise_vs_bias, the list of commanded bias voltages
         is recorded in a txt file. This function simply extracts those
         values and returns them as a list.
@@ -724,7 +724,7 @@ class SmurfNoiseMixin(SmurfBase):
         -------
         biases : list of float
             Floats of commanded bias voltages.
-        '''
+        """
         biases = []
         f_biases = open(fn_biases,'r')
         for line in f_biases:
@@ -738,7 +738,7 @@ class SmurfNoiseMixin(SmurfBase):
 
 
     def get_iv_data(self, iv_data_filename, band, high_current_mode=False):
-        '''
+        """
         Takes IV data and extracts responsivities as a function of commanded
         bias voltage.
 
@@ -757,7 +757,7 @@ class SmurfNoiseMixin(SmurfBase):
         -------
         iv_band_data : dict
             Dictionary with IV information for band.
-        '''
+        """
         self.log(f'Extracting IV data from {iv_data_filename}')
         iv_data = np.load(iv_data_filename, allow_pickle=True).item()
         iv_band_data = iv_data[band]
@@ -793,7 +793,7 @@ class SmurfNoiseMixin(SmurfBase):
 
 
     def NEI_to_NEP(self, iv_band_data, ch, v_bias):
-        '''
+        """
         Takes NEI in pA/rtHz and converts to NEP in aW/rtHz.
 
         Args
@@ -809,7 +809,7 @@ class SmurfNoiseMixin(SmurfBase):
         -------
         float
             Noise-equivalent power in aW/rtHz.
-        '''
+        """
         v_bias_array,si_array = self.get_si_data(iv_band_data, ch)
         si = np.interp(v_bias, v_bias_array[:-1], si_array)
         return 1./np.absolute(si)
@@ -1346,30 +1346,37 @@ class SmurfNoiseMixin(SmurfBase):
 
     def analyze_psd(self, f, Pxx, fs=None, p0=[100.,0.5,0.01],
             flux_ramp_freq=None, filter_a=None, filter_b=None):
-        '''
+        """
         Return model fit for a PSD.
         p0 (float array): initial guesses for model fitting: [white-noise level
         in pA/rtHz, exponent of 1/f^n component, knee frequency in Hz]
 
-        Args:
-        -----
-        f (float array) : The frequency information
-        Pxx (float array) : The power spectral data
-
-        Opt Args:
-        ---------
-        fs (float) : Sampling frequency. If None, loads in the current
-            sampling frequency.
-        flux_ramp_freq (float) : The flux ramp frequency in Hz
-        p0 (float array) : Initial guess for fitting PSDs
-
-        Ret:
+        Args
         ----
-        popt (float array) : The fit parameters - [white_noise_level, n, f_knee]
-        pcov (float array) : Covariance matrix
-        f_fit (float array) : The frequency bins of the fit
-        Pxx_fit (flot array) : The amplitude
-        '''
+        f : float array
+            The frequency information.
+        Pxx : float array
+            The power spectral data.
+
+        fs : float or None, optional, default None
+            Sampling frequency. If None, loads in the current sampling
+            frequency.
+        p0 : float array, optional, default [100.0,0.5,0.01]
+            Initial guess for fitting PSDs.
+        flux_ramp_freq : float, optional, default None
+            The flux ramp frequency in Hz.
+
+        Returns
+        -------
+        popt : float array
+            The fit parameters - [white_noise_level, n, f_knee].
+        pcov : float array
+            Covariance matrix.
+        f_fit : float array
+            The frequency bins of the fit.
+        Pxx_fit : float array
+            The amplitude.
+        """
         # incorporate timestream filtering
         if filter_b is None:
             filter_b = self.get_filter_b()
@@ -1383,12 +1390,18 @@ class SmurfNoiseMixin(SmurfBase):
             fs = self.get_sample_frequency()
 
         def noise_model(freq, wl, n, f_knee):
-            '''
+            """
             Crude model for noise modeling.
-            wl (float): white-noise level
-            n (float): exponent of 1/f^n component
-            f_knee (float): frequency at which white noise = 1/f^n component
-            '''
+
+            Args
+            ----
+            wl : float
+                White-noise level.
+            n : float
+                Exponent of 1/f^n component.
+            f_knee : float
+                Frequency at which white noise = 1/f^n component
+            """
             A = wl*(f_knee**n)
 
             # The downsample filter is at the flux ramp frequency
@@ -1530,27 +1543,35 @@ class SmurfNoiseMixin(SmurfBase):
 
     def NET_CMB(self, NEI, V_b, R_tes, opt_eff, f_center=150e9, bw=32e9,
             R_sh=None, high_current_mode=False):
-        '''
+        """
         Converts current spectral noise density to NET in uK rt(s). Assumes NEI
         is white-noise level.
 
         Args
         ----
-        NEI (float): current spectral density in pA/rtHz
-        V_b (float): commanded bias voltage in V
-        R_tes (float): resistance of TES at bias point in Ohm
-        opt_eff (float): optical efficiency (in the range 0-1)
+        NEI : float
+            Current spectral density in pA/rtHz.
+        V_b : float
+            Commanded bias voltage in V.
+        R_tes : float
+            Resistance of TES at bias point in Ohm.
+        opt_eff : float
+            Optical efficiency (in the range 0-1).
+        f_center : float, optional, default 150e9
+            Center optical frequency of detector in Hz, e.g., 150 GHz
+            for E4c.
+        bw : float, optional, default 32e9
+            Effective optical bandwidth of detector in Hz, e.g., 32
+            GHz for E4c.
+        R_sh : float or None, optional, default None
+            Shunt resistance in Ohm; defaults to stored config figure.
+        high_current_mode : bool, optional, default False
+            Whether the bias voltage was set in high-current mode.
 
-        Opt Args:
-        ---------
-        f_center (float): center optical frequency of detector in Hz, e.g., 150 GHz for E4c
-        bw (float): effective optical bandwidth of detector in Hz, e.g., 32 GHz for E4c
-        R_sh (float): shunt resistance in Ohm; defaults to stored config figure
-        high_current_mode (bool): whether the bias voltage was set in high-current mode
-        Ret:
-        ----
+        Returns
+        -------
         NET (float) : The noise equivalent temperature in units of uKrts
-        '''
+        """
         NEI *= 1e-12 # bring NEI to SI units, i.e., A/rt(Hz)
         if high_current_mode:
             V_b *= self.high_low_current_ratio
@@ -1574,38 +1595,43 @@ class SmurfNoiseMixin(SmurfBase):
         """ Analysis script associated with noise_vs_tone. Writes outputs
         and plots to output_dir and plot_dir respectively.
 
-        Parameters:
-        -----------
+        Args
+        ----
         tone : str
-            The full path to the tone file
+            The full path to the tone file.
         datafile : str
             The full path to the text file holding all the data files.
-        channel : int array
+        channel : int array or None, optional, default None
             The channels to analyze.
-        band : int
+        band : int or None, optional, default None
             The band where the data is taken.
-        nperseg : int
-            Passed to scipy.signal.welch. Number of elements per segment of the
-            PSD.
-        detrend : str
+        nperseg : int, optional, default 2**13
+            Passed to scipy.signal.welch. Number of elements per
+            segment of the PSD.
+        detrend : str, optional, default 'constant'
             Passed to scipy.signal.welch.
-        fs : float
+        fs : float or None, optional, default None
             Passed to scipy.signal.welch. The sample rate.
-        save_plot : bool
-            Whether to save the plot. Default is True.
-        show_plot : bool
-            Whether to how the plot. Default is False.
-        data_timestamp : str
-            The string used as a save name. Default is None.
-        bias_group : int or int array
-            which bias groups were used. Default is None.
-        smooth_len : int
-            length of window over which to smooth PSDs for plotting
-        show_legend : bool
-            Whether to show the legend. Default True.
-        freq_range_summary : tup
-            frequencies between which to take mean noise for summary plot of
-            noise vs. bias; if None, then plot white-noiselevel from model fit
+        save_plot : bool, optional, default True
+            Whether to save the plot.
+        show_plot : bool, optional, default False
+            Whether to how the plot.
+        make_timestream_plot : bool, optional, default False
+            ???
+        data_timestamp : str or None, optional, default None
+            The string used as a save name.
+        psd_ylim : ???, optional, default (10.0,1000.0)
+            ???
+        bias_group : int or int array or None, optional, default None
+            Which bias groups were used.
+        smooth_len : int, optional, default 11
+            Length of window over which to smooth PSDs for plotting.
+        show_legend : bool, optional, default True
+            Whether to show the legend.
+        freq_range_summary : tuple or None, optional, default None
+            frequencies between which to take mean noise for summary
+            plot of noise vs. bias; if None, then plot white-noise
+            level from model fit.
         """
         if not show_plot:
             plt.ioff()
@@ -1817,21 +1843,24 @@ class SmurfNoiseMixin(SmurfBase):
         Calculates the SVD modes of the input data.
         Only uses the data called out by the mask
 
-        Args:
+        Args
         -----
-        d (float array) : The raw data
-        mask (int array) : The channel mask
+        d : float array
+            The raw data.
+        mask : int array
+            The channel mask.
 
-        Opt Args:
-        ---------
-        mean_subtract (bool) : Whether to mean subtract
-            before taking the SVDs.
+        mean_subtract : bool, optional, default True
+            Whether to mean subtract before taking the SVDs.
 
-        Ret:
-        ----
-        u (float array) : The SVD coefficients
-        s (float array) : The SVD amplitudes
-        vh (float array) : The SVD modes
+        Returns
+        -------
+        u : float array
+            The SVD coefficients.
+        s : float array
+            The SVD amplitudes.
+        vh : float array
+            The SVD modes.
         """
         dat = d[mask[np.where(mask!=-1)]]
         if mean_subtract:
@@ -1847,16 +1876,18 @@ class SmurfNoiseMixin(SmurfBase):
         Requires seaborn to be installed. Plots a heatmap
         of the coefficients and the log10 of the amplitudes.
 
-        Args:
-        -----
-        u (float array) : SVD coefficients from noise_svd
-        s (float array) : SVD amplitudes from noise_svd
-
-        Opt Args:
-        ---------
-        save_plot (bool) : Whether to save the plot
-        save_name (str) : The name of the file
-        show_plot (bool) : Whether to show the plot
+        Args
+        ----
+        u : float array
+            SVD coefficients from noise_svd.
+        s : float array
+            SVD amplitudes from noise_svd.
+        save_plot : bool, optional, default False
+            Whether to save the plot.
+        save_name : str or None, optional, default None
+            The name of the file.
+        show_plot : bool, optional, default False
+            Whether to show the plot.
         """
         if not show_plot:
             plt.ioff()
@@ -1901,18 +1932,26 @@ class SmurfNoiseMixin(SmurfBase):
             save_plot=False, save_name=None, show_plot=False, sharey=True):
         """
         Plots the first N modes where N is n_row x n_col.
-        Args:
-        -----
-        vh (float array) : SVD modes from noise_svd
-        Opt Args:
-        --------
-        n_row (int) : The number of rows in the figure
-        n_col (int) : The number of columns in the figure
-        figsize (ints) : The size of the figure
-        sharey (bool) : whether the subplots share y
-        save_plot (bool) : Whether to save the plot
-        save_name (str) : The name of the file
-        show_plot (bool) : Whether to show the plot
+
+        Args
+        ----
+        vh : float array
+            SVD modes from noise_svd.
+
+        n_row : int, optional, default 4
+            The number of rows in the figure.
+        n_col : int, optional, default 5
+            The number of columns in the figure.
+        figsize : tuple of float, optional, default (10.0,7.5)
+            The size of the figure.
+        save_plot : bool, optional, default False
+            Whether to save the plot.
+        save_name : str or None, optional, default None
+            The name of the file.
+        show_plot : bool, optional, default False
+            Whether to show the plot.
+        sharey : bool, optional, default True
+            Whether the subplots share y.
         """
         if not show_plot:
             plt.ioff()
@@ -1951,23 +1990,27 @@ class SmurfNoiseMixin(SmurfBase):
         """
         Removes the requsted SVD modes
 
-        Args:
-        -----
-        d (float array) : The input data
-        u (float array) : The SVD coefficients
-        s (float array) : The SVD amplitudes
-        mask (int array) : The channel mask
-        vh (float arrry) : The SVD modes
-
-        Opt Args:
-        ---------
-        modes (int or int array) : The modes to remove. If int, removes the first
-            N modes. If array, uses the modes indicated in the array. Default 3.
-
-        Ret:
+        Args
         ----
-        diff (float array) : The difference of the input data matrix and the
-            requested SVD modes.
+        d : float array
+            The input data.
+        u : float array
+            The SVD coefficients.
+        s : float array
+            The SVD amplitudes.
+        mask : int array
+            The channel mask.
+        vh : float arrry
+            The SVD modes.
+        modes : int or int array, optional, default 3
+            The modes to remove. If int, removes the first N modes. If
+            array, uses the modes indicated in the array.
+
+        Returns
+        -------
+        diff : float array
+            The difference of the input data matrix and the requested
+            SVD modes.
         """
         n_mode = np.size(s)
         n_samp, _ = np.shape(vh)

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -45,11 +45,10 @@ class SmurfNoiseMixin(SmurfBase):
         It takes into account the sampling frequency and the downsampling
         filter and downsampler.
 
-        Args:
-        -----
+        Args
+        ----
         meas_time : float
             The amount of time to observe in seconds.
-
         channel : int array or None, optional, default None
             The channels to plot. Note that this script always takes
             data on all the channels. This only sets the ones to plot.
@@ -61,7 +60,9 @@ class SmurfNoiseMixin(SmurfBase):
         fs : float or None, optional, default None
             Sample frequency. If None, reads it in.
         low_freq : numpy.ndarray, optional, default numpy.array([0.1,1.0])
+            ???
         high_freq : numpy.ndarray, optional, default numpy.array([1.0,10.0])
+            ???
         make_channel_plot : bool, optional, default True
             Whether to make the individual channel plots.
         make_summary_plot : bool, optional, default True
@@ -453,42 +454,53 @@ class SmurfNoiseMixin(SmurfBase):
         slow. band and channel inputs only dictate what plots are made. Data
         is taken on every band and channel that is on.
 
-        Parameters:
-        -----------
+        Args
+        ----
         bias_group : int or int array
             which bias group(s) to bias/read back.
-        band :int
-            The band to take noise vs bias data on
-        bias : float array
-            The array of bias values to step through. If None, uses values in
-            defined by bias_high, bias_low, and step_size.
-        bias_high : float
-            The bias voltage to start at
-        bias_low : float
-            The bias votlage to end at
-        step_size : float
+        band : int or None, optional, default None
+            The band to take noise vs bias data on.
+        channel : int or None, optional, default None
+            The channel to run analysis on. Note that data is taken on
+            all channels. This only affects what is analyzed. You can
+            always run the analyze script later.
+        bias_high : float, optional, default 1.5
+            The bias voltage to start at.
+        bias_low : float, optional, default 0.0
+            The bias votlage to end at.
+        step_size : float, optional, default 0.25
             The step in voltage.
-        overbias_voltage : float
-            voltage to set the overbias
-        meas_time : float
+        bias : float array or None, optional, default None
+            The array of bias values to step through. If None, uses
+            values in defined by bias_high, bias_low, and step_size.
+        high_current_mode : bool, optional, default True
+            ???
+        overbias_voltage : float, optional, default 9.0
+            Voltage to set the overbias in volts.
+        meas_time : float, optional, default 30.0
             The amount of time to take data at each TES bias.
-        analyze : bool
-            Whether to analyze the data
-        channel : int
-            The channel to run analysis on. Note that data is taken on all
-            channels. This only affects what is analyzed. You can always run the
-            analyze script later.
-        nperseg : int
+        analyze : bool, optional, default False
+            Whether to analyze the data.
+        nperseg : int, optional, default 2**13
             The number of samples per segment in the PSD.
-        detrend : str
-            Whether to detrend the data before taking the PSD. Default is to
-            remove a constant.
-        fs : float
+        detrend : str, optional, default 'constant'
+            Whether to detrend the data before taking the PSD. Default
+            is to remove a constant.
+        fs : float or None, optional, default None
             The sample frequency.
-        show_plot : bool
-            Whether to show analysis plots. Defaults to False.
-        only_overbias_once : bool
-            Whether or not to overbias right before each TES bias step
+        show_plot : bool, optional, default False
+            Whether to show analysis plots.
+        cool_wait : float, optional, default 30.0
+            ???
+        psd_ylim : tuple of float, optional, default (10.0,1000.0)
+            ???
+        make_timestream_plot : bool, optional, default False
+            ???
+        only_overbias_once : bool, optional, default False
+            Whether or not to overbias right before each TES bias
+            step.
+        overbias_wait : float, optional, default 1.0
+            ???
         """
         if bias is None:
             if step_size > 0:
@@ -510,10 +522,14 @@ class SmurfNoiseMixin(SmurfBase):
             step_size=1, amplitudes=None, meas_time=30., analyze=False,
             channel=None, nperseg=2**13, detrend='constant', fs=None,
             show_plot=False, make_timestream_plot=False, psd_ylim=None):
-        """
-        Args:
-        -----
-        band (int): The band to take noise vs bias data on
+        """???
+
+        ???
+
+        Args
+        ----
+        band : int
+            The band to take noise vs bias data on.
         """
         if amplitudes is None:
             if step_size > 0:
@@ -536,28 +552,41 @@ class SmurfNoiseMixin(SmurfBase):
         """ Generic script for analyzing noise vs some variable. This is called
         by noise_vs_bias and noise_vs_tone.
 
-        Parameters:
-        -----------
-        band int :
-            The 500 MHz band to analyze
-        var (dict) : A dictionary values to use in the analysis. The values
+        Args
+        ----
+        band : int
+            The 500 MHz band to analyze.
+        var : dict
+            A dictionary values to use in the analysis. The values
             depend on which variable is being varied.
-        var_range (float array) : The range of the test variable.
-        meas_time (int) : The measurement time in seconds.
-        analyze (bool) : Whether to analyze the data.
-        channel (int array) : The channels to analyze
-        nperseg (int) : The number of segments in the PSD.
-        detrend (str) : The type of filtering to use before using the PSD.
-            See the documentation of scipy.signal.welch.
-        fs (float) : The sample frequency
-        show_plot (bool) : Whether to show the plot.
-        psd_ylim (float array) : The ylim to use in the plot. If None, uses
-            the default plot value. Default is None.
-        make_timestream_plot (bool) : Whether to plot the timestream. Default
-            False.
-        only_overbias_once (bool) : Whether to only overbias at the beginning
-            of the measurement (as opposed to between every step). Default
-            False.
+        var_range : float array
+            The range of the test variable.
+
+        meas_time : float, optional, default 30.0
+            The measurement time in seconds.
+        analyze : bool, optional, default False
+            Whether to analyze the data.
+        channel : int array or None, optional, default None
+            The channels to analyze.
+        nperseg : int, optional, default 2**13
+            The number of segments in the PSD.
+        detrend : str, optional, default 'constant'
+            The type of filtering to use before using the PSD.  See
+            the documentation of scipy.signal.welch.
+        fs : float or None, optional, default None
+            The sample frequency.
+        show_plot : bool, optional, default False
+            Whether to show the plot.
+        psd_ylim : float array or None, optional, default None
+            The ylim to use in the plot. If None, uses the default
+            plot value.
+        make_timestream_plot : bool, optional, default False
+            Whether to plot the timestream.
+        only_overbias_once : bool, optional, default False
+            Whether to only overbias at the beginning of the
+            measurement (as opposed to between every step).
+        **kwargs : ???
+            ???
         """
         if fs is None:
             fs = self.get_sample_frequency()
@@ -796,8 +825,8 @@ class SmurfNoiseMixin(SmurfBase):
             unit_override=None):
         """ Analysis script associated with noise_vs_bias.
 
-        Parameters:
-        -----------
+        Args
+        ----
         bias :float array
             The bias in voltage. Can also pass an absolute path to a txt
             containing the bias points.

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -346,7 +346,7 @@ class SmurfNoiseMixin(SmurfBase):
                       n_phi0=4, make_timestream_plot=True,
                       new_master_assignment=True, from_old_tune=False,
                       old_tune=None):
-        """Takes timestream noise at various tone powers. 
+        """Takes timestream noise at various tone powers.
 
         Operates on one band at a time because it needs to retune
         between taking another timestream at a different tone power.
@@ -1481,7 +1481,7 @@ class SmurfNoiseMixin(SmurfBase):
             make_channel_plot=False):
         """
         Analyzes the data from noise_all_vs_noise_solo
-        
+
         Args
         ----
         ret : dict
@@ -1492,7 +1492,7 @@ class SmurfNoiseMixin(SmurfBase):
             ???
         make_channel_plot : bool, optional, default False
             ???
-        
+
         Returns
         -------
         wl_diff : ???

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -133,7 +133,6 @@ class SmurfTuneMixin(SmurfBase):
         ----
         band : int
             The band to tune.
-
         freq : float array or None, optional, default None
             The frequency information. If both freq and resp are not
             None, it will skip full_band_resp.
@@ -262,44 +261,50 @@ class SmurfTuneMixin(SmurfBase):
 
         return resonances
 
-    def tune_band_serial(self, band, n_samples=2**19,
-            make_plot=False, save_plot=True, save_data=True, show_plot=False,
+    def tune_band_serial(self, band, n_samples=2**19, make_plot=False,
+            save_plot=True, save_data=True, show_plot=False,
             make_subband_plot=False, subband=None, n_scan=5,
-            subband_plot_with_slow=False, window=5000, rolling_med=True,
-            grad_cut=.03, freq_min=-2.5E8, freq_max=2.5E8, amp_cut=.25,
-            del_f=.005, drive=None, new_master_assignment=False,
-            from_old_tune=False, old_tune=None, pad=50, min_gap=50,
+            subband_plot_with_slow=False, window=5000,
+            rolling_med=True, grad_cut=.03, freq_min=-2.5E8,
+            freq_max=2.5E8, amp_cut=.25, del_f=.005, drive=None,
+            new_master_assignment=False, from_old_tune=False,
+            old_tune=None, pad=50, min_gap=50,
             highlight_phase_slip=True, amp_ylim=None):
-        """ Tunes band using serial_gradient_descent and then serial_eta_scan.
-        This requires an initial guess, which this function gets by either
-        loading an old tune or by using the full_band_resp.  This takes about 3
-        minutes per band if there are about 150 resonators.
-        This saves the results to the freq_resp dictionary.
+        """Tunes band using serial_gradient_descent and then
+        serial_eta_scan.  This requires an initial guess, which this
+        function gets by either loading an old tune or by using the
+        full_band_resp.  This takes about 3 minutes per band if there
+        are about 150 resonators.  This saves the results to the
+        freq_resp dictionary.
 
-        Parameters:
-        -----------
+        Args
+        ----
         band : int
-            The band the tune
-        from_old_tune : bool
-            Whether to use an old tuning file. This will load a tuning file and
-            use its peak frequencies as a starting point for
-            serial_gradient_descent.
-        old_tune : str
-            The full path to the tuning file.
-        new_master_assignment : bool
-            Whether to overwrite the previous master_assignment list. Default
-            False.
-        make_plot : bool
-            Whether to make plots. Default is False.
-        save_plot : bool
-            If make_make plot is True, whether to save the plots. Default is True.
-        show_plot : bool
+            The band the tune.
+        n_samples : int, optional, default 2**19
+            The number of samples to take in full_band_resp.
+        make_plot : bool, optional, default False
+            Whether to make plots.
+        save_plot : bool, optional, default True
+            Whether to save the plot. If True, it will close the plots
+            before they are shown. If False, plots will be brought to
+            the screen.
+        show_plot : bool, optional, default False
             If make_plot is True, whether to display the plots to screen.
-        highlight_phase_slip : bool
-            Whether to highlight the phase slip. Default True.
-        amp_ylim : float
-            The ylim for the amplitude plot. If None, does nothing. Default
-            None.
+        make_subband_plot : bool, optional, default False
+            Whether to make a plot per subband. This is very slow.
+        new_master_assignment : bool, optional, default False
+            Whether to overwrite the previous master_assignment list.
+        from_old_tune : bool, optional, default False
+            Whether to use an old tuning file. This will load a tuning
+            file and use its peak frequencies as a starting point for
+            serial_gradient_descent.
+        old_tune : str or None, optional, default None
+            The full path to the tuning file.
+        highlight_phase_slip : bool, optional, default True
+            Whether to highlight the phase slip.
+        amp_ylim : float or None, optional, default None
+            The ylim for the amplitude plot. If None, does nothing.
         """
         timestamp = self.get_timestamp()
         center_freq = self.get_band_center_mhz(band)
@@ -3423,44 +3428,55 @@ class SmurfTuneMixin(SmurfBase):
             timestamp=None, pad=2, min_gap=2):
         """
         find the peaks within each subband requested from a fullbandamplsweep
-        Args:
-        -----
-        freq (array):  (n_subbands x n_freq_swept) array of frequencies swept
-        response (complex array): n_subbands x n_freq_swept array of complex
-            response
-        subbands (list of ints): subbands that we care to search in
 
-        Optional Args:
-        --------------
-        rolling_med (bool): whether to use a rolling median for the background
-        window (int): number of samples to window together for rolling med
-        grad_cut (float): The value of the gradient of phase to look for
-            resonances. Default is .05
-        amp_cut (float): The fractional distance from the median value to decide
-            whether there is a resonance. Default is .25.
-        freq_min (float): The minimum frequency relative to the center of
-            the band to look for resonances. Units of Hz. Defaults is -2.5E8
-        freq_max (float): The maximum frequency relative to the center of
-            the band to look for resonances. Units of Hz. Defaults is 2.5E8
-        make_plot (bool): Whether to make a plot. Default is False.
-        make_subband_plot (bool): Whether to make a plot per subband. This is
-            very slow. Default is False.
-        save_plot (bool): Whether to save the plot to self.plot_dir. Default
-            is True.
-        plotname_append (string): Appended to the default plot filename.
-            Default is ''.
-        band (int): The band to take find the peaks in. Mainly for saving
-            and plotting.
-        timestamp (str): The timestamp. Mainly for saving and plotting
-        pad (int): number of samples to pad on either side of a resonance search
-            window
-        min_gap (int): minimum number of samples between resonances
-        grad_kernel_width (int) : The number of samples to take after a point
-            to calculate the gradient of phase. Default is 8.
-
-        Ret:
+        Args
         ----
-        peaks (float array) : The frequency of all the peaks found
+        freq : array
+            (n_subbands x n_freq_swept) array of frequencies swept.
+        resp : complex array
+            n_subbands x n_freq_swept array of complex response
+        subband : list of int or None, optional, default None
+            Subbands that we care to search in.
+
+        rolling_med : bool, optional, default False
+            Whether to use a rolling median for the background.
+        window : int, optional, default 500
+            Number of samples to window together for rolling med.
+        grad_cut : float, optional, default 0.05
+            The value of the gradient of phase to look for resonances.
+        amp_cut : float, optional, default 0.25
+            The fractional distance from the median value to decide
+            whether there is a resonance.
+        freq_min : float, optional, default -2.5e8
+            The minimum frequency relative to the center of the band
+            to look for resonances. Units of Hz.
+        freq_max : float, optional, default 2.5e8
+            The maximum frequency relative to the center of the band
+            to look for resonances. Units of Hz.
+        make_plot : bool, optional, default False
+            Whether to make a plot.
+        save_plot : bool, optional, default True
+            Whether to save the plot to self.plot_dir.
+        plotname_append : str, optional, default ''
+            Appended to the default plot filename.
+        band : int or None, optional, default None
+            The band to take find the peaks in. Mainly for saving and
+            plotting.
+        make_subband_plot : bool, optional, default False
+            Whether to make a plot per subband. This is very
+            slow.
+        timestamp : str or None, optional, default None
+            The timestamp. Mainly for saving and plotting.
+        pad : int, optional, default 2
+            Number of samples to pad on either side of a resonance
+            search window.
+        min_gap : int, optional, default 2
+            Minimum number of samples between resonances.
+
+        Returns
+        -------
+        peaks : float array
+            The frequency of all the peaks found.
         """
         peaks = np.array([])
         timestamp = self.get_timestamp()
@@ -3490,22 +3506,30 @@ class SmurfTuneMixin(SmurfBase):
 
     def fast_eta_scan(self, band, subband, freq, n_read, drive,
             make_plot=False):
-        """copy of fastEtaScan.m from Matlab. Sweeps quickly across a range of
-        freq and gets I, Q response
-        Args:
-         band (int): which 500MHz band to scan
-         subband (int): which subband to scan
-         freq (n_freq x 1 array): frequencies to scan relative to subband
-            center
-         n_read (int): number of times to scan
-         drive (int): tone power
-        Optional Args:
-        make_plot (bool): Make eta plots
-        Outputs:
-         resp (n_freq x 2 array): real, imag response as a function of
-            frequency
-         freq (n_freq x n_read array): frequencies scanned, relative to
-            subband center
+        """copy of fastEtaScan.m from Matlab. Sweeps quickly across a
+        range of freq and gets I, Q response
+
+        Args
+        ----
+        band : int
+            Which 500MHz band to scan.
+        subband : int
+            Which subband to scan.
+        freq : (n_freq x 1 array
+            Frequencies to scan relative to subband center.
+        n_read : int
+            Number of times to scan.
+        drive : int
+            Tone power.
+        make_plot : bool, optional, default False
+            Make eta plots.
+
+        Returns
+        -------
+        resp : (n_freq x 2 array)
+            Real, imag response as a function of frequency.
+        freq : (n_freq x n_read array)
+            Frequencies scanned, relative to subband center.
         """
         n_subbands = self.get_number_sub_bands(band)
         n_channels = self.get_number_channels(band)
@@ -3559,26 +3583,32 @@ class SmurfTuneMixin(SmurfBase):
         recommended that you follow this up with run_serial_gradient_descent()
         afterwards.
 
-        Args:
-        -----
-        band (int) : The 500 MHz band to setup.
-        Optional Args:
-        --------------
-        resonance (float array) : A 2 dimensional array with resonance
-            frequencies and the subband they are in. If given, this will take
-            precedent over the one in self.freq_resp.
-        drive (int) : The power to drive the resonators. Default is defined in cfg file.
-        sweep_width (float) : The range to scan around the input resonance in
-            units of MHz. Default .3
-        df_sweep (float) : The sweep step size in MHz. Default .005
-        min_offset (float): Minimum distance in MHz between two resonators for assigning channels.
-        delta_freq (float): The frequency offset at which to measure
-            the complex transmission to compute the eta parameters.
-            Passed to eta_estimator.  Units are MHz.  If none supplied
-            as an argument, takes value in config file.
-        new_master_assignment (bool): Whether to create a new master assignment
-            file. This file defines the mapping between resonator frequency
-            and channel number.
+        Args
+        ----
+        band : int
+            The 500 MHz band to setup.
+        resonance : float array or None, optional, default None
+            A 2 dimensional array with resonance frequencies and the
+            subband they are in. If given, this will take precedent
+            over the one in self.freq_resp.
+        drive : int or None, optional, default None
+            The power to drive the resonators. Default is defined in cfg file.
+        sweep_width : float, optional, default 0.3
+            The range to scan around the input resonance in units of
+            MHz.
+        df_sweep : float, optional, default 0.002
+            The sweep step size in MHz.
+        min_offset : float, optional, default 0.1
+            Minimum distance in MHz between two resonators for assigning channels.
+        delta_freq : float or None, optional, default None
+            The frequency offset at which to measure the complex
+            transmission to compute the eta parameters.  Passed to
+            eta_estimator.  Units are MHz.  If None, takes value in
+            config file.
+        new_master_assignment : bool, optional, default False
+            Whether to create a new master assignment file. This file
+            defines the mapping between resonator frequency and
+            channel number.
         """
         # Turn off all tones in this band first
         self.band_off(band)
@@ -3686,16 +3716,19 @@ class SmurfTuneMixin(SmurfBase):
     def load_tune(self, filename=None, override=True, last_tune=True, band=None):
         """
         Loads the tuning information (self.freq_resp) from tuning directory
-        Opt Args:
-        ---------
-        filename (str) : The name of the tuning.
-        last_tune (bool): Whether to use the most recent tuning
-            file. Default is True.
-        override (bool) : Whether to replace self.freq_resp. Default
-            is True.
-        band (int, int array) : if None, loads entire tune.  If band
-            number is provided, only loads the tune for that band.
-            Not used at all unless override=True.
+
+        Args
+        ----
+        filename : str or None, optional, default None
+            The name of the tuning.
+        override : bool, optional, default True
+            Whether to replace self.freq_resp.
+        last_tune : bool, optional, default True
+            Whether to use the most recent tuning file.
+        band : (int, int array), optional, default None
+            If None, loads entire tune.  If band number is provided,
+            only loads the tune for that band.  Not used at all unless
+            override=True.
         """
         if filename is None and last_tune:
             filename = self.last_tune()
@@ -3746,30 +3779,31 @@ class SmurfTuneMixin(SmurfBase):
         on in the requested 500 MHz band (0..7) using the flux_mod2
         routine.
 
-        Args:
-        -----
-        band (int): Will attempt to estimate the carrier rate on the
-                    channels which are on in this band.
-        reset_rate_khz (float): The flux ramp reset rate (in kHz).
-        Opt Args:
-        ---------
-        fraction_full_scale (float): Passed on to the internal
-                                     tracking_setup call - the
-                                     fraction of full scale exercised
-                                     by the flux ramp.  Defaults to
-                                     value in cfg.
-        new_epics_root (str): Passed on to internal tracking_setup
-                              call ; If using a different RTM to flux
-                              ramp, the epics root of the pyrogue
-                              server controlling that RTM..  Defaults
-                              to None.
-        channel (int array): Passed on to the internal flux_mod2 call.
-                             Which channels (if any) to plot.  Default
-                             is None.
-        make_plot (bool): Whether or not to make plots.
-        Ret:
+        Args
         ----
-        The estimated lms frequency in Hz
+        band : int
+            Will attempt to estimate the carrier rate on the channels
+            which are on in this band.
+        reset_rate_khz : float
+            The flux ramp reset rate (in kHz).
+        fraction_full_scale : float or None, optional, default None
+            Passed on to the internal tracking_setup call - the
+            fraction of full scale exercised by the flux ramp.
+            Defaults to value in cfg.
+        new_epics_root : str or None, optional, default None
+            Passed on to internal tracking_setup call ; If using a
+            different RTM to flux ramp, the epics root of the pyrogue
+            server controlling that RTM.
+        channel : int array or None, optional, default None
+            Passed on to the internal flux_mod2 call.  Which channels
+            (if any) to plot.
+        make_plot : bool, optional, default False
+            Whether or not to make plots.
+
+        Returns
+        -------
+        float
+            The estimated lms frequency in Hz.
         """
         if fraction_full_scale is None:
             fraction_full_scale = \

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -1841,19 +1841,27 @@ class SmurfTuneMixin(SmurfBase):
         """
         Turns on the tones. Also cuts bad resonators.
 
-        Args:
-        -----
-        band (int): The band to relock
-        Opt args:
-        ---------
-        res_num (int array): The resonators to lock. If None, tries all the
-            resonators.
-        drive (int): The tone amplitudes to set
-        check_vals (bool) : Whether to check r2 and Q values. Default is False.
-        r2_max (float): The highest allowable R^2 value
-        q_max (float): The maximum resonator Q factor
-        q_min (float): The minimum resonator Q factor
-        min_gap (float) : Thee minimum distance between resonators.
+        Args
+        ----
+        band : int
+            The band to relock.
+
+        res_num : int array or None, optional, default None
+            The resonators to lock. If None, tries all the resonators.
+        drive : int or None, optional, default None
+            The tone amplitudes to set.
+        r2_max : float, optional, default 0.08
+            The highest allowable R^2 value.
+        q_max : float, optional, default 1e5
+            The maximum resonator Q factor.
+        q_min : float, optional, default 0
+            The minimum resonator Q factor.
+        check_vals : bool, optional, default False 
+            Whether to check r2 and Q values.
+        min_gap : float or None, optional, default None 
+            The minimum distance between resonators.
+        write_log : bool, optional, default False
+            ???
         """
         n_channels = self.get_number_channels(band)
 
@@ -2110,13 +2118,10 @@ class SmurfTuneMixin(SmurfBase):
 
         Args
         ----
-        band : int)
+        band : int
             The band.
         freq : float
             The frequency to scan.
-
-        Opt Args:
-        ---------
         drive : int, optional, default 12
             The tone amplitude.
         f_sweep_half : float, optional, default 0.3
@@ -2213,19 +2218,23 @@ class SmurfTuneMixin(SmurfBase):
         Tries to measure the V-phi curve in feedback disable mode.
         You can also run this with flux ramp off to see the intrinsic
         noise on the readout channel.
-        Args:
-        -----
-        band (int) : The band to check.
-        Opt Args:
-        ---------
-        reset_rate_khz (float) : The flux ramp rate in kHz.
-        fraction_full_scale (float) : The amplitude of the flux ramp from
-           zero to one.
-        flux_ramp (bool) : Whether to flux ramp. Default is True.
-        save_plot (bool) : Whether to save the plot. Default True.
-        show_plot (bool) : Whether to show the plot. Default False.
-        setup_flux_ramp (bool) : Whether to setup the flux ramp at the end.
-            Default True.
+
+        Args
+        ----
+        band : int
+            The band to check.
+        reset_rate_khz : float or None, optional, default None
+            The flux ramp rate in kHz.
+        fraction_full_scale : float or None, optional, default None
+            The amplitude of the flux ramp from zero to one.
+        flux_ramp : bool, optional, default True
+            Whether to flux ramp.
+        save_plot : bool, optional, default True
+            Whether to save the plot.
+        show_plot : bool, optional, default False
+            Whether to show the plot.
+        setup_flux_ramp : bool, optional, default True
+            Whether to setup the flux ramp at the end.
         """
         if show_plot:
             plt.ion()
@@ -2339,45 +2348,63 @@ class SmurfTuneMixin(SmurfBase):
         just tracks at the input lms frequency. This will also make plots for
         the channels listed in {channel} input.
 
-        Args:
-        -----
-        band (int) : The band number
-        Opt Args:
-        ---------
-        channel (int or int array) : The channels to plot
-        reset_rate_khz (float) : The flux ramp frequency
-        write_log (bool) : Whether to write output to the log.  Default False.
-        make_plot (bool) : Whether to make plots. Default False.
-        save_plot (bool) : Whether to save plots. Default True.
-        plotname_append (string): Appended to the default plot filename.
-            Default ''.
-        show_plot (bool) : Whether to display the plot. Default True.
-        lms_freq_hz (float) : The frequency of the tracking algorithm.
-           Default is 4000
-        flux_ramp (bool) : Whether to turn on flux ramp. Default True.
-        fraction_full_scale (float) : The flux ramp amplitude, as a
-           fraction of the maximum. Default is .4950.
-        lms_enable1 (bool) : Whether to use the first harmonic for tracking.
-           Default True.
-        lms_enable2 (bool) : Whether to use the second harmonic for tracking.
-           Default True.
-        lms_enable3 (bool) : Whether to use the third harmonic for tracking.
-           Default True.
-        lms_gain (int) : The tracking gain parameters. Default is the value
-           in the config table.
-        feedback_start_frac (float) : The fraction of the full flux
-           ramp at which to stop applying feedback in each flux ramp
-           cycle.  Must be in [0,1).  Defaults to whatever's in the cfg
-           file.
-        feedback_end_frac (float) : The fraction of the full flux ramp
-           at which to stop applying feedback in each flux ramp cycle.
-           Must be >0.  Defaults to whatever's in the cfg file.
-        meas_lms_freq (bool) : Whether or not to try to estimate the
-           carrier rate using the flux_mod2 function.  Default false.
-           lms_freq_hz must be None.
-        setup_flux_ramp (bool) : Whether to setup the flux ramp. Default
-           is True.
-        plotname_append (str) : Optional string to append plots with.
+        Args
+        ----
+        band : int
+            The band number.
+
+        channel : int or int array or None, optional default None
+            The channels to plot.
+        reset_rate_khz : float or None, optional default None
+            The flux ramp frequency.
+        write_log : bool, optional default False
+            Whether to write output to the log.
+        make_plot : bool, optional default False
+            Whether to make plots.
+        save_plot : bool, optional default True
+            Whether to save plots.
+        show_plot : bool, optional default True
+            Whether to display the plot.
+        nsamp : int, optional default 2**19
+            ???
+        lms_freq_hz : float or None, optional default None
+            The frequency of the tracking algorithm.
+        meas_lms_freq : bool, optional default False
+            Whether or not to try to estimate the carrier rate using
+            the flux_mod2 function.  lms_freq_hz must be None.
+        meas_flux_ramp_amp : bool, optional default False
+            ???
+        nphi0 : ???, optional default 4
+            ???
+        flux_ramp : bool, optional default True
+            Whether to turn on flux ramp.
+        fraction_full_scale : float or None, optional default None
+            The flux ramp amplitude, as a fraction of the maximum.
+        lms_enable1 : bool, optional default True
+            Whether to use the first harmonic for tracking.
+        lms_enable2 : bool, optional default True
+            Whether to use the second harmonic for tracking.
+        lms_enable3 : bool, optional default True
+            Whether to use the third harmonic for tracking.
+        lms_gain : int or None, optional default None
+            The tracking gain parameters. Default is the value in the
+            config table.
+        return_data : bool, optional default True
+            ???
+        new_epics_root : ??? or None, optional default None
+            ???
+        feedback_start_frac : float or None, optional default None
+            The fraction of the full flux ramp at which to stop
+            applying feedback in each flux ramp cycle.  Must be in
+            [0,1).  Defaults to whatever's in the cfg file.
+        feedback_end_frac : float or None, optional default None
+            The fraction of the full flux ramp at which to stop
+            applying feedback in each flux ramp cycle.  Must be >0.
+            Defaults to whatever's in the cfg file.
+        setup_flux_ramp : bool, optional default True
+            Whether to setup the flux ramp.
+        plotname_append : str, optional default ''
+            Optional string to append plots with.
         """
         if reset_rate_khz is None:
             reset_rate_khz = self.reset_rate_khz

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3888,28 +3888,31 @@ class SmurfTuneMixin(SmurfBase):
         """
         Attempts to find the number of phi0s in a tracking_setup.
         Takes df and sync from a tracking_setup with feedback off.
-        Args:
-        -----
-        band (int) : which band
-        df (float array): The df term from tracking setup with
-            feedback off.
-        sync (float array): The sync term from tracking setup.
-        Opt Args:
-        ---------
-        min_scale (float): The minimum df amplitude used in analysis.
-            This is used to cut channels that are not responding
-            to flux ramp. Default is .002
-        threshold (float): The minimum convolution amplitude to
-            consider a peak. Default is .01
-        make_plot (bool): Whether to make a plot. If True, you must
-            also supply the channels to plot using the channel opt
-            arg.
-        channel (int or int array): The channels to plot. Default
-            is None.
-        Ret:
+
+        Args
         ----
-        n (float): The number of phi0 swept out per sync. To get
-           lms_freq_hz, multiply by the flux ramp frequency.
+        band : int
+            Which band.
+        df : float array
+            The df term from tracking setup with feedback off.
+        sync : float array
+            The sync term from tracking setup.
+        min_scale : float, optional, default 0
+            The minimum df amplitude used in analysis.  This is used
+            to cut channels that are not responding to flux ramp.
+        make_plot : bool, optional, default False
+            Whether to make a plot. If True, you must also supply the
+            channels to plot using the channel opt arg.
+        channel : int or int array or None, optional, default None
+            The channels to plot.
+        threshold : float, optional, default 0.5
+            The minimum convolution amplitude to consider a peak.
+
+        Returns
+        -------
+        n : float
+            The number of phi0 swept out per sync. To get lms_freq_hz,
+            multiply by the flux ramp frequency.
         """
         sync_flag = self.make_sync_flag(sync)
 
@@ -3985,15 +3988,20 @@ class SmurfTuneMixin(SmurfBase):
 
     def make_sync_flag(self, sync):
         """
-        Takes the sync from tracking setup and makes a flag for when the sync
-        is True.
-        Args:
-        -----
-        sync (float array): The sync term from tracking_setup
-        Ret:
+        Takes the sync from tracking setup and makes a flag for when
+        the sync is True.
+
+        Args
         ----
-        start (int array): The start index of the sync
-        end (int array) The end index of the sync
+        sync : float array
+            The sync term from tracking_setup.
+
+        Returns
+        -------
+        start : int array
+            The start index of the sync.
+        end : int array
+            The end index of the sync.
         """
         s, e = self.find_flag_blocks(sync[:,0], min_gap=1000)
         n_proc=self.get_number_processed_channels()
@@ -4110,12 +4118,15 @@ class SmurfTuneMixin(SmurfBase):
     def dump_state(self, output_file=None, return_screen=False):
         """
         Dump the current tuning info to config file and write to disk
-        Args:
-        -----
-        output_file (str): path to output file location. Defaults to the config
-            file status dir and timestamp
-        return_screen (bool): whether to also return the contents of the config
-            file in addition to writing to file. Defaults False.
+
+        Args
+        ----
+        output_file : str or None, optional, default None
+            Path to output file location. Defaults to the config file
+            status dir and timestamp
+        return_screen : bool, optional, default False
+            Whether to also return the contents of the config file in
+            addition to writing to file.
         """
 
         # get the HEMT info because why not
@@ -4162,17 +4173,22 @@ class SmurfTuneMixin(SmurfBase):
         """
         Takes a list of resonance frequencies and fakes a resonance dictionary
         so that we can run setup_notches on a subset without find_freqs
-        Args:
-        freqs (list of floats): given in MHz, list of frequencies to tune.
-        Need to be within 100kHz to be really effective
-        bands (list): band numbers that we have (This should be in the config
-        file but I can't find it...)
-        save_sweeps (bool): whether to save each band as an amplitude sweep.
-        Defaults False.
-        Outputs:
-        resonance dictionary like the one that comes out of find_freqs
-        You probably want to assign it to the right place, as in S.freq_resp =
-        S.fake_resonance_dict(freqs, bands)
+
+        Args
+        ----
+        freqs : list of floats
+            Given in MHz, list of frequencies to tune.  Need to be
+            within 100kHz to be really effective
+        save_sweeps : bool, optional, default False
+            Whether to save each band as an amplitude sweep.
+
+        Returns
+        -------
+        freq_dict : dict
+            Resonance dictionary like the one that comes out of
+            find_freqs You probably want to assign it to the right
+            place, as in S.freq_resp = S.fake_resonance_dict(freqs,
+            bands)
         """
 
         bands = self.config.get('init').get('bands')
@@ -4223,14 +4239,19 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convert the frequency to which band we're in. This is almost certainly
         a duplicate but I can't find the original...
-        Args:
-        -----
-        frequency (float): frequency in MHz
-        band_center_list (list): frequency centers of bands we're running with.
-        Formatted as [[band_no, band_center],[band_no, band_center],etc.]
-        Ret:
+
+        Args
         ----
-        band_no of the frequency
+        frequency : float
+            Frequency in MHz.
+        band_center_list : list
+            Frequency centers of bands we're running with.  Formatted
+            as [[band_no, band_center],[band_no, band_center],etc.]
+
+        Returns
+        -------
+        band_no : int
+            Which band.
         """
 
         band_width = 500. # hardcoding this is probably bad

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -119,44 +119,71 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def tune_band(self, band, freq=None, resp=None, n_samples=2**19,
-            make_plot=False, show_plot=False, plot_chans=[], save_plot=True,
-            save_data=True,  make_subband_plot=False, subband=None, n_scan=5,
-            subband_plot_with_slow=False, drive=None, grad_cut=.05, freq_min=-2.5E8,
-            freq_max=2.5E8, amp_cut=.5, use_slow_eta=False):
+            make_plot=False, show_plot=False, plot_chans=[],
+            save_plot=True, save_data=True, make_subband_plot=False,
+            n_scan=5, subband_plot_with_slow=False, drive=None,
+            grad_cut=.05, freq_min=-2.5E8, freq_max=2.5E8, amp_cut=.5,
+            use_slow_eta=False):
         """
         This does the full_band_resp, which takes the raw resonance data.
         It then finds the where the resonances are. Using the resonance
         locations, it calculates the eta parameters.
-        Args:
-        -----
-        band (int): The band to tune
-        Opt Args:
-        ---------
-        freq (float array): The frequency information. If both freq and resp
-            are not None, it will skip full_band_resp.
-        resp (float array): The response information. If both freq and resp
-            are not None, it will skip full_band_resp.
-        n_samples (int): The number of samples to take in full_band_resp.
-            Default is 2^19.
-        make_plot (bool): Whether to make plots. This is slow, so if you want
-            to tune quickly, set to False. Default True.
-        plot_chans (list): if making plots, which channels to plot. If empty,
-            will just plot all of them
-        save_plot (bool): Whether to save the plot. If True, it will close the
-            plots before they are shown. If False, plots will be brought to the
-            screen.
-        save_data (bool): If True, saves the data to disk.
-        grad_cut (float): The value of the gradient of phase to look for
-            resonances. Default is .05
-        amp_cut (float): The distance from the median value to decide whether
-            there is a resonance. Default is .25.
-        freq_min (float): The minimum frequency relative to the center of
-            the band to look for resonances. Units of Hz. Defaults is -2.5E8
-        freq_max (float): The maximum frequency relative to the center of
-            the band to look for resonances. Units of Hz. Defaults is 2.5E8
-        Returns:
-        --------
-        res (dict): A dictionary with resonance frequency, eta, eta_phase,
+
+        Args
+        ----
+        band : int
+            The band to tune.
+
+        freq : float array or None, optional, default None
+            The frequency information. If both freq and resp are not
+            None, it will skip full_band_resp.
+        resp : float array or None, optional, default None
+            The response information. If both freq and resp are not
+            None, it will skip full_band_resp.
+        n_samples : int, optional, default 2**19
+            The number of samples to take in full_band_resp.
+        make_plot : bool, optional, default False
+            Whether to make plots. This is slow, so if you want to
+            tune quickly, set to False.
+        show_plot : bool, optional, default False
+            Whether to display the plots to screen.
+        plot_chans : list, optional, default []
+            If making plots, which channels to plot. If empty, will
+            just plot all of them.
+        save_plot : bool, optional, default True
+            Whether to save the plot. If True, it will close the plots
+            before they are shown. If False, plots will be brought to
+            the screen.
+        save_data : bool, optional, default True
+            If True, saves the data to disk.
+        make_subband_plot : bool, optional default False
+            Whether to make a plot per subband. This is very slow.
+        n_scan : int, optional, default 5
+            ???
+        subband_plot_with_slow : bool, optional, default False
+            ???
+        drive : int or None, optional, default None
+            ???
+        grad_cut : float, optional, default 0.05
+            The value of the gradient of phase to look for resonances.
+        amp_cut : float, optional, default 
+            The distance from the median value to decide whether
+            there is a resonance.
+        freq_min : float, optional, default -2.5e8
+            The minimum frequency relative to the center of the band
+            to look for resonances. Units of Hz.
+        freq_max : float, optional, default 2.5e8
+            The maximum frequency relative to the center of the band
+            to look for resonances. Units of Hz.
+        amp_cut: float, optional, default 0.5
+            ???
+        use_slow_eta : bool, optional, default False
+            ???
+
+        Returns
+        -------
+        resonances : dict
+            A dictionary with resonance frequency, eta, eta_phase,
             R^2, and amplitude.
         """
         timestamp = self.get_timestamp()
@@ -3933,3 +3960,4 @@ class SmurfTuneMixin(SmurfBase):
             print("Frequency not found. Check band list and that frequency "+
                 "is given in MHz")
             return
+        

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -156,7 +156,7 @@ class SmurfTuneMixin(SmurfBase):
             the screen.
         save_data : bool, optional, default True
             If True, saves the data to disk.
-        make_subband_plot : bool, optional default False
+        make_subband_plot : bool, optional, default False
             Whether to make a plot per subband. This is very slow.
         n_scan : int, optional, default 5
             The number of scans to take and average.
@@ -2353,57 +2353,57 @@ class SmurfTuneMixin(SmurfBase):
         band : int
             The band number.
 
-        channel : int or int array or None, optional default None
+        channel : int or int array or None, optional, default None
             The channels to plot.
-        reset_rate_khz : float or None, optional default None
+        reset_rate_khz : float or None, optional, default None
             The flux ramp frequency.
-        write_log : bool, optional default False
+        write_log : bool, optional, default False
             Whether to write output to the log.
-        make_plot : bool, optional default False
+        make_plot : bool, optional, default False
             Whether to make plots.
-        save_plot : bool, optional default True
+        save_plot : bool, optional, default True
             Whether to save plots.
-        show_plot : bool, optional default True
+        show_plot : bool, optional, default True
             Whether to display the plot.
-        nsamp : int, optional default 2**19
+        nsamp : int, optional, default 2**19
             ???
-        lms_freq_hz : float or None, optional default None
+        lms_freq_hz : float or None, optional, default None
             The frequency of the tracking algorithm.
-        meas_lms_freq : bool, optional default False
+        meas_lms_freq : bool, optional, default False
             Whether or not to try to estimate the carrier rate using
             the flux_mod2 function.  lms_freq_hz must be None.
-        meas_flux_ramp_amp : bool, optional default False
+        meas_flux_ramp_amp : bool, optional, default False
             ???
-        nphi0 : ???, optional default 4
+        nphi0 : ???, optional, default 4
             ???
-        flux_ramp : bool, optional default True
+        flux_ramp : bool, optional, default True
             Whether to turn on flux ramp.
-        fraction_full_scale : float or None, optional default None
+        fraction_full_scale : float or None, optional, default None
             The flux ramp amplitude, as a fraction of the maximum.
-        lms_enable1 : bool, optional default True
+        lms_enable1 : bool, optional, default True
             Whether to use the first harmonic for tracking.
-        lms_enable2 : bool, optional default True
+        lms_enable2 : bool, optional, default True
             Whether to use the second harmonic for tracking.
-        lms_enable3 : bool, optional default True
+        lms_enable3 : bool, optional, default True
             Whether to use the third harmonic for tracking.
-        lms_gain : int or None, optional default None
+        lms_gain : int or None, optional, default None
             The tracking gain parameters. Default is the value in the
             config table.
-        return_data : bool, optional default True
+        return_data : bool, optional, default True
             ???
-        new_epics_root : ??? or None, optional default None
+        new_epics_root : ??? or None, optional, default None
             ???
-        feedback_start_frac : float or None, optional default None
+        feedback_start_frac : float or None, optional, default None
             The fraction of the full flux ramp at which to stop
             applying feedback in each flux ramp cycle.  Must be in
             [0,1).  Defaults to whatever's in the cfg file.
-        feedback_end_frac : float or None, optional default None
+        feedback_end_frac : float or None, optional, default None
             The fraction of the full flux ramp at which to stop
             applying feedback in each flux ramp cycle.  Must be >0.
             Defaults to whatever's in the cfg file.
-        setup_flux_ramp : bool, optional default True
+        setup_flux_ramp : bool, optional, default True
             Whether to setup the flux ramp.
-        plotname_append : str, optional default ''
+        plotname_append : str, optional, default ''
             Optional string to append plots with.
         """
         if reset_rate_khz is None:

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -796,53 +796,56 @@ class SmurfTuneMixin(SmurfBase):
             amp_ylim=None):
         """ Find the peaks within a given subband.
 
-        Parameters:
-        -----------
+        Args
+        ----
         freq : float array
-            should be a single row of the broader freq array, in Mhz.
+            Should be a single row of the broader freq array, in Mhz.
         resp : complex array
-            complex response for just this subband
-        rolling_med : bool
-            Whether to use a rolling median for the background
-        window : int
-            number of samples to window together for rolling med
-        grad_cut : float
-            The value of the gradient of phase to look for resonances. Default
-            is .05
-        amp_cut : float
-            The fractional distance from the median value to decide whether
-            there is a resonance. Default is .25.
-        freq_min : float
-            The minimum frequency relative to the center of the band to look for
-            resonances. Units of Hz. Defaults is -2.5E8
-        freq_max : float
-            The maximum frequency relative to the center of the band to look for
-            resonances. Units of Hz. Defaults is 2.5E8
-        make_plot : bool
-            Whether to make a plot. Default is False.
-        make_subband_plot : bool
-            Whether to make a plot per subband. This is very slow. Default is
-            False.
-        save_plot :bool
-            Whether to save the plot to self.plot_dir. Default is True.
-        plotname_append : string
-            Appended to the default plot filename. Default is ''.
-        band : int
+            Complex response for just this subband.
+        rolling_med : bool, optional, default True
+            Whether to use a rolling median for the background.
+        window : int, optional, default 5000
+            Number of samples to window together for rolling med.
+        grad_cut : float, optional, default 0.5
+            The value of the gradient of phase to look for resonances.
+        amp_cut : float, optional, default 0.25
+            The fractional distance from the median value to decide
+            whether there is a resonance.
+        freq_min : float, optional, default -2.5e8
+            The minimum frequency relative to the center of the band
+            to look for resonances. Units of Hz.
+        freq_max : float, optional, default 2.5e8
+            The maximum frequency relative to the center of the band
+            to look for resonances. Units of Hz.
+        make_plot : bool, optional, default False
+            Whether to make a plot.
+        save_plot : bool, optional, default True
+            Whether to save the plot to self.plot_dir.
+        plotname_append : str, optional, default ''
+            Appended to the default plot filename.
+        show_plot : bool, optional, default False
+            Whether or not to show plots.
+        band : int or None, optional, default None
             The band to take find the peaks in. Mainly for saving and plotting.
-        timestamp : str
-            The timestamp. Mainly for saving and plotting
-        pad : int
-            number of samples to pad on either side of a resonance search window
-        min_gap : int
-            minimum number of samples between resonances
-        grad_kernel_width : int
-            The number of samples to take after a point to calculate the
-            gradient of phase. Default is 8.
-        highlight_phase_slip : bool
-            Whether to highlight the phase slip. Default True.
-        amp_ylim : float
-            The ylim for the amplitude plot. If None, does nothing. Default
-            None.
+        subband : int or None, optional, default None
+            The subband to take find the peaks in. Mainly for saving
+            and plotting.
+        make_subband_plot : bool, optional, default False
+            Whether to make a plot per subband. This is very slow.
+        timestamp : str or None, optional, default None
+            The timestamp. Mainly for saving and plotting.
+        pad : int, optional, default 50
+            Number of samples to pad on either side of a resonance
+            search window.
+        min_gap : int, optional, default 100
+            Minimum number of samples between resonances.
+        grad_kernel_width : int, optional, default 8
+            The number of samples to take after a point to calculate
+            the gradient of phase.
+        highlight_phase_slip : bool, optional, default True
+            Whether to highlight the phase slip.
+        amp_ylim : float or None, optional, default None
+            The ylim for the amplitude plot. If None, does nothing.
 
         Returns
         -------
@@ -3330,10 +3333,10 @@ class SmurfTuneMixin(SmurfBase):
     def plot_find_freq(self, f=None, resp=None, subband=None, filename=None,
             save_plot=True, save_name='amp_sweep.png', show_plot=False):
         '''
-        Plots the response of the frequency sweep. Must input f and resp, or
-        give a path to a text file containing the data for offline plotting.
-        To do:
-        Add ability to use timestamp and multiple plots
+        Plots the response of the frequency sweep. Must input f and
+        resp, or give a path to a text file containing the data for
+        offline plotting.  To do: Add ability to use timestamp and
+        multiple plots.
 
         Args
         ----
@@ -3349,7 +3352,7 @@ class SmurfTuneMixin(SmurfBase):
             Save the plot.
         save_name : str, optional, default 'amp_sweep.png'
             What to name the plot.
-         show_plot : bool, optional, default False
+        show_plot : bool, optional, default False
             Whether to show the plot.
         '''
         if subband is None:
@@ -3387,16 +3390,24 @@ class SmurfTuneMixin(SmurfBase):
 
     def full_band_ampl_sweep(self, band, subband, drive, n_read, n_step=121):
         """sweep a full band in amplitude, for finding frequencies
-        args:
-        -----
-            band (int) = bandNo (500MHz band)
-            subband (int) = which subbands to sweep
-            drive (int) = drive power (defaults to 10)
-            n_read (int) = numbers of times to sweep, defaults to 2
-        returns:
-        --------
-            freq (list, n_freq x 1) = frequencies swept
-            resp (array, n_freq x 2) = complex response
+
+        Args
+        ----
+        band : int
+            bandNo (500MHz band).
+        subband : int
+            Which subbands to sweep.
+        drive : int
+            Drive power.
+        n_read : int
+            Numbers of times to sweep.
+
+        Returns
+        -------
+        freq : (list, n_freq x 1)
+            Frequencies swept.
+        resp : (array, n_freq x 2)
+            Complex response.
         """
         digitizer_freq = self.get_digitizer_frequency_mhz(band)  # in MHz
         n_subbands = self.get_number_sub_bands(band)

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -159,24 +159,22 @@ class SmurfTuneMixin(SmurfBase):
         make_subband_plot : bool, optional default False
             Whether to make a plot per subband. This is very slow.
         n_scan : int, optional, default 5
-            ???
+            The number of scans to take and average.
         subband_plot_with_slow : bool, optional, default False
             ???
         drive : int or None, optional, default None
             ???
         grad_cut : float, optional, default 0.05
             The value of the gradient of phase to look for resonances.
-        amp_cut : float, optional, default 
-            The distance from the median value to decide whether
-            there is a resonance.
         freq_min : float, optional, default -2.5e8
             The minimum frequency relative to the center of the band
             to look for resonances. Units of Hz.
         freq_max : float, optional, default 2.5e8
             The maximum frequency relative to the center of the band
             to look for resonances. Units of Hz.
-        amp_cut: float, optional, default 0.5
-            ???
+        amp_cut : float, optional, default 
+            The distance from the median value to decide whether
+            there is a resonance.
         use_slow_eta : bool, optional, default False
             ???
 
@@ -426,25 +424,30 @@ class SmurfTuneMixin(SmurfBase):
         Plots summary of tuning. Requires self.freq_resp to be filled.
         In other words, you must run find_freq and setup_notches
         before calling this function. Saves the plot to plot_dir.
-        This will also make individual eta plots as well if {eta_scan} is True.
-        The eta scan plots are slow because there are many of them.
+        This will also make individual eta plots as well if {eta_scan}
+        is True.  The eta scan plots are slow because there are many
+        of them.
 
-        Args:
-        -----
-        band (int): The band number to plot
-
-        Opt Args:
-        ---------
-        eta_scan (bool) : Whether to also plot individual eta scans.
-           Warning this is slow. Default is False.
-        show_plot (bool) : Whether to display the plot. Default is False.
-        save_plot (bool) : Whether to save the plot. Default is True.
-        eta_width (float) : The width to plot in MHz.
-        channels (int list) : Which channels to plot.  Default is None,
-                             which plots all available channels.
-        plot_summary (bool) : Plot summary.
-        plotname_append (string): Appended to the default plot filename. Default
-            is ''.
+        Args
+        ----
+        band : int
+            The band number to plot.
+        eta_scan : bool, optional, default False
+           Whether to also plot individual eta scans.  Warning this is
+           slow.
+        show_plot : bool, optional, default False
+            Whether to display the plot.
+        save_plot : bool, optional, default True
+            Whether to save the plot.
+        eta_width : float, optional, default 0.3
+            The width to plot in MHz.
+        channels : list of int or None, optional, default None
+            Which channels to plot.  If None, plots all available
+            channels.
+        plot_summary : bool, optional, default True
+            Plot summary.
+        plotname_append : str, optional, default '' 
+            Appended to the default plot filename.
         """
         if show_plot:
             plt.ion()
@@ -565,37 +568,52 @@ class SmurfTuneMixin(SmurfBase):
         """
         Injects high amplitude noise with known waveform. The ADC measures it.
         The cross correlation contains the information about the resonances.
-        Args:
-        -----
-        band (int): The band to sweep.
 
-        Opt Args:
-        ---------
-        n_scan (int): The number of scans to take and average
-        n_samples (int): The number of samples to take. Default 2^18.
-        make_plot (bool): Whether the make plots. Default is False.
-        show_plot (bool): Whether to show plots. Default False
-        save_data (bool): Whether to save the data.
-        save_raw_data (bool): Whether to save the raw ADC/DAC data. Default
-            False.
-        timestamp (str): The timestamp as a string. If None, loads the current
+        Args
+        ----
+        band : int
+            The band to sweep.
+
+        n_scan : int, optional, default 1
+            The number of scans to take and average.
+        n_samples : int, optional, default 2**19
+            The number of samples to take.
+        make_plot : bool, optional, default False
+            Whether the make plots.
+        save_plot : bool, optional, default True
+            If making plots, whether to save them.
+        show_plot : bool, optional, default False
+            Whether to show plots.
+        save_data : bool, optional, default False
+            Whether to save the data.
+        timestamp : str or None, optional, default None
+            The timestamp as a string. If None, loads the current
             timestamp.
-        correct_att (bool): Correct the response for the attenuators. Default
-            is True.
-        swap (bool): Whether to reverse the data order of the ADC relative
-            to the DAC. This solved an legacy problem. Default False.
-        hw_trigger (bool): Whether to start the broadband noise file using
-            the hardware trigger. Default True.
-        return_plot_path (bool) : Whether to return the full path to the
-            summary plot. Default False.
-        check_if_adc_is_saturated (bool): Right after playing the
-            noise file, checks if ADC for the requested band is
-            saturated.  If it is saturated, gives up with an error.
+        save_raw_data : bool, optional, default False
+            Whether to save the raw ADC/DAC data.
+        correct_att : bool, optional, default True
+            Correct the response for the attenuators.
+        swap : bool, optional, default False
+            Whether to reverse the data order of the ADC relative to
+            the DAC. This solved a legacy problem.
+        hw_trigger : bool, optional, default True 
+            Whether to start the broadband noise file using the
+            hardware trigger.
+        write_log : bool, optional, default False
+            Whether to write output to the log.
+        return_plot_path : bool, optional, default False
+            Whether to return the full path to the summary plot.
+        check_if_adc_is_saturated : bool, optional, default True
+            Right after playing the noise file, checks if ADC for the
+            requested band is saturated.  If it is saturated, gives up
+            with an error.
 
-        Returns:
-        --------
-        f (float array): The frequency information. Length n_samples/2
-        resp (complex array): The response information. Length n_samples/2
+        Returns
+        -------
+        f : float array
+            The frequency information. Length n_samples/2.
+        resp : complex array
+            The response information. Length n_samples/2.
         """
         if timestamp is None:
             timestamp = self.get_timestamp()

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3831,21 +3831,22 @@ class SmurfTuneMixin(SmurfBase):
         This is like estimate_lms_freq, except it changes the
         flux ramp amplitude instead of the flux ramp frequency.
 
-        Args:
-        -----
-        band (int) : The beand to measure
-        n_phi0 (float) : The number of phi0 desired per flux
-            ramp cycle. It is recommended, but not required that
-            this is an integer.
+        Args
+        ----
+        band : int
+            The band to measure.
+        n_phi0 : float
+            The number of phi0 desired per flux ramp cycle. It is
+            recommended, but not required that this is an integer.
 
-        Opt Args:
-        ---------
-        write_log (bool) : Whether to write log messages. Default True.
-        reset_rate_khz (bool) : The reset (or flux ramp cycle) frequency
-            in kHz. If None, reads the current value. Default is None.
-        channel (int array) : The channels to use to estimate the
-            amplitude. If None, uses all channels that are on. Default
-            None.
+        write_log : bool, optional, default True
+            Whether to write log messages.
+        reset_rate_khz : float or None, optional, default None
+            The reset (or flux ramp cycle) frequency in kHz. If None,
+            reads the current value.
+        channel : int array or None, optional, default None
+            The channels to use to estimate the amplitude. If None,
+            uses all channels that are on.
         """
         start_fraction_full_scale = self.get_fraction_full_scale()
         if write_log:

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2352,7 +2352,6 @@ class SmurfTuneMixin(SmurfBase):
         ----
         band : int
             The band number.
-
         channel : int or int array or None, optional, default None
             The channels to plot.
         reset_rate_khz : float or None, optional, default None
@@ -2666,52 +2665,59 @@ class SmurfTuneMixin(SmurfBase):
         all the same inputs and tracking_setup and check_lock. In particular the
         cut parameters are f_min, f_max, and df_max.
 
-        Args:
-        -----
-        band (int): The band to track and check
-
-        Opt Args:
-        ---------
-        channel (int or int array): List of channels to plot.
-        toggle_feedback (bool): Whether or not to reset feedback (both the
-            global band feedbackEnable and the lmsEnables between tracking_setup
-            and  check_lock.
-        relock (bool): Whether or not to relock at the start. Default True.
-        tracking_setup (bool): Whether or not to run tracking_setup. Default
-            True.
-        reset_rate_khz (float) : The flux ramp frequency
-        write_log (bool) : Whether to write output to the log.  Default False.
-        make_plot (bool) : Whether to make plots. Default False.
-        save_plot (bool) : Whether to save plots. Default True.
-        show_plot (bool) : Whether to display the plot. Default True.
-        lms_freq_hz (float) : The frequency of the tracking algorithm.
-           Default is 4000
-        flux_ramp (bool) : Whether to turn on flux ramp. Default True.
-        fraction_full_scale (float) : The flux ramp amplitude, as a
-           fraction of the maximum. Default is .4950.
-        lms_enable1 (bool) : Whether to use the first harmonic for tracking.
-           Default True.
-        lms_enable2 (bool) : Whether to use the second harmonic for tracking.
-           Default True.
-        lms_enable3 (bool) : Whether to use the third harmonic for tracking.
-           Default True.
-        lms_gain (int) : The tracking gain parameters. Default is the value
-           in the config file
-        feedback_start_frac (float) : The fraction of the full flux
-           ramp at which to stop applying feedback in each flux ramp
-           cycle.  Must be in [0,1).  Defaults to whatever's in the cfg
-           file.
-        feedback_end_frac (float) : The fraction of the full flux ramp
-           at which to stop applying feedback in each flux ramp cycle.
-           Must be >0.  Defaults to whatever's in the cfg file.
-        meas_lms_freq (bool) : Whether or not to try to estimate the
-           carrier rate using the flux_mod2 function.  Default false.
-           lms_freq_hz must be None.
-        f_min (float) : The maximum frequency swing.
-        f_max (float) : The minimium frequency swing
-        df_max (float) : The maximum value of the stddev of df
-        setup_flux_ramp (bool) : Whether to setup the flux ramp at the end.
-            Default True.
+        Args
+        ----
+        band : int
+            The band to track and check.
+        channel : int or int array or None, optional, default None
+            List of channels to plot.
+        reset_rate_khz : float or None, optional, default None
+            The flux ramp frequency.
+        make_plot : bool, optional, default False
+            Whether to make plots.
+        save_plot : bool, optional, default True
+            Whether to save plots.
+        show_plot : bool, optional, default True
+            Whether to display the plot.
+        lms_freq_hz : float or None, optional, default None
+            The frequency of the tracking algorithm.
+        flux_ramp : bool, optional, default True
+            Whether to turn on flux ramp.
+        fraction_full_scale : float or None, optional, default None
+            The flux ramp amplitude, as a fraction of the maximum.
+        lms_enable1 : bool, optional, default True
+            Whether to use the first harmonic for tracking.
+        lms_enable2 : bool, optional, default True
+            Whether to use the second harmonic for tracking.
+        lms_enable3 : bool, optional, default True
+            Whether to use the third harmonic for tracking.
+        lms_gain : int or None, optional, default None
+            The tracking gain parameters. Default is the value in the
+            config file
+        f_min : float, optional, default 0.015
+            The maximum frequency swing.
+        f_max : float, optional, default 0.20
+            The minimium frequency swing.
+        df_max : float, optional, default 0.03
+            The maximum value of the stddev of df.
+        toggle_feedback : bool, optional, default True
+            Whether or not to reset feedback (both the global band
+            feedbackEnable and the lmsEnables between tracking_setup
+            and check_lock.
+        relock : bool, optional, default True
+            Whether or not to relock at the start.
+        tracking_setup : bool, optional, default True
+            Whether or not to run tracking_setup.
+        feedback_start_frac : float or None, optional, default None
+            The fraction of the full flux ramp at which to stop
+            applying feedback in each flux ramp cycle.  Must be in
+            [0,1).  Defaults to whatever's in the cfg file.
+        feedback_end_frac : float or None, optional, default None
+            The fraction of the full flux ramp at which to stop
+            applying feedback in each flux ramp cycle.  Must be >0.
+            Defaults to whatever's in the cfg file.
+        setup_flux_ramp : bool, optional, default True
+            Whether to setup the flux ramp at the end.
         """
         if reset_rate_khz is None:
             reset_rate_khz = self.reset_rate_khz

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -171,7 +171,7 @@ class SmurfTuneMixin(SmurfBase):
         freq_max : float, optional, default 2.5e8
             The maximum frequency relative to the center of the band
             to look for resonances. Units of Hz.
-        amp_cut : float, optional, default 
+        amp_cut : float, optional, default 0.5
             The distance from the median value to decide whether
             there is a resonance.
         use_slow_eta : bool, optional, default False
@@ -458,7 +458,7 @@ class SmurfTuneMixin(SmurfBase):
             channels.
         plot_summary : bool, optional, default True
             Plot summary.
-        plotname_append : str, optional, default '' 
+        plotname_append : str, optional, default ''
             Appended to the default plot filename.
         """
         if show_plot:
@@ -608,7 +608,7 @@ class SmurfTuneMixin(SmurfBase):
         swap : bool, optional, default False
             Whether to reverse the data order of the ADC relative to
             the DAC. This solved a legacy problem.
-        hw_trigger : bool, optional, default True 
+        hw_trigger : bool, optional, default True
             Whether to start the broadband noise file using the
             hardware trigger.
         write_log : bool, optional, default False
@@ -1617,7 +1617,7 @@ class SmurfTuneMixin(SmurfBase):
 
         band : int or None, optional, default None
             The band to assign channels.
-        band_center : float array or None, optional, default None 
+        band_center : float array or None, optional, default None
             The frequency center of the band. Must supply band or
             subband center.
         channel_per_subband : int, optional, default 4
@@ -1889,9 +1889,9 @@ class SmurfTuneMixin(SmurfBase):
             The maximum resonator Q factor.
         q_min : float, optional, default 0
             The minimum resonator Q factor.
-        check_vals : bool, optional, default False 
+        check_vals : bool, optional, default False
             Whether to check r2 and Q values.
-        min_gap : float or None, optional, default None 
+        min_gap : float or None, optional, default None
             The minimum distance between resonators.
         write_log : bool, optional, default False
             ???
@@ -4282,4 +4282,3 @@ class SmurfTuneMixin(SmurfBase):
             print("Frequency not found. Check band list and that frequency "+
                 "is given in MHz")
             return
-        

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -1168,32 +1168,48 @@ class SmurfTuneMixin(SmurfBase):
         """
         Cyndia's eta finding code.
 
-        Args:
-        -----
-        freq (float array): The frequency data
-        resp (float array): The response data
-        peak_freq (float): The frequency of the resonance peak
-        delta_freq (float): The width of frequency to calculate values
+        Args
+        ----
+        freq : float array
+            The frequency data.
+        resp : float array
+            The response data.
+        peak_freq : float
+            The frequency of the resonance peak.
+        delta_freq : float
+            The width of frequency to calculate values.
+        make_plot : bool, optional, default False
+            Whether to make plots.
+        plot_chans : int array, optional, default []
+            The channels to plot. If an empty array, it will make
+            plots for all channels.
+        save_plot : bool, optional, default True
+            Whether to save plots.
+        band : int or None, optional, default None
+            Only used for plotting - the band number of the resontaor.
+        timestamp : str or None, optional, default None
+            The timestamp of the data.
+        res_num : int or None, optional, default None
+            The resonator number.
+        use_slow_eta : bool, optional, default False
+            ???.
 
-        Opt Args:
-        ---------
-        make_plot (bool): Whether to make plots. Default is False.
-        save_plot (bool): Whether to save plots. Default is True.
-        plot_chans (int array): The channels to plot. If an empty array, it
-            will make plots for all channels.
-        band (int): Only used for plotting - the band number of the resontaor
-        timestamp (str): The timestamp of the data.
-        res_num (int): The resonator number
-
-        Rets:
-        -----
-        eta (complex): The eta parameter
-        eta_scaled (complex): The eta parameter divided by subband_half_Width
-        eta_phase_deg (float): The angle to rotate IQ circle
-        r2 (float): The R^2 value copared to the resonator fit
-        eta_mag (float): The amplitude of eta
-        latency (float): THe delay
-        Q (float): THe resonator quality factor
+        Returns
+        -------
+        eta : complex
+            The eta parameter.
+        eta_scaled : complex
+            The eta parameter divided by subband_half_width.
+        eta_phase_deg : float
+            The angle to rotate IQ circle.
+        r2 : float
+            The R^2 value compared to the resonator fit.
+        eta_mag : float
+            The amplitude of eta.
+        latency : float
+            The delay.
+        Q : float
+            The resonator quality factor.
         """
 
         if band is None:
@@ -1283,23 +1299,42 @@ class SmurfTuneMixin(SmurfBase):
         Plots the eta parameter fits. This is called by self.eta_fit or
         plot_tune_summary.
 
-        Args:
-        -----
-        freq (float array): The frequency data
-        resp (complex array): THe response data
-
-        Opt Args:
-        ---------
-        eta (complex): The eta parameter
-        eta_mag (complex): The amplitude of the eta parameter
-        eta_phase_deg (float): The angle of the eta parameter in degrees
-        r2 (float): The R^2 value
-        save_plot (bool): Whether to save the plot. Default True.
-        plotname_append (string): Appended to the default plot filename. Default ''.
-        timestamp (str): The timestamp to name the file
-        res_num (int): The resonator number to label the plot
-        band (int): The band number to label the plot
-        sk_fit (flot array): The fit parameters for the skewe lorentzian
+        Args
+        ----
+        freq : float array
+            The frequency data.
+        resp : complex array
+            The response data.
+        eta : complex or None, optional, default None
+            The eta parameter.
+        eta_mag : complex or None, optional, default None
+            The amplitude of the eta parameter.
+        peak_freq : ??? or None, optional, default None
+            ???
+        eta_phase_deg : float or None, optional, default None
+            The angle of the eta parameter in degrees.
+        r2 : float or None, optional, default None
+            The R^2 value.
+        save_plot : bool, optional, default True
+            Whether to save the plot.
+        plotname_append : str, optional, default ''
+            Appended to the default plot filename.
+        show_plot : bool, optional, default False
+            ???
+        timestamp : str or None, optional, default None
+            The timestamp to name the file.
+        res_num : int or None, optional, default None
+            The resonator number to label the plot.
+        band : int or None, optional, default None
+            The band number to label the plot.
+        sk_fit : float array or None, optional, default None
+            The fit parameters for the skewed lorentzian.
+        f_slow : ??? or None, optional, default None
+            ???
+        resp_slow : ??? or None, optional, default None
+            ???
+        channel : ??? or None, optional, default None
+            ???
         """
         if timestamp is None:
             timestamp = self.get_timestamp()

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3061,12 +3061,16 @@ class SmurfTuneMixin(SmurfBase):
     def get_fraction_full_scale(self, new_epics_root=None):
         """
         Returns the fraction_full_scale.
-        Opt Args:
-        ---------
-        new_epics_root (str) : Overrides the initialized epics root.
-        Ret:
+
+        Args
         ----
-        fraction_full_scale (float) : The fraction of the flux ramp amplitude
+        new_epics_root : str or None, optional, default None
+            Overrides the initialized epics root.
+
+        Returns
+        -------
+        fraction_full_scale : float
+            The fraction of the flux ramp amplitude.
         """
         return 1-2*(self.get_fast_slow_rst_value(new_epics_root=new_epics_root)/
                     2**self.num_flux_ramp_counter_bits)
@@ -3081,26 +3085,35 @@ class SmurfTuneMixin(SmurfBase):
         tracking. The limits are set by the variables f_min, f_max,
         and df_max. The output is stored to freq_resp[band]['lock_status'] dict.
 
-        Args:
-        -----
-        band (int) : The band the check
-        Opt Args:
-        ---------
-        f_min (float) : The maximum frequency swing.
-        f_max (float) : The minimium frequency swing
-        df_max (float) : The maximum value of the stddev of df
-        make_plot (bool) : Whether to make plots. Default False
-        flux_ramp (bool) : Whether to flux ramp or not. Default True
-        faction_full_scale (float): Number between 0 and 1. The amplitude
-           of the flux ramp.
-        lms_freq_hz (float) : The tracking frequency in Hz. Default is None
-        reset_rate_khz (float) : The flux ramp reset rate in kHz.
-        feedback_start_frac (float) : What fraction of the flux ramp to
-            skip before feedback. Float between 0 and 1.
-        feedback_end_frac (float) : What fraction of the flux ramp to skip
-            at the end of feedback. Float between 0 and 1.
-        setup_flux_ramp (bool) : Whether to setup the flux ramp at the end.
-            Default is True.
+        Args
+        ----
+        band : int
+            The band the check.
+
+        f_min : float, optional, default 0.015
+            The maximum frequency swing.
+        f_max : float, optional, default 0.2
+            The minimium frequency swing.
+        df_max : float, optional, default 0.03
+            The maximum value of the stddev of df.
+        make_plot : bool, optional, default False
+            Whether to make plots.
+        flux_ramp : bool, optional, default True
+            Whether to flux ramp or not.
+        faction_full_scale : float, optional, default None
+            Number between 0 and 1. The amplitude of the flux ramp.
+        lms_freq_hz : float or None, optional, default None
+            The tracking frequency in Hz.
+        reset_rate_khz : float or None, optional, default None
+            The flux ramp reset rate in kHz.
+        feedback_start_frac : float or None, optional, default None
+            What fraction of the flux ramp to skip before
+            feedback. Float between 0 and 1.
+        feedback_end_frac : float or None, optional, default None
+            What fraction of the flux ramp to skip at the end of
+            feedback. Float between 0 and 1.
+        setup_flux_ramp : bool, optional, default True
+            Whether to setup the flux ramp at the end.
         """
         self.log('Checking lock on band {}'.format(band))
 
@@ -3186,27 +3199,39 @@ class SmurfTuneMixin(SmurfBase):
             show_plot=False, grad_cut=.05, amp_cut=.25, pad=2, min_gap=2):
         '''
         Finds the resonances in a band (and specified subbands)
-        Args:
-        -----
-        band (int) : The band to search
-        Optional Args:
-        --------------
-        subband (int) : An int array for the subbands
-        drive_power (int) : The drive amplitude.  If none given, takes from cfg.
-        n_read (int) : The number sweeps to do per subband
-        make_plot (bool) : make the plot frequency sweep. Default False.
-        save_plot (bool) : save the plot. Default True.
-        plotname_append (string): Appended to the default plot filename. Default ''.
-        rolling_med (bool) : Whether to iterate on a rolling median or just
-           the median of the whole sample.
-        window (int) : The width of the rolling median window
-        pad (int): number of samples to pad on either side of a resonance search
-            window
-        min_gap (int): minimum number of samples between resonances
-        grad_cut (float): The value of the gradient of phase to look for
-            resonances. Default is .05
-        amp_cut (float): The fractional distance from the median value to decide
-            whether there is a resonance. Default is .25.
+
+        Args
+        ----
+        band : int
+            The band to search.
+        subband : numpy.ndarray of int, optional, default numpy.arange(13,115)
+            An int array for the subbands.
+        drive_power : int or None, optional, default None
+            The drive amplitude.  If None, takes from cfg.
+        n_read : int, optional, default 2
+            The number sweeps to do per subband.
+        make_plot : bool, optional, default False
+            Make the plot frequency sweep.
+        save_plot : bool, optional, default True
+            Save the plot.
+        plotname_append : str, optional, default ''
+            Appended to the default plot filename.
+        window : int, optional, default 50
+            The width of the rolling median window.
+        rolling_med : bool, optional, default True
+            Whether to iterate on a rolling median or just the median
+            of the whole sample.
+        grad_cut : float, optional, default 0.05
+            The value of the gradient of phase to look for
+            resonances.
+        amp_cut : float, optional, default 0.25
+            The fractional distance from the median value to decide
+            whether there is a resonance.
+        pad : int, optional, default 2
+            Number of samples to pad on either side of a resonance
+            search window
+        min_gap : int, optional, default 2
+            Minimum number of samples between resonances.
         '''
 
         # Turn off all tones in this band first.  May want to make
@@ -3280,16 +3305,22 @@ class SmurfTuneMixin(SmurfBase):
         To do:
         Add ability to use timestamp and multiple plots
 
-        Opt Args:
-        ---------
-        f (float array) : An array of frequency data
-        resp (complex array) : An array of find_freq response values
-        subband (int array): A list of subbands that are scanned
-        filename (str) : The full path to the file where the find_freq
-            is stored.
-        save_plot (bool) : save the plot. Default True.
-        show_plot (bool) : Whether to show the plot. Defualt False.
-        save_name (string) : What to name the plot. default find_freq.png
+        Args
+        ----
+        f : float array or None, optional, default None
+            An array of frequency data.
+        resp : complex array or None, optional, default None
+            An array of find_freq response values.
+        subband : int array or None, optional, default None
+            A list of subbands that are scanned.
+        filename : str or None, optional, default None
+            The full path to the file where the find_freq is stored.
+        save_plot : bool, optional, default True
+            Save the plot.
+        save_name : str, optional, default 'amp_sweep.png'
+            What to name the plot.
+         show_plot : bool, optional, default False
+            Whether to show the plot.
         '''
         if subband is None:
             subband = np.arange(128)

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2872,10 +2872,15 @@ class SmurfTuneMixin(SmurfBase):
             do_config=True):
         """
         ???
-        Args:
+
+        Args
         -----
-        fractionFullScale (float) : Fraction of full flux ramp scale to output
-        from [-1,1]
+        fractionFullScale : float
+            Fraction of full flux ramp scale to output from [-1,1].
+        debug : bool, optional, default True
+            ???
+        do_config : bool, optional, default True
+            ???
         """
 
         # fractionFullScale must be between [0,1]
@@ -2937,18 +2942,23 @@ class SmurfTuneMixin(SmurfBase):
         Set flux ramp sawtooth rate and amplitude. If there are errors, check
         that you are using an allowed reset rate! Not all rates are allowed.
         Allowed rates: 1, 2, 3, 4, 5, 6, 8, 10, 12, 15 kHz
-        Args:
-        -----
-        reset_rate_khz (int) : The flux ramp rate to set in kHz. The allowable
-            values are 1, 2, 3, 4, 5, 6, 8, 10, 12, 15 kHz
-        fraction_full_scale (float) : The amplitude of the flux ramp as a
-            fraction of the maximum possible value.
-        Opt Args:
-        ---------
-        df_range (float) :
-        band (int) : The band to setup the flux ramp on.
-        write_log (bool) : Whether to write output to the log
-        new_epics_root (str) : Override the original epics root.
+
+        Args
+        ----
+        reset_rate_khz : int
+            The flux ramp rate to set in kHz. The allowable values are
+            1, 2, 3, 4, 5, 6, 8, 10, 12, 15 kHz
+        fraction_full_scale : float
+            The amplitude of the flux ramp as a fraction of the
+            maximum possible value.
+        df_range : float, optional, default 0.1
+            ???
+        band : int, optional, default 2
+            The band to setup the flux ramp on.
+        write_log : bool, optional, default False
+            Whether to write output to the log.
+        new_epics_root : str or None, optional, default None
+            Override the original epics root.
         """
 
         # Disable flux ramp

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -39,29 +39,40 @@ class SmurfTuneMixin(SmurfBase):
         This runs a tuning, does tracking setup, and prunes bad
         channels using check lock. When this is done, we should
         be ready to take data.
-        Opt Args:
-        ---------
-        load_tune (bool): Whether to load in a tuning file. If False, will
-            do a full tuning. This will be very slow (~ 1 hour)
-        tune_file (str): The tuning file to load in. Default is None. If
-            tune_file is None and last_tune is False, this will load the
-            default tune file defined in exp.cfg.
-        last_tune (bool): Whether to load the most recent tuning file. Default
-            is False.
-        retune (bool): Whether to re-run tune_band_serial to refind peaks and
-            eta params. This will take about 5 minutes. Default is False.
-        f_min (float): The minimum frequency swing allowable for check_lock.
-        f_max (float): The maximum frequency swing allowable for check_lock.
-        df_max (float): The maximum df stddev allowable for check_lock.
-        fraction_full_scale (float): The fraction (between 0-1) to set the
-            flux ramp amplitude.
-        make_plot (bool): Whether to make a plot. Default is False.
-        save_plot (bool): If making plots, whether to save them. Default is True.
-        show_plot (bool): Whether to display the plots to screen. Default is False.
-        track_and_check (bool): Whether or not after tuning to run
-            track and check.  Default is True.
-        new_master_assignment (bool): Whether to make a new master assignment
-            which forces resonators at a given frequency to a given channel.
+
+        Args
+        ----
+        load_tune : bool, optional, default True
+            Whether to load in a tuning file. If False, will do a full
+            tuning. This will be very slow (~ 1 hour)
+        tune_file : str or None, optional, default None
+            The tuning file to load in. If tune_file is None and
+            last_tune is False, this will load the default tune file
+            defined in exp.cfg.
+        last_tune : bool, optional, default False
+            Whether to load the most recent tuning file.
+        retune : bool, optional, default False
+            Whether to re-run tune_band_serial to refind peaks and eta
+            params. This will take about 5 minutes.
+        f_min : float, optional, default 0.02
+            The minimum frequency swing allowable for check_lock.
+        f_max : float, optional, default 0.3
+            The maximum frequency swing allowable for check_lock.
+        df_max : float, optional, default 0.03
+            The maximum df stddev allowable for check_lock.
+        fraction_full_scale : float or None, optional, default None
+            The fraction (between 0-1) to set the flux ramp amplitude.
+        make_plot : bool, optional, default False
+            Whether to make a plot.
+        save_plot : bool, optional, default True
+            If making plots, whether to save them.
+        show_plot : bool, optional, default False
+            Whether to display the plots to screen.
+        new_master_assignment : bool, optional, default False
+            Whether to make a new master assignment which forces
+            resonators at a given frequency to a given channel.
+        track_and_check : bool, optional, default True
+            Whether or not after tuning to run track and check.
         """
         bands = self.config.get('init').get('bands')
         tune_cfg = self.config.get('tune_band')

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -784,44 +784,63 @@ class SmurfTuneMixin(SmurfBase):
         """
         Find the peaks within a given subband.
 
-        Args:
+        Args
         -----
-        freq (float array): should be a single row of the broader freq
-                            array, in Mhz.
-        resp (complex array): complex response for just this subband
+        freq : float array
+            Should be a single row of the broader freq array, in MHz.
+        resp : complex array
+            Complex response for just this subband.
 
-        Opt Args:
-        ---------
-        rolling_med (bool): whether to use a rolling median for the background
-        window (int): number of samples to window together for rolling med
-        grad_cut (float): The value of the gradient of phase to look for
-            resonances. Default is .05
-        amp_cut (float): The fractional distance from the median value to decide
-            whether there is a resonance. Default is .25.
-        freq_min (float): The minimum frequency relative to the center of
-            the band to look for resonances. Units of Hz. Defaults is -2.5E8
-        freq_max (float): The maximum frequency relative to the center of
-            the band to look for resonances. Units of Hz. Defaults is 2.5E8
-        make_plot (bool): Whether to make a plot. Default is False.
-        make_subband_plot (bool): Whether to make a plot per subband. This is
-            very slow. Default is False.
-        save_plot (bool): Whether to save the plot to self.plot_dir. Default
-            is True.
-        plotname_append (string): Appended to the default plot filename.
-            Default is ''.
-        band (int): The band to take find the peaks in. Mainly for saving
+        rolling_med : bool, optional, default True
+            Whether to use a rolling median for the background.
+        window : int, optional, default 5000
+            Number of samples to window together for rolling med.
+        grad_cut : float, optional, default 0.5
+            The value of the gradient of phase to look for resonances.
+        amp_cut : float, optional, default 0.25
+            The fractional distance from the median value to decide
+            whether there is a resonance.
+        freq_min : float, optional, default -2.5e8
+            The minimum frequency relative to the center of the band
+            to look for resonances. Units of Hz.
+        freq_max : float, optional, default 2.5e8
+            The maximum frequency relative to the center of the band
+            to look for resonances. Units of Hz.
+        make_plot : bool, optional, default False
+            Whether to make a plot.
+        save_plot : bool, optional, default True
+            Whether to save the plot to self.plot_dir.
+        plotname_append : str, optional, default '' 
+            Appended to the default plot filename.
+        show_plot : bool, optional, default False
+            ???
+        band : int or None, optional, default None
+            The band to take find the peaks in. Mainly for saving and
+            plotting.
+        subband : int or None, optional, default None
+            The subband to take find the peaks in. Mainly for saving
             and plotting.
-        timestamp (str): The timestamp. Mainly for saving and plotting
-        pad (int): number of samples to pad on either side of a resonance search
-            window
-        min_gap (int): minimum number of samples between resonances
-        grad_kernel_width (int) : The number of samples to take after a point
-            to calculate the gradient of phase. Default is 8.
+        make_subband_plot : bool, optional, default False
+            Whether to make a plot per subband. This is very slow.
+        subband_plot_with_slow : bool, optional, default False
+            ???
+        timestamp : str or None, optional, default None
+            The timestamp. Mainly for saving and plotting.
+        pad : int, optional, default 50
+            Number of samples to pad on either side of a resonance
+            search window.
+        min_gap : int, optional, default 100
+            Minimum number of samples between resonances.
+        plot_title : str or None, optional, default None
+            ???
+        grad_kernel_width : int, optional, default 8
+            The number of samples to take after a point to calculate
+            the gradient of phase.
 
-        Returns:
-        -------_
-        resonances (float array): The frequency of the resonances in the band
-            in Hz.
+        Returns
+        -------
+        float array
+            The frequencies of the resonances in the band in Hz.
         """
         if timestamp is None:
             timestamp = self.get_timestamp()
@@ -996,25 +1015,28 @@ class SmurfTuneMixin(SmurfBase):
 
     def find_flag_blocks(self, flag, minimum=None, min_gap=None):
         """
-        Find blocks of adjacent points in a boolean array with the same value.
+        Find blocks of adjacent points in a boolean array with the
+        same value.
 
-        Args:
-        -----
-        flag : bool, array_like
-            The array in which to find blocks
+        Args
+        ----
+        flag : array-like of bool
+            The array in which to find blocks.
+        minimum : int or None, optional, default None
+            The minimum length of block to return. Discards shorter
+            blocks.
+        min_gap : int or None, optional, default None
+            The minimum gap between flag blocks. Fills in gaps
+            smaller.
 
-        Opt Args:
-        ---------
-        minimum : int (optional)
-            The minimum length of block to return. Discards shorter blocks
-        min_gap : int (optional)
-            The minimum gap between flag blocks. Fills in gaps smaller.
         Returns
         -------
-        starts, ends : int arrays
-            The start and end indices for each block.
-            NOTE: the end index is the last index in the block. Add 1 for
-            slicing, where the upper limit should be after the block
+        starts : list of int
+            The start indices for each block.
+        ends : list of int
+            The end indices for each block.  NOTE: the end index is
+            the last index in the block. Add 1 for slicing, where the
+            upper limit should be after the block
         """
         if min_gap is not None:
             _flag = self.pad_flags(np.asarray(flag, dtype=bool),
@@ -1041,18 +1063,24 @@ class SmurfTuneMixin(SmurfBase):
         """
         Adds and combines flagging.
 
-        Args:
-        -----
-        f (bool array): The flag array to pad
-        Opt Args:
-        ---------
-        before_pad (int): The number of samples to pad before a flag
-        after_pad (int); The number of samples to pad after a flag
-        min_gap (int): The smallest allowable gap. If bigger, it combines.
-        min_length (int): The smallest length a pad can be.
-        Ret:
+        Args
         ----
-        pad_flag (bool array): The padded boolean array
+        f : list of bool
+            The flag array to pad.
+
+        before_pad : int, optional, default 0
+            The number of samples to pad before a flag.
+        after_pad : int, optional, default 0
+            The number of samples to pad after a flag.
+        min_gap : int, optional, default 0
+            The smallest allowable gap. If bigger, it combines.
+        min_length : int, optional, default 0
+            The smallest length a pad can be.
+
+        Returns
+        -------
+        pad_flag : list of bool
+            The padded boolean array.
         """
         before, after = self.find_flag_blocks(f)
         after += 1
@@ -1076,16 +1104,18 @@ class SmurfTuneMixin(SmurfBase):
         """
         Plots the output of find_freq.
 
-        Args:
-        -----
-        freq (float array): The frequency data
-        resp (float array): The response to full_band_resp
-        peak_ind (int array): The indicies of peaks found
-
-        Opt Args:
-        ---------
-        save_plot (bool): Whether to save the plot
-        save_name (str): THe name of the plot
+        Args
+        ----
+        freq : float array
+            The frequency data.
+        resp : float array
+            The response to full_band_resp.
+        peak_ind : int array
+            The indicies of peaks found.
+        save_plot : bool, optional, default True
+            Whether to save the plot.
+        save_name : str or None, optional, default None
+            The name of the plot.
         """
         if save_plot:
             plt.ioff()
@@ -1404,13 +1434,20 @@ class SmurfTuneMixin(SmurfBase):
     def get_closest_subband(self, f, band, as_offset=True):
         """
         Gives the closest subband number for a given input frequency.
-        Args:
-        -----
-        f (float): The frequency to search for a subband
-        band (int): The band to identify
-        Ret:
+
+        Args
         ----
-        subband (int): The subband that contains the frequency
+        f : float
+            The frequency to search for a subband.
+        band : int
+            The band to identify.
+        as_offset : bool, optional, default True
+            ???
+
+        Returns
+        -------
+        subband : int
+            The subband that contains the frequency.
         """
         # get subband centers:
         subbands, centers = self.get_subband_centers(band, as_offset=as_offset)
@@ -1426,13 +1463,18 @@ class SmurfTuneMixin(SmurfBase):
     def check_freq_scale(self, f1, f2):
         """
         Makes sure that items are the same frequency scale (ie MHz, kHZ, etc.)
-        Args:
-        -----
-        f1 (float): The first frequency
-        f2 (float): The second frequency
-        Ret:
+
+        Args
         ----
-        same_scale (bool): Whether the frequency scales are the same
+        f1 : float
+            The first frequency.
+        f2 : float
+            The second frequency.
+
+        Returns
+        -------
+        same_scale : bool
+            Whether the frequency scales are the same.
         """
         if abs(f1/f2) > 1e3:
             return False
@@ -1445,11 +1487,13 @@ class SmurfTuneMixin(SmurfBase):
         By default, pysmurf loads the most recent master assignment.
         Use this function to overwrite the default one.
 
-        Args:
-        -----
-        band (int): The band for the master assignment file
-        filename (str): The full path to the new master assignment
-            file. Should be in self.tune_dir.
+        Args
+        ----
+        band : int
+            The band for the master assignment file.
+        filename : str
+            The full path to the new master assignment file. Should be
+            in self.tune_dir.
         """
         if 'band_{}'.format(band) in self.channel_assignment_files.keys():
             self.log('Old master assignment file:'+
@@ -1462,15 +1506,22 @@ class SmurfTuneMixin(SmurfBase):
     def get_master_assignment(self, band):
         """
         Returns the master assignment list.
-        Args:
-        -----
-        band (int) : The band number
-        Ret:
+
+        Args
         ----
-        freqs (float array): The frequency of the resonators
-        subbands (int array): The subbands the channels are assigned to
-        channels (int array): The channels the resonators are assigned to
-        groups (int array): The bias group the channel is in
+        band : int
+            The band number.
+
+        Returns
+        -------
+        freqs : float array
+            The frequency of the resonators.
+        subbands : int array
+            The subbands the channels are assigned to.
+        channels : int array
+            The channels the resonators are assigned to.
+        groups : int array
+            The bias group the channel is in.
         """
         fn = self.channel_assignment_files[f'band_{band}']
         self.log(f'Drawing channel assignments from {fn}')
@@ -1489,27 +1540,34 @@ class SmurfTuneMixin(SmurfBase):
         """
         Figures out the subbands and channels to assign to resonators
 
-        Args:
-        -----
-        freq (flot array): The frequency of the resonators. This is not the
-            same as the frequency output from full_band_resp. This is only
+        Args
+        ----
+        freq : float array
+            The frequency of the resonators. This is not the same as
+            the frequency output from full_band_resp. This is only
             where the resonators are.
 
-        Opt Args:
-        ---------
-        band (int): The band to assign channels
-        band_center (float array): The frequency center of the band. Must supply
-            band or subband center.
-        channel_per_subband (int): The number of channels to assign per
-            subband. Default is 4.
-        min_offset (float): The minimum offset between two resonators in MHz.
-            If closer, then both are ignored.
+        band : int or None, optional, default None
+            The band to assign channels.
+        band_center : float array or None, optional, default None 
+            The frequency center of the band. Must supply band or
+            subband center.
+        channel_per_subband : int, optional, default 4
+            The number of channels to assign per subband.
+        as_offset : bool, optional, default True
+            ???
+        min_offset : float, optional, default 0.1
+            The minimum offset between two resonators in MHz.  If
+            closer, then both are ignored.
 
-        Ret:
-        ----
-        subbands (int array): An array of subbands to assign resonators
-        channels (int array): An array of channel numbers to assign resonators
-        offsets (float array): The frequency offset from the subband center
+        Returns
+        -------
+        subbands : int array
+            An array of subbands to assign resonators.
+        channels : int array
+            An array of channel numbers to assign resonators.
+        offsets : float array
+            The frequency offset from the subband center.
         """
         freq = np.sort(freq)  # Just making sure its in sequential order
 
@@ -1592,17 +1650,18 @@ class SmurfTuneMixin(SmurfBase):
         channel, group. Group number defaults to -1. The order of inputs is
         legacy and weird.
 
-        Args:
-        -----
-        band (int array) : A list of bands
-        freqs (float array) : A list of frequencies
-        subbands (int array) : A list of subbands
-        channels (int array) : A list of channel numbers
-
-        Opt Args:
-        ---------
-        bias_groups (int array) : A list of bias groups. If None,
-           populates the array with -1.
+        Args
+        ----
+        band : int array
+            A list of bands.
+        freqs : float array
+            A list of frequencies.
+        subbands : int array
+            A list of subbands
+        channels : int array
+            A list of channel numbers
+        bias_groups : list of int or None, optional, default None
+            A list of bias groups. If None, fills the array with -1.
         '''
         timestamp = self.get_timestamp()
         if bias_groups is None:
@@ -1624,11 +1683,13 @@ class SmurfTuneMixin(SmurfBase):
         """
         Makes a master assignment file
 
-        Args:
-        -----
-        band (int) : The band number
-        tuning_filename : The tuning file to use for generating the
-            master_assignemnt
+        Args
+        ----
+        band : int
+            The band number.
+        tuning_filename : str
+            The tuning file to use for generating the
+            master_assignment.
         """
         self.log('Drawing band-{} tuning data from {}'.format(band,
             tuning_filename))
@@ -1654,15 +1715,17 @@ class SmurfTuneMixin(SmurfBase):
         group. Note that it is possible to have channels that are
         on the same bias group but different bands.
 
-        Args:
+        Args
         ----
-        band (int) : The band number.
-        group (int) : The bias group number.
+        band : int
+            The band number.
+        group : int
+            The bias group number.
 
-        Ret:
-        ----
-        bias_group_list (int array) : The list of channels that
-            are in the band and bias group.
+        Returns
+        -------
+        bias_group_list : int array
+            The list of channels that are in the band and bias group.
         """
         _, _, channels, groups = self.get_master_assignment(band)
         chs_in_group = []
@@ -1677,14 +1740,17 @@ class SmurfTuneMixin(SmurfBase):
         Gets the bias group number of a band, channel pair. The
         master_channel_assignment must be filled.
 
-        Args:
-        -----
-        band (int) : The band number
-        ch (int) : The channel number
-
-        Ret:
+        Args
         ----
-        bias_group (int) : The bias group number
+        band : int
+            The band number.
+        ch : int
+            The channel number.
+
+        Returns
+        -------
+        bias_group : int
+            The bias group number.
         """
         _, _, channels,groups = self.get_master_assignment(band)
         for i in range(len(channels)):
@@ -1698,9 +1764,10 @@ class SmurfTuneMixin(SmurfBase):
         Combs master channel assignment and assigns group number to all channels
         in ch_list. Does not affect other channels in the master file.
 
-        Args:
-        -----
-        bias_group_dict (dict) : The output of identify_bias_groups
+        Args
+        ----
+        bias_group_dict : dict
+            The output of identify_bias_groups.
         '''
         bias_groups = list(bias_group_dict.keys())
 
@@ -1839,14 +1906,17 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convenience function to get values from the freq_resp dictionary.
 
-        Args:
-        -----
-        band (int) : The 500 MHz band to get values from
-        key (str) : The dictionary value to read out
-
-        Ret:
+        Args
         ----
-        val (array) : The array of values associated with key.
+        band : int
+            The 500 MHz band to get values from.
+        key : str
+            The dictionary value to read out.
+
+        Returns
+        -------
+        array
+            The array of values associated with key.
         """
         if 'resonances' not in self.freq_resp[band].keys():
             self.log('No tuning. Run setup_notches() or load_tune()')
@@ -1860,13 +1930,15 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convenience function that gets the frequency results from eta scans.
 
-        Args:
-        -----
-        band (int) : The band
-
-        Ret:
+        Args
         ----
-        freq (float array) : The frequency in MHz of the resonators.
+        band : int
+            The band.
+
+        Returns
+        -------
+        freq : float array
+            The frequency in MHz of the resonators.
         """
         return self._get_eta_scan_result_from_key(band, 'freq')
 
@@ -1875,13 +1947,15 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convenience function that gets thee eta values from eta scans.
 
-        Args:
-        -----
-        band (int) : The band
-
-        Ret:
+        Args
         ----
-        eta (complex array) : The eta of the resonators.
+        band : int
+            The band.
+
+        Returns
+        -------
+        eta : complex array
+            The eta of the resonators.
         """
         return self._get_eta_scan_result_from_key(band, 'eta')
 
@@ -1891,13 +1965,15 @@ class SmurfTuneMixin(SmurfBase):
         Convenience function that gets thee eta mags from
         eta scans.
 
-        Args:
-        -----
-        band (int) : The band
-
-        Ret:
+        Args
         ----
-        eta_mag (float array) : The eta of the resonators.
+        band : int
+            The band.
+
+        Returns
+        -------
+        eta_mag : float array
+            The eta of the resonators.
         """
         return self._get_eta_scan_result_from_key(band, 'eta_mag')
 
@@ -1907,13 +1983,15 @@ class SmurfTuneMixin(SmurfBase):
         Convenience function that gets the eta scaled from
         eta scans. eta_scaled is eta_mag/digitizer_freq_mhz/n_subbands
 
-        Args:
-        -----
-        band (int) : The band
-
-        Ret:
+        Args
         ----
-        eta_mag (float array) : The eta_scaled of the resonators.
+        band : int
+            The band.
+
+        Returns
+        -------
+        eta_scaled : float array
+            The eta_scaled of the resonators.
         """
         return self._get_eta_scan_result_from_key(band, 'eta_scaled')
 
@@ -1923,13 +2001,15 @@ class SmurfTuneMixin(SmurfBase):
         Convenience function that gets the eta phase values from
         eta scans.
 
-        Args:
-        -----
-        band (int) : The band
-
-        Ret:
+        Args
         ----
-        eta_phase (float array) : The eta_phase of the resonators.
+        band : int
+            The band.
+
+        Returns
+        -------
+        eta_phase : float array
+            The eta_phase of the resonators.
         """
         return self._get_eta_scan_result_from_key(band, 'eta_phase')
 
@@ -1939,13 +2019,15 @@ class SmurfTuneMixin(SmurfBase):
         Convenience function that gets the channel assignments from
         eta scans.
 
-        Args:
-        -----
-        band (int) : The band
-
-        Ret:
+        Args
         ----
-        channels (int array) : The channels of the resonators.
+        band : int
+            The band.
+
+        Returns
+        -------
+        channels : int array
+            The channels of the resonators.
         """
         return self._get_eta_scan_result_from_key(band, 'channel')
 
@@ -1954,13 +2036,15 @@ class SmurfTuneMixin(SmurfBase):
         """
         Convenience function that gets the subband from eta scans.
 
-        Args:
-        -----
-        band (int) : The band
-
-        Ret:
+        Args
         ----
-        subband (float array) : The subband of the resonators.
+        band : int
+            The band.
+
+        Returns
+        -------
+        subband : float array
+            The subband of the resonators.
         """
         return self._get_eta_scan_result_from_key(band, 'subband')
 
@@ -1970,34 +2054,53 @@ class SmurfTuneMixin(SmurfBase):
         Convenience function that gets the offset from center frequency
         from eta scans.
 
-        Args:
-        -----
-        band (int) : The band
-
-        Ret:
+        Args
         ----
-        offset (float array) : The offset from the subband centers  of
-           the resonators.
+        band : int
+            The band.
+
+        Returns
+        -------
+        offset : float array
+            The offset from the subband centers of the resonators.
         """
         return self._get_eta_scan_result_from_key(band, 'offset')
 
 
-    def eta_estimator(self, band, freq, drive=10, f_sweep_half=.3,
+    def eta_estimator(self, band, freq, drive=12, f_sweep_half=.3,
                       df_sweep=.002, delta_freq=.01,
                       lock_max_derivative=False):
         """
         Estimates eta parameters using the slow eta_scan.
 
-        Args:
-        -----
-        band (int) : The 500 MHz band
-        freq (float) : The frequency to scan
+        Args
+        ----
+        band : int)
+            The band.
+        freq : float
+            The frequency to scan.
 
         Opt Args:
         ---------
-        drive (int) : The tone ampltidue. Default is 10.
-        f_sweep_half (float) : The frequency to sweep.
-        df_sweep (float) : The freqeucny step size
+        drive : int, optional, default 12
+            The tone amplitude.
+        f_sweep_half : float, optional, default 0.3
+            The frequency to sweep.
+        df_sweep : float, optional, default 0.002
+            The frequency step size.
+        delta_freq : float, optional, default 0.01
+            ???
+        lock_max_derivative : bool, optional, default False
+            ???
+
+        Returns
+        -------
+        f_sweep : array
+            ???
+        resp : array
+            ???
+        eta : array
+            ???
         """
         subband, offset = self.freq_to_subband(band, freq)
         f_sweep = np.arange(offset-f_sweep_half, offset+f_sweep_half, df_sweep)

--- a/python/pysmurf/client/util/pub.py
+++ b/python/pysmurf/client/util/pub.py
@@ -142,17 +142,17 @@ class Publisher:
         """
         Publishes file info so it can be picked up by the pysmurf-archiver.
 
-        Args:
-        -----
-        path (str):
-            full path to file.
-        type (str):
-            Type of data file, e.g. "tuning" or "config_snapshot"
-        format (str):
-            File extension. E.g. "npy" or "txt"
-        timestamp (float):
+        Args
+        ----
+        path : str
+            Full path to file.
+        type : str
+            Type of data file, e.g. "tuning" or "config_snapshot".
+        format : str
+            File extension. E.g. "npy" or "txt".
+        timestamp : float or None, optional, default None
             Unix timestamp when file was created.
-        plot (bool):
+        plot : bool, optional, default False
             True if file is a plot
         """
         if timestamp is None:

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -32,8 +32,8 @@ class SmurfUtilMixin(SmurfBase):
             IQstream=1, single_channel_readout=1, debug=False, write_log=True):
         """ Takes raw debugging data
 
-        Parameters:
-        -----------
+        Args
+        ----
         band : int
             The band to take data on
         single_channel_readout : int
@@ -51,8 +51,8 @@ class SmurfUtilMixin(SmurfBase):
         write_log : bool
             Whether to write lowlevel commands to the log file.
 
-        Returns:
-        --------
+        Returns
+        -------
         f : float array
             The frequency response
         df : float array
@@ -609,16 +609,18 @@ class SmurfUtilMixin(SmurfBase):
         """
         decode take_debug_data file if in singlechannel mode
 
-        Args:
-        -----
-        filename (str): path to file to decode
+        Args
+        ----
+        filename : str
+            Path to file to decode.
+        swapFdF : bool, optional, default False
+            Whether to swap f and df streams.
 
-        Optional:
-        swapFdF (bool): whether to swap f and df streams
-
-        Returns:
-        [f, df, sync] if iq_stream_enable = False
-        [I, Q, sync] if iq_stream_enable = True
+        Returns
+        -------
+        list
+            [f, df, sync] if iq_stream_enable = False
+            [I, Q, sync] if iq_stream_enable = True
         """
 
         n_subbands = self.get_number_sub_bands()
@@ -669,34 +671,40 @@ class SmurfUtilMixin(SmurfBase):
 
         To do: move downsample_factor to config table
 
-        Args:
-        -----
-        meas_time (float) : The amount of time to observe for in seconds
+        Args
+        ----
+        meas_time : float
+            The amount of time to observe for in seconds.
+        downsample_factor : int or None, optional, default None
+            The number of fast sample (the flux ramp reset rate -
+            typically 4kHz) to skip between reporting. If None, does
+            not update.
+        write_log : bool, optional, default True
+            Whether to write to the log file.
+        update_payload_size : bool, optional, default True
+            Whether to update the payload size (the number of channels
+            written to disk). If the number of channels on is greater
+            than the payload size, then only the first N channels are
+            written. This bool will update the payload size to be the
+            same as the number of channels on across all bands)
+        reset_unwrapper : bool, optional, default True
+            Whether to reset the unwrapper before taking data.
+        reset_filter : bool, optional, default True
+            Whether to reset the filter before taking data.
+        return_data : bool, optional, default False
+            Whether to return the data. If False, returns the full
+            path to the data.
+        make_freq_mask : bool, optional, default True
+            Whether to write a text file with resonator frequencies.
+        register_file : bool, optional, default True
+            Whether to register the data file with the pysmurf
+            publisher.
 
-        Opt Args:
-        ---------
-        downsample_factor (int) : The number of fast sample (the flux ramp
-            reset rate - typically 4kHz) to skip between reporting. If None,
-            does not update.
-        write_log (bool) : Whether to write to the log file. Default True.
-        update_payload_size (bool) : Whether to update the payload size
-            (the number of channels written to disk). If the number of channels
-            on is greater than the payload size, then only the first N channels
-            are written. This bool will update the payload size to be the same
-            as the number of channels on across all bands)
-        reset_unwrapper (bool) : Whether to reset the unwrapper before
-            taking data.
-        reset_filter (bool) : Whether to reset the filter before
-            taking data.
-        return_data (bool) : Whether to return the data. If False, returns
-            the full path to the data. Default False.
-        register_file (bool): Whether to register the data file with the
-            pysmurf publisher. Default True.
 
-
-        Returns:
-        --------
-        data_filename (string): The fullpath to where the data is stored
+        Returns
+        -------
+        data_filename : str
+            The fullpath to where the data is stored.
         """
         if write_log:
             self.log('Starting to take data.', self.LOG_USER)
@@ -728,30 +736,35 @@ class SmurfUtilMixin(SmurfBase):
         """
         Turns on streaming data.
 
-        Opt Args:
-        ---------
-        write_config (bool) : Whether to dump the entire config. Default
-            is False. Warning this can be slow.
-        data_filename (str) : The full path to store the data. If None, it
-            uses the timestamp.
-        write_log (bool) : Whether to write to the log file. Default True.
-        update_payload_size (bool) : Whether to update the payload size
-            (the number of channels written to disk). If the number of channels
-            on is greater than the payload size, then only the first N channels
-            are written. This bool will update the payload size to be the same
-            as the number of channels on across all bands)
-        downsample_factor (int) : The number of fast samples to skip between
-            sending.
-        reset_unwrapper (bool) : Whether to reset the unwrapper before
-            taking data.
-        reset_filter (bool) : Whether to reset the filter before
-            taking data.
-        make_freq_mask (bool) : Whether to write a text file with resonator
-            frequencies. Default True.
+        Args
+        ----
+        write_config : bool, optional, default False
+            Whether to dump the entire config. Warning this can be
+            slow.
+        data_filename : str or None, optional, default None
+            The full path to store the data. If None, it uses the
+            timestamp.
+        downsample_factor : int or None, optional, default None
+            The number of fast samples to skip between sending.
+        write_log : bool, optional, default True
+            Whether to write to the log file.
+        update_payload_size : bool, optional, default True
+            Whether to update the payload size (the number of channels
+            written to disk). If the number of channels on is greater
+            than the payload size, then only the first N channels are
+            written. This bool will update the payload size to be the
+            same as the number of channels on across all bands)
+        reset_filter : bool, optional, default True
+            Whether to reset the filter before taking data.
+        reset_unwrapper : bool, optional, default True
+            Whether to reset the unwrapper before taking data.
+        make_freq_mask : bool, optional, default True
+            Whether to write a text file with resonator frequencies.
 
-        Returns:
-        --------
-        data_filename (string): The fullpath to where the data is stored
+        Returns
+        -------
+        data_filename : str
+            The fullpath to where the data is stored.
         """
         bands = self.config.get('init').get('bands')
 
@@ -864,12 +877,13 @@ class SmurfUtilMixin(SmurfBase):
         """
         Turns off streaming data.
 
-        Args:
-            write_log (bool):
-                Whether to log the CA commands or not. Default False
-            register_file (bool):
-                If true, the stream data file will be registered through the
-                publisher.
+        Args
+        ----
+        write_log : bool, optional, default True
+            Whether to log the CA commands or not.
+        register_file : bool, optional, default False
+            If true, the stream data file will be registered through
+            the publisher.
         """
         self.close_data_file(write_log=write_log)
 
@@ -894,24 +908,31 @@ class SmurfUtilMixin(SmurfBase):
         can optionally return the header (which has things
         like the TES bias).
 
-        Args:
-        -----
-        datafile (str): The full path to the data to read
-
-        Opt Args:
-        ---------
-        channel (int or int array): Channels to load.
-        n_samp (int) : The number of samples to read.
-        array_size (int) : The size of the output arrays. If 0, then
-            the size will be the number of channels in the data file.
-        return_header (bool) : Whether to also read in the header
-            and return the header data. Returning the full header
-            is slow for large files. This overrides return_tes_bias.
-        return_tes_bias (bool) : Whether to return the TES bias.
-        write_log (bool) : Whether to write outputs to the log
-            file. Default True.
-        n_max (int) : The number of elements to read in before appending
-            the datafile. This is just for speed.
+        Args
+        ----
+        datafile : str
+            The full path to the data to read.
+        
+        channel : int or int array or None, optional, default None
+            Channels to load.
+        n_samp : int or None, optional, default None
+            The number of samples to read.
+        array_size : int or None, optional, default None
+            The size of the output arrays. If 0, then the size will be
+            the number of channels in the data file.
+        return_header : bool, optional, default False
+            Whether to also read in the header and return the header
+            data. Returning the full header is slow for large
+            files. This overrides return_tes_bias.
+        return_tes_bias : bool, optional, default False
+            Whether to return the TES bias.
+        write_log : bool, optional, default True
+            Whether to write outputs to the log file.
+        n_max : int, optional, default 2048
+            The number of elements to read in before appending the
+            datafile. This is just for speed.
+        make_freq_mask : bool, optional, default False
+            Whether to write a text file with resonator frequencies.
         gcp_mode (bool) : Indicates that the data was written in GCP mode. This
             is the legacy data mode which was depracatetd in Rogue 4.
 
@@ -1249,16 +1270,18 @@ class SmurfUtilMixin(SmurfBase):
         to the smurf_to_mce mask number. In other words, mask[band, channel]
         returns the GCP index in the mask that corresonds to band, channel.
 
-        Parameters:
-        -----------
+        Args
+        ----
         mask_file : str
             The full path the a mask file
-        mask_channel_offset : int
+        mask_channel_offset : int, optional, default 0
             Offset to remove from channel numbers in GCP mask file after
-            loading.  Default is 0.
+            loading.
+        make_freq_mask : bool, optional, default False
+            Whether to write a text file with resonator frequencies.
 
-        Returns:
-        --------
+        Returns
+        -------
         mask_lookup : int array
             An array with the GCP numbers.
         """
@@ -1308,16 +1331,17 @@ class SmurfUtilMixin(SmurfBase):
         """
         Reads the stream data from the DAQ.
 
-        Args:
-        -----
-        data_length (int) : The number of samples to process
-
-        Opt Args:
-        ---------
-        bay (int) : The AMC bay number
-        hw_trigger (bool) : Whehter to trigger the start of the acquistion
-            with a hardware trigger. Default False.
-        write_log (bool) : Whether to write outputs to log. Default False
+        Args
+        ----
+        data_length : int
+            The number of samples to process.
+        bay : int, optional, default 0
+            The AMC bay number.
+        hw_trigger : bool, optional, default False
+            Whether to trigger the start of the acquistion with a
+            hardware trigger.
+        write_log : bool, optional, default False
+            Whether to write outputs to log.
         """
         # Ask mitch why this is what it is...
         if bay == 0:
@@ -1351,13 +1375,15 @@ class SmurfUtilMixin(SmurfBase):
         """
         Reads data directly off the ADC.  Checks for input saturation.
 
-        Args:
+        Args
         -----
-        band (int) : Which band.  Assumes adc number is band%4.
+        band : int
+            Which band.  Assumes adc number is band%4.
 
-        Ret:
-        ----
-        saturated (bool) : Flag if ADC is saturated.
+        Returns
+        -------
+        saturated : bool
+           True if ADC is saturated, otherwise False.
         """
         adc = self.read_adc_data(band, data_length=2**12, do_plot=False,
                   save_data=False, show_plot=False, save_plot=False)

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -916,7 +916,6 @@ class SmurfUtilMixin(SmurfBase):
         ----
         datafile : str
             The full path to the data to read.
-        
         channel : int or int array or None, optional, default None
             Channels to load.
         n_samp : int or None, optional, default None
@@ -1115,7 +1114,7 @@ class SmurfUtilMixin(SmurfBase):
             The timestamp data.
         d : numpy.ndarray
             The resonator data in units of phi0.
-        m : numpy.ndarray 
+        m : numpy.ndarray
             The maskfile that maps smurf num to gcp num.
         """
         import struct
@@ -2231,7 +2230,7 @@ class SmurfUtilMixin(SmurfBase):
     def get_subband_from_channel(self, band, channel, channelorderfile=None,
             yml=None):
         """Returns subband number given a channel number
-        
+
         Args
         ----
         band : int
@@ -4159,7 +4158,7 @@ class SmurfUtilMixin(SmurfBase):
         update_channel_assignment : bool, optional, default True
             Whether to update the master channels assignment to
             contain the new bias group information.
-        high_current_mode : bool, optional, default True 
+        high_current_mode : bool, optional, default True
             Whether to use high or low current mode.
 
         Returns

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -3619,13 +3619,15 @@ class SmurfUtilMixin(SmurfBase):
         Goes from the smurf2mce mask file to a gcp number.
         Inverse of gcp_num_to_mask_num.
 
-        Args:
-        -----
-        mask_num (int) : The index in the mask file.
-
-        Ret:
+        Args
         ----
-        gcp_num (int) : The index of the channel in GCP.
+        mask_num : int
+            The index in the mask file.
+
+        Returns
+        -------
+        gcp_num : int
+            The index of the channel in GCP.
         """
         return (mask_num*33)%528+mask_num//16
 
@@ -3635,13 +3637,15 @@ class SmurfUtilMixin(SmurfBase):
         Goes from a GCP number to the smurf2mce index.
         Inverse of mask_num_to_gcp_num
 
-        Args:
+        Args
         ----
-        gcp_num (int) : The gcp index
+        gcp_num : int
+            The gcp index.
 
-        Ret:
-        ----
-        mask_num (int) : The index in the mask.
+        Returns
+        -------
+        mask_num : int
+            The index in the mask.
         """
         return (gcp_num*16)%528 + gcp_num//33
 
@@ -3650,19 +3654,20 @@ class SmurfUtilMixin(SmurfBase):
         """
         Converts from smurf channel (band and channel) to a gcp number
 
-        Args:
-        -----
-        band (int) : The smurf band number
-        channel (int) : The smurf channel number
-
-        Opt Args:
-        ---------
-        mask_file (int array) : The mask file to convert between smurf channel
-            and GCP number.
-
-        Ret:
+        Args
         ----
-        gcp_num (int) : The GCP number
+        band : int
+            The smurf band number.
+        channel : int
+            The smurf channel number.
+        mask_file : int array or None, optional, default None
+            The mask file to convert between smurf channel and GCP
+            number.
+
+        Returns
+        -------
+        gcp_num : int
+            The GCP number.
         """
         if mask_file is None:
             mask_file = self.smurf_to_mce_mask_file

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -1549,31 +1549,37 @@ class SmurfUtilMixin(SmurfBase):
         """
         Read the data directly off the DAC.
 
-        Args:
-        -----
-        band (int) : Which band.  Assumes dac number is band%4.
-        data_length (int): The number of samples
-
-        Opt Args:
-         ---------
-        hw_trigger (bool) : Whether to use the hardware trigger. If
-            False, uses an internal trigger.
-        do_plot (bool) : Whether or not to plot.  Default false.
-        save_data (bool) : Whether or not to save the data in a time
-            stamped file.  Default true.
-        timestamp (int) : ctime to timestamp the plot and data with
-            (if saved to file).  Default None, in which case it gets
-            the time stamp right before acquiring data.
-        show_plot (bool) : If do_plot is True, whether or not to show
-            the plot.  Default True.
-        save_plot (bool) : Whether or not to save plot to file.
-            Default True.
-        plot_ylimits ([float,float]) : y-axis limit (amplitude) to
-            restrict plotting over.
-
-        Ret:
+        Args
         ----
-        dat (int array) : The raw DAC data.
+        band : int
+            Which band.  Assumes dac number is band%4.
+
+        data_length : int, optional, default 2**19
+            The number of samples.
+        hw_trigger : bool, optional, default False
+            Whether to use the hardware trigger. If False, uses an
+            internal trigger.
+        do_plot : bool, optional, default False
+            Whether or not to plot.
+        save_data : bool, optional, default True
+            Whether or not to save the data in a time stamped file.
+        timestamp : int or None, optional, default None
+            ctime to timestamp the plot and data with (if saved to
+            file).  If None, in which case it gets the time stamp
+            right before acquiring data.
+        show_plot : bool, optional, default True
+            If do_plot is True, whether or not to show the plot.
+        save_plot : bool, optional, default True
+            Whether or not to save plot to file.
+        plot_ylimits : list of float or list of None, optional,
+        default [None,None]
+            2-element list of y-axis limits (amplitude) to restrict
+            plotting over.
+
+        Returns
+        -------
+        dat : int array
+            The raw DAC data.
         """
         if timestamp is None:
             timestamp = self.get_timestamp()
@@ -1644,13 +1650,21 @@ class SmurfUtilMixin(SmurfBase):
         """
         Sets up for either ADC or DAC data taking.
 
-        Args:
-        -----
-        converter (str) : Whether it is the ADC or DAC. choices are 'adc',
-            'dac', or 'debug'. The last one takes data on a single band.
-        converter_number (int) : The ADC or DAC number to take data on.
-        data_length (int) : The amount of data to take.
-        band (int): which band to get data on
+        Args
+        ----
+        converter : str
+            Whether it is the ADC or DAC. choices are 'adc', 'dac', or
+            'debug'. The last one takes data on a single band.
+        converter_number : int
+            The ADC or DAC number to take data on.
+        data_length : int
+            The amount of data to take.
+        band : int, optional, default 0
+            which band to get data on.
+        debug : bool, optional, default False
+            ???
+        write_log : bool, optional, default False
+            ???
         """
 
         bay=self.band_to_bay(band)
@@ -1685,9 +1699,16 @@ class SmurfUtilMixin(SmurfBase):
         """
         Sets the buffer size for reading and writing DAQs
 
-        Args:
-        -----
-        size (int) : The buffer size in number of points
+        Args
+        ----
+        bay : int
+            ???
+        size : int
+            The buffer size in number of points.
+        debug : bool, optional, default False
+            ???
+        write_log : bool, optional, default False
+            ???
         """
         # Change DAQ data buffer size
 
@@ -1708,15 +1729,22 @@ class SmurfUtilMixin(SmurfBase):
         """
         Set parameters on a single cryo channel
 
-        Args:
-        -----
-        band (int) : The band for the channel
-        channel (int) : which channel to configure
-        frequencyMHz (float) : the frequency offset from the subband center in MHz
-        amplitude (int) : amplitude scale to set for the channel (0..15)
-        feedback_enable (bool) : whether to enable feedback for the channel
-        eta_phase (float) : feedback eta phase, in degrees (-180..180)
-        eta_mag (float) : feedback eta magnitude
+        Args
+        ----
+        band : int
+            The band for the channel.
+        channel : int
+            Which channel to configure.
+        frequencyMHz : float
+            The frequency offset from the subband center in MHz.
+        amplitude : int
+            Amplitude scale to set for the channel (0..15).
+        feedback_enable : bool
+            Whether to enable feedback for the channel.
+        eta_phase : float
+            Feedback eta phase, in degrees (-180..180).
+        eta_mag : float
+            Feedback eta magnitude.
         """
 
         n_subbands = self.get_number_sub_bands(band)
@@ -1761,13 +1789,15 @@ class SmurfUtilMixin(SmurfBase):
         """
         Finds all detectors that are on.
 
-        Args:
-        -----
-        band (int) : The band to search.
+        Args
+        ----
+        band : int
+            The band to search.
 
-        Returns:
+        Returns
         --------
-        channels_on (int array) : The channels that are on
+        int array
+            The channels that are on.
         """
         amps = self.get_amplitude_scale_array(band)
         return np.ravel(np.where(amps != 0))
@@ -1779,9 +1809,12 @@ class SmurfUtilMixin(SmurfBase):
         this band.  Only toggles back to 1 if it was 1 when asked to
         toggle, otherwise leaves it zero.
 
-        Args:
-        -----
-        band (int) : The band whose feedback to toggle.
+        Args
+        ----
+        band : int
+           The band whose feedback to toggle.
+        ***kwargs : ???
+           ???
         """
 
         # current vals?
@@ -1827,9 +1860,12 @@ class SmurfUtilMixin(SmurfBase):
         """
         Turns off all tones in a band
 
-        Args:
-        -----
-        band (int) : The band that is to be turned off.
+        Args
+        ----
+        band : int
+            The band that is to be turned off.
+        **kwards : ???
+            ???
         """
         self.set_amplitude_scales(band, 0, **kwargs)
         self.set_feedback_enable_array(band, np.zeros(512, dtype=int), **kwargs)
@@ -1841,10 +1877,12 @@ class SmurfUtilMixin(SmurfBase):
         Turns off the tone for a single channel by setting the amplitude to
         zero and disabling feedback.
 
-        Args:
-        -----
-        band (int) : The band that is to be turned off.
-        channel (int) : The channel to turn off.
+        Args
+        ----
+        band : int
+            The band that is to be turned off.
+        channel : int
+            The channel to turn off.
         """
         self.log('Turning off band {} channel {}'.format(band, channel),
             self.LOG_USER)
@@ -1856,10 +1894,12 @@ class SmurfUtilMixin(SmurfBase):
         """
         Sets the feedback limit
 
-        Args:
-        -----
-        band (int) : The band that is to be turned off.
-        feedback_limit_khz (float) : The feedback rate in units of kHz.
+        Args
+        ----
+        band : int
+            The band that is to be turned off.
+        feedback_limit_khz : float
+            The feedback rate in units of kHz.
         """
         digitizer_freq_mhz = self.get_digitizer_frequency_mhz(band)
         n_subband = self.get_number_sub_bands(band)
@@ -1955,10 +1995,17 @@ class SmurfUtilMixin(SmurfBase):
         Queries the Jesd tx and rx and compares the
         data_valid and enable bits.
 
-        Opt Args:
-        ---------
-        silent_if_valid (bool) : If True, does not print
-            anything if things are working.
+        Args
+        ----
+        bay : int
+            Which bay (0 or 1).
+        silent_if_valid : bool, optional, default False
+            If True, does not print anything if things are working.
+
+        Returns
+        -------
+        (bool,bool)
+            (JesdTx is ok, JesdRx is ok)
         """
         # JESD Tx
         jesd_tx_enable = self.get_jesd_tx_enable(bay)
@@ -1985,8 +2032,10 @@ class SmurfUtilMixin(SmurfBase):
         """
         Loads FPGA status checks if JESD is ok.
 
-        Returns:
-        ret (dict) : A dictionary containing uptime, fpga_version, git_hash,
+        Returns
+        -------
+        ret : dict
+            A dictionary containing uptime, fpga_version, git_hash,
             build_stamp, jesd_tx_enable, and jesd_tx_valid
         """
         uptime = self.get_fpga_uptime()
@@ -2043,15 +2092,19 @@ class SmurfUtilMixin(SmurfBase):
         Look up subband number of a channel frequency, and its subband
         frequency offset.
 
-        Args:
-        -----
-        band (float): The band to place the resonator
-        freq (float): frequency in MHz
+        Args
+        ----
+        band : float
+            The band to place the resonator.
+        freq : float
+            Frequency in MHz.
 
-        Returns:
-        --------
-        subband_no (int): subband (0..128) of the frequency within the band
-        offset (float): offset from subband center
+        Returns
+        -------
+        subband_no : int
+            Subband (0..128) of the frequency within the band.
+        offset : float
+            Offset from subband center.
 
         """
         subbands, subband_centers = self.get_subband_centers(band,
@@ -2069,19 +2122,21 @@ class SmurfUtilMixin(SmurfBase):
         """
         Gives the frequency of the channel.
 
-        Args:
-        -----
-        band (int) : The band the channel is in
-
-        Opt Args:
-        ---------
-        channel (int) :  The channel number
-
-        Ret:
+        Args
         ----
-        freq (float): The channel frequency in MHz or an array
-            of values if channel is None. In the array format,
-            the freq list is aligned with self.which_on(band).
+        band : int
+            The band the channel is in.
+        channel : int or None, optional, default none
+            The channel number.
+        yml : str or None, optional, default None
+            ???
+
+        Returns
+        -------
+        freq : float
+            The channel frequency in MHz or an array of values if
+            channel is None. In the array format, the freq list is
+            aligned with self.which_on(band).
         """
         if band is None and channel is None:
             return None

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -3599,19 +3599,20 @@ class SmurfUtilMixin(SmurfBase):
         """
         Converts from gcp number to smurf channel (band and channel).
 
-        Args:
-        -----
-        gcp_num (int) : The GCP number
-
-        Opt Args:
-        ---------
-        mask_file (int array) : The mask file to convert between smurf channel
-            and GCP number.
-
-        Ret:
+        Args
         ----
-        band (int) : The smurf band number
-        channel (int) : The smurf channel number
+        gcp_num : int
+            The GCP number.
+        mask_file : int array or None, optional, default None
+            The mask file to convert between smurf channel and GCP
+            number.
+
+        Returns
+        -------
+        band : int
+            The smurf band number.
+        channel : int
+            The smurf channel number.
         """
         if mask_file is None:
             mask_file = self.smurf_to_mce_mask_file
@@ -3630,18 +3631,18 @@ class SmurfUtilMixin(SmurfBase):
         voltage. The conversion from requested volts to bits
         is calculated in this function.
 
-        Args:
-        -----
-        bias_group (int) : The bias group to play a sine wave on
-        tone_amp (float) : The amplitude of the sine wave in units of
-            out TES bias in volts.
-        tone_freq (float) : The frequency of the tone in Hz.
-
-        Opt Args:
-        ---------
-        dc_amp (float) : The amplitude of the DC term of the sine wave.
-            If None, reads the current DC value and uses that. Default
-            is None.
+        Args
+        ----
+        bias_group : int
+            The bias group to play a sine wave on.
+        tone_amp : float
+            The amplitude of the sine wave in units of out TES bias in
+            volts.
+        tone_freq : float
+            The frequency of the tone in Hz.
+        dc_amp : float or None, optional, default None
+            The amplitude of the DC term of the sine wave.  If None,
+            reads the current DC value and uses that.
         """
         if dc_amp is None:
             dc_amp = self.get_tes_bias_bipolar(bias_group)
@@ -3670,18 +3671,17 @@ class SmurfUtilMixin(SmurfBase):
         for tone file, assumes the path to the correct tone file has
         already been loaded.
 
-        Args:
+        Args
         ----
-        band (int) : Which band to play tone file on.
-
-        Optional Args:
-        --------------
-        tone_file (str) : Path (including csv file name) to tone file.
-                          If none given, uses whatever's already been loaded.
-        load_tone_file (bool) : Whether or not to load the tone file.
-                                The tone file is loaded per DAC, so if you
-                                already loaded the tone file for this DAC you
-                                don't have to do it again.
+        band : int
+            Which band to play tone file on.
+        tone_file : str or None, optional, default None
+            Path (including csv file name) to tone file.  If None,
+            uses whatever's already been loaded.
+        load_tone_file : bool, optional, default True
+            Whether or not to load the tone file.  The tone file is
+            loaded per DAC, so if you already loaded the tone file for
+            this DAC you don't have to do it again.
         """
         # the bay corresponding to this band.
         bay = self.band_to_bay(band)
@@ -3701,9 +3701,10 @@ class SmurfUtilMixin(SmurfBase):
         Stops playing tone file on the specified band and reverts
         to DSP.
 
-        Args:
+        Args
         ----
-        band (int) : Which band to play tone file on.
+        band : int
+            Which band to play tone file on.
         """
 
         self.set_waveform_select(band,0)
@@ -3718,14 +3719,15 @@ class SmurfUtilMixin(SmurfBase):
         Convenience function for getting all the serial
         gradient descent parameters
 
-        Args:
-        -----
-        band (int): The band to query
-
-        Ret:
+        Args
         ----
-        params (dict): A dictionary with all the gradient
-            descent parameters
+        band : int
+            The band to query.
+
+        Returns
+        -------
+        params : dict
+            A dictionary with all the gradient descent parameters
         """
         ret = {}
         ret['averages'] = self.get_gradient_descent_averages(band)
@@ -3748,14 +3750,15 @@ class SmurfUtilMixin(SmurfBase):
         frequency falls into (where a channel is deemed "assigned" if
         it has non-zero amplitude).
 
-        Args:
-        -----
-        freq_mhz (float): The frequency in MHz at which to place a fixed tone.
-        drive (int): The amplitude for the fixed tone (0-15 in recent fw revisions).
-
-        Opt Args:
-        ---------
-        quiet (bool) : Whether to look at one channel
+        Args
+        ----
+        freq_mhz : float
+            The frequency in MHz at which to place a fixed tone.
+        drive : int
+            The amplitude for the fixed tone (0-15 in recent fw
+            revisions).
+        quiet : bool, optional, ddefault False
+            ???
         """
 
         # Find which band the requested frequency falls into.
@@ -3807,15 +3810,10 @@ class SmurfUtilMixin(SmurfBase):
         Turns off every channel which has nonzero amplitude but
         feedback set to zero.
 
-        Args:
-        -----
-        freq_mhz (float): The frequency in MHz at which to place a fixed tone.
-        drive (int): The amplitude for the fixed tone (0-15 in recent fw revisions).
-
-        Opt Args:
-        ---------
-        quiet (bool) : Whether to look at one channel
-
+        Args
+        ----
+        band : int
+            The band to query.
         """
         amplitude_scale_array=self.get_amplitude_scale_array(band)
         feedback_enable_array=self.get_feedback_enable_array(band)
@@ -4009,9 +4007,12 @@ class SmurfUtilMixin(SmurfBase):
         """
         Stop the bipolar waveform being played on a bias group.
 
-        Args:
-        -----
-        bias_group (int): The bias group
+        Args
+        ----
+        bias_group : int
+            The bias group.
+        **kwargs : ???
+            ???
         """
         # https://confluence.slac.stanford.edu/display/SMuRF/SMuRF+firmware#SMuRFfirmware-RTMDACarbitrarywaveforms
         # Target the two bipolar DACs assigned to this bias group:
@@ -4028,8 +4029,8 @@ class SmurfUtilMixin(SmurfBase):
     def get_sample_frequency(self):
         """ Gives the data rate.
 
-        Returns:
-        --------
+        Returns
+        -------
         sample_frequency : float
             The data sample rate in Hz.
         """

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2790,9 +2790,10 @@ class SmurfUtilMixin(SmurfBase):
         value for this offset (see 50k_Id_offset in the amplifier
         block).
 
-        Returns:
-        --------
-        cur (float): 50K amplifier drain current in mA
+        Returns
+        -------
+        cur : float
+            50K amplifier drain current in mA.
         """
 
         # assumes circuit topology on rev C2 cryostat card
@@ -3248,20 +3249,18 @@ class SmurfUtilMixin(SmurfBase):
 
     def get_filter_params(self):
         """
-        Get the downsample filter parameters: filter order,
-        filter gain, num averages, and the actual filter
-        parameters. This reads the most recent smurf_to_mce_file
-        to get the parameters. This is defined in
-        self.smurf_to_mce_file.
+        Get the downsample filter parameters: filter order, filter
+        gain, num averages, and the actual filter parameters. This
+        reads the most recent smurf_to_mce_file to get the
+        parameters. This is defined in self.smurf_to_mce_file.
 
-        If filter order is -1, the downsampler is using a
-        rectangula integrator. This will set filter_a, filter_b
-        to None.
+        If filter order is -1, the downsampler is using a rectangula
+        integrator. This will set filter_a, filter_b to None.
 
-        Ret:
-        ----
-        filter_params (dict) : A dictionary with the filter
-            parameters.
+        Returns
+        -------
+        filter_params : dict
+            A dictionary with the filter parameters.
         """
         # Get filter order, gain, and averages
         filter_order = self.get_filter_order()

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -3361,11 +3361,12 @@ class SmurfUtilMixin(SmurfBase):
             self.log('Warning: new mask has not been read in yet.')
 
 
-    def bias_bump(self, bias_group, wait_time=.5, step_size=.001, duration=5,
-                  start_bias=None, make_plot=False, skip_samp_start=10,
-                  high_current_mode=True, skip_samp_end=10, plot_channels=None,
-                  gcp_mode=False, gcp_wait=.5, gcp_between=1., dat_file=None,
-                  offset_percentile=2):
+    def bias_bump(self, bias_group, wait_time=.5, step_size=0.001,
+                  duration=5.0, start_bias=None, make_plot=False,
+                  skip_samp_start=10, high_current_mode=True,
+                  skip_samp_end=10, plot_channels=None,
+                  gcp_mode=False, gcp_wait=0.5, gcp_between=1.0,
+                  dat_file=None, offset_percentile=2):
         """
         Toggles the TES bias high and back to its original state. From this, it
         calculates the electrical responsivity (sib), the optical responsivity (siq),
@@ -3378,40 +3379,60 @@ class SmurfUtilMixin(SmurfBase):
         Note that only the resistance is well defined now because the phase response
         has an un-set factor of -1. We will need to calibrate this out.
 
-        Args:
-        -----
-        bias_group (int of int array): The bias groups to toggle. The response will
-            return every detector that is on.
+        Args
+        ----
+        bias_group : int of int array
+            The bias groups to toggle. The response will return every
+            detector that is on.
+        wait_time : float, optional, default 0.5
+            The time to wait between steps
+        step_size : float, optional, default 0.001
+            The voltage to step up and down in volts (for low current
+            mode).
+        duration : float, optional, default 5.0
+            The total time of observation.
+        start_bias : float or None, optional, default None
+            The TES bias to start at. If None, uses the current TES
+            bias.
+        make_plot : bool, optional, default False
+            Whether to make plots. Must set some channels in
+            plot_channels.
+        skip_samp_start : int, optional, default 10
+            The number of samples to skip before calculating a DC
+            level.
+        high_current_mode : bool, optional, default True
+            Whether to observe in high or low current mode.
+        skip_samp_end : int, optional, default 10
+            The number of samples to skip after calculating a DC
+            level.
+        plot_channels : int array or None, optional, default None
+           The channels to plot.
+        grid_mode : bool, optional, default False
+            ???
+        gcp_wait : float, optional, default 0.5
+            ???
+        gcp_between : float, optional, default 1.0
+            ???
+        dat_file : str or None, optional, default None
+            Filename to read bias-bump data from; if provided, data is
+            read from file instead of being measured live.
+        offset_percentile : float, optional, default 2.0
+            Number between 0 and 100. Determines the percentile used
+            to calculate the DC level of the TES data.
 
-        Opt Args:
-        --------
-        wait_time (float) : The time to wait between steps
-        step_size (float) : The voltage to step up and down in volts (for low
-            current mode).
-        duration (float) : The total time of observation
-        start_bias (float) : The TES bias to start at. If None, uses the current
-            TES bias.
-        skip_samp_start (int) : The number of samples to skip before calculating
-            a DC level
-        skip_samp_end (int) : The number of samples to skip after calculating a
-            DC level.
-        high_current_mode (bool) : Whether to observe in high or low current mode.
-            Default is True.
-        make_plot (bool) : Whether to make plots. Must set some channels in plot_channels.
-        plot_channels (int array) : The channels to plot.
-        dat_file (str) : filename to read bias-bump data from; if provided, data is read
-            from file instead of being measured live
-        offset_percentile (float) : Number between 0 and 100. Determines the percentile
-            used to calculate the DC level of the TES data.
-
-        Ret:
-        ---
-        bands (int array) : The bands
-        channels (int array) : The channels
-        resistance (float array) : The inferred resistance of the TESs in Ohms
-        sib (float array) : The electrical responsivity. This may be incorrect until
+        Returns
+        -------
+        bands : int array
+           The bands.
+        channels : int array
+           The channels.
+        resistance : float array
+            The inferred resistance of the TESs in Ohms.
+        sib : float array
+            The electrical responsivity. This may be incorrect until
             we define a phase convention. This is dimensionless.
-        siq (float array) : The power responsivity. This may be incorrect until we
+        siq : float array
+            The power responsivity. This may be incorrect until we
             define a phase convention. This is in uA/pW
 
         """

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2813,27 +2813,28 @@ class SmurfUtilMixin(SmurfBase):
         tes_bias.  Then waits cool_wait seconds before returning
         control.
 
-        Args:
-        -----
-        bias_group (int): The bias group to overbias.  Asserts if not
-                          a valid bias group.
-
-        Opt Args:
-        ---------
-        overbias_voltage (float): The value of the TES bias in the high current
-            mode. Default 19.9.
-        overbias_wait (float): The time to stay in high current mode in seconds.
-            Default is .5
-        tes_bias (float): The value of the TES bias when put back in low current
-            mode. Default is 19.9.
-        cool_wait (float): The time to wait after setting the TES bias for
-            transients to die off.
-        high_current_mode (bool) : Whether to keep the TES bias in high current
-            mode after the kick. Default is False
-        flip_polarity (bool) : Whether to flip the TES bias bipolar DAC
-            polarity. Default False.
-        actually_overbias (bool) : Whether to actaully do the overbias. Default
-            True.
+        Args
+        ----
+        bias_group : int
+            The bias group to overbias.  Asserts if not a valid bias
+            group.
+        overbias_voltage : float, optional, default 19.9
+            The value of the TES bias in the high current mode.
+        overbias_wait : float, optional, default 1.0
+            The time to stay in high current mode in seconds.
+        tes_bias : float, optional, default 19.9
+            The value of the TES bias when put back in low current
+            mode.
+        cool_wait : float, optional, default 20.0
+            The time to wait after setting the TES bias for transients
+            to die off.
+        high_current_mode : bool, optional, default False
+            Whether to keep the TES bias in high current mode after
+            the kick.
+        flip_polarity : bool, optional, default False
+            Whether to flip the TES bias bipolar DAC polarity.
+        actually_overbias : bool, optional, default True
+            Whether to actaully do the overbias.
         """
         bias_groups = self.bias_group_to_pair[:,0]
         assert (bias_group in bias_groups),\
@@ -2874,23 +2875,27 @@ class SmurfUtilMixin(SmurfBase):
         tes_bias.  Then waits cool_wait seconds before returning
         control.
 
-        Opt Args:
-        ---------
-        bias_groups (array): which bias groups to overbias. defaults to
-            all_groups.  Asserts if any of the bias groups listed is not a
-            defined bias group.
-        overbias_voltage (float): The value of the TES bias in the high current
-            mode. Default 19.9.
-        overbias_wait (float): The time to stay in high current mode in seconds.
-            Default is .5
-        tes_bias (float): The value of the TES bias when put back in low current
-            mode. Default is 19.9.
-        cool_wait (float): The time to wait after setting the TES bias for
-            transients to die off.
-        high_current_mode (bool) : Whether to keep the TES bias in high current
-            mode after the kick. Default is False
-        actually_overbias (bool) : Whether to actaully do the overbias. Default
-            True.
+        Args
+        ----
+        bias_groups : array or None, optional, default None
+            Which bias groups to overbias. defaults to all_groups.
+            Asserts if any of the bias groups listed is not a defined
+            bias group.
+        overbias_voltage : float, optional, default 19.9
+            The value of the TES bias in the high current mode.
+        overbias_wait : float, optional, default 1.0
+            The time to stay in high current mode in seconds.
+        tes_bias : float, optional, default 19.9
+            The value of the TES bias when put back in low current
+            mode.
+        cool_wait : float, optional, default 20.0
+            The time to wait after setting the TES bias for transients
+            to die off.
+        high_current_mode : bool, optional, default False
+            Whether to keep the TES bias in high current mode after
+            the kick.
+        actually_overbias : bool, optional, default True
+            Whether to actaully do the overbias.
         """
         # drive high current through the TES to attempt to drive normal
         if bias_groups is None:
@@ -2943,9 +2948,12 @@ class SmurfUtilMixin(SmurfBase):
         number is not the same as the relay number. It also does not matter,
         because Joe's code secretly flips all the relays when you flip one.
 
-        Args:
-        -----
-        bias_group (int): The bias group(s) to set to high current mode.
+        Args
+        ----
+        bias_group : int
+            The bias group(s) to set to high current mode.
+        write_log : bool, optional, default False
+            ???
         """
         old_relay = self.get_cryo_card_relays()
         old_relay = self.get_cryo_card_relays()  # querey twice to ensure update
@@ -2974,9 +2982,12 @@ class SmurfUtilMixin(SmurfBase):
         number is not the same as the relay number. It also does not matter,
         because Joe's code secretly flips all the relays when you flip one
 
-        Args:
-        -----
-        bias_group (int): The bias group to set to low current mode
+        Args
+        ----
+        bias_group : int
+            The bias group to set to low current mode.
+        write_log : bool, optional, default False
+            ???
         """
         old_relay = self.get_cryo_card_relays()
         old_relay = self.get_cryo_card_relays()  # querey twice to ensure update
@@ -3004,9 +3015,10 @@ class SmurfUtilMixin(SmurfBase):
         """
         Sets flux ramp to DC coupling
 
-        Opt Args:
-        ---------
-        write_log (bool) : Whether to write outputs to log. Default False.
+        Args
+        ----
+        write_log : bool, optional, default False
+            Whether to write outputs to log.
         """
         # The 16th bit (0 indexed) is the AC/DC coupling
         # self.set_tes_bias_high_current(16)
@@ -3027,9 +3039,10 @@ class SmurfUtilMixin(SmurfBase):
         """
         Sets flux ramp to AC coupling
 
-        Opt Args:
-        ---------
-        write_log (bool) : Whether to write outputs to log. Default False.
+        Args
+        ----
+        write_log : bool, optional, default False
+            Whether to write outputs to log.
         """
         # The 16th bit (0 indexed) is the AC/DC coupling
         # self.set_tes_bias_low_current(16)
@@ -3050,13 +3063,15 @@ class SmurfUtilMixin(SmurfBase):
         """
         Gives the band associated with a given attenuator number
 
-        Args:
-        -----
-        att (int) : The attenuatory number.
-
-        Ret:
+        Args
         ----
-        band (int) : The band associated with the attenuator.
+        att : int
+            The attenuatory number.
+
+        Returns
+        -------
+        band : int
+            The band associated with the attenuator.
         """
         return self.att_to_band['band'][np.ravel(
             np.where(self.att_to_band['att']==att))[0]]
@@ -3065,13 +3080,15 @@ class SmurfUtilMixin(SmurfBase):
         """
         Gives the att associated with a given 500 MHz band.
 
-        Args:
-        -----
-        band (int) : The 500 MHz band number
-
-        Ret:
+        Args
         ----
-        att (int) : The attenuatory number.
+        band : int
+            The 500 MHz band number.
+
+        Returns
+        -------
+        att : int
+            The attenuatory number.
         """
         # for now, mod 4 ; assumes the band <-> att correspondence is the same
         # for the LB and HB AMCs.
@@ -3135,16 +3152,19 @@ class SmurfUtilMixin(SmurfBase):
         that are on. If both band and smurf_chans are supplied, a mask
         in the input order is created.
 
-        Opt Args:
-        ---------
-        band (int array) : An array of band numbers. Must be the same
-            length as smurf_chans
-        smurf_chans (int_array) : An array of SMuRF channel numbers.
-            Must be the same length as band
-
-        Ret:
+        Args
         ----
-        output_chans (int array) : The output channels.
+        band : int array or None, optional, default None
+            An array of band numbers. Must be the same length as
+            smurf_chans
+        smurf_chans : int_array or None, optional, default None
+            An array of SMuRF channel numbers.  Must be the same
+            length as band.
+
+        Returns
+        -------
+        output_chans : int array
+            The output channels.
         """
         output_chans = np.array([], dtype=int)
 
@@ -3170,14 +3190,15 @@ class SmurfUtilMixin(SmurfBase):
         Makes the frequency mask. These are the frequencies
         associated with the channels in the channel mask.
 
-        Args:
-        -----
-        mask (int array) : The channel mask file
-
-        Ret:
+        Args
         ----
-        freqs (float array) : An array with frequencies associated
-            with the mask file.
+        mask : int array
+            The channel mask file.
+
+        Returns
+        -------
+        freqs : float array
+            An array with frequencies associated with the mask file.
         """
         freqs = np.zeros(len(mask), dtype=float)
         channels_per_band = 512  # avoid hardcoding this
@@ -3198,10 +3219,14 @@ class SmurfUtilMixin(SmurfBase):
         that filters data at the flux_ramp reset rate, which is
         before the downsampler.
 
-        Args:
-        -----
-        filter_order (int) : The number of poles in the filter.
-        cutoff_freq (float) : The filter cutoff frequency
+        Args
+        ----
+        filter_order : int
+            The number of poles in the filter.
+        cutoff_freq : float
+            The filter cutoff frequency.
+        write_log : bool, optional, default False
+            ???
         """
         # Get flux ramp frequency
         flux_ramp_freq = self.get_flux_ramp_freq()*1.0E3
@@ -3275,18 +3300,21 @@ class SmurfUtilMixin(SmurfBase):
         that are on. If both band and smurf_chans are supplied, a mask
         in the input order is created.
 
-        Opt Args:
-        ---------
-        band (int array) : An array of band numbers. Must be the same
-            length as smurf_chans
-        smurf_chans (int_array) : An array of SMuRF channel numbers.
-            Must be the same length as band.
-        gcp_chans (int_array) : A list of smurf numbers to be passed
-            on as GCP channels.
-        read_gcp_mask (bool) : Whether to read in the new GCP mask file.
-            If not read in, it will take no effect. Default is True.
-        mask_channel_offset (int) : Offset to add to channel numbers in GCP
-            mask file.  Default is 0.
+        Args
+        ----
+        band : int array or None, optional, default None
+            An array of band numbers. Must be the same length as
+            smurf_chans
+        smurf_chans : int_array or None, optional, default None
+            An array of SMuRF channel numbers.  Must be the same
+            length as band.
+        gcp_chans : int_array or None, optional, default None
+            A list of smurf numbers to be passed on as GCP channels.
+        read_gcp_mask : bool, optional, default True
+            Whether to read in the new GCP mask file.  If not read in,
+            it will take no effect.
+        mask_channel_offset : int, optional, default 0
+            Offset to add to channel numbers in GCP mask file.
         """
         if self.config.get('smurf_to_mce').get('mask_channel_offset') is not None:
             mask_channel_offset=int(self.config.get('smurf_to_mce').get('mask_channel_offset'))

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2168,18 +2168,20 @@ class SmurfUtilMixin(SmurfBase):
     def get_channel_order(self, band=None, channel_orderfile=None):
         """ produces order of channels from a user-supplied input file
 
-        Optional Args:
-        --------------
-        band (int): Which band.  Default is None.  If none specified,
-           assumes all bands have the same number of channels, and
-           pulls the number of channels from the first band in the
-           list of bands specified in the experiment.cfg.
-        channelorderfile (str): path to a file that contains one
-           channel per line
+        Args
+        ----
+        band : int or None, optional, default None
+            Which band.  If None, assumes all bands have the same
+            number of channels, and pulls the number of channels from
+            the first band in the list of bands specified in the
+            experiment.cfg.
+        channelorderfile : str or None, optional, default None
+            Path to a file that contains one channel per line.
 
-        Returns :
-        --------------
-        channel_order (int array) : An array of channel orders
+        Returns
+        -------
+        channel_order : int array
+            An array of channel orders.
         """
 
         if band is None:
@@ -2210,13 +2212,15 @@ class SmurfUtilMixin(SmurfBase):
         tracking_setup only returns data for the processed
         channels. Therefore every channel is not returned.
 
-        Optional Args:
-        --------------
-        channelorderfile (str): path to a file that contains one channel per line
-
-        Ret:
+        Args
         ----
-        processed_channels (int array)
+        channelorderfile : str or None, optional, default None
+            Path to a file that contains one channel per line.
+
+        Returns
+        -------
+        processed_channels : int array
+            ???
         """
         n_proc = self.get_number_processed_channels()
         n_chan = self.get_number_channels()
@@ -2226,20 +2230,21 @@ class SmurfUtilMixin(SmurfBase):
 
     def get_subband_from_channel(self, band, channel, channelorderfile=None,
             yml=None):
-        """ returns subband number given a channel number
-        Args:
-        -----
-        root (str): epics root (eg mitch_epics)
-        band (int): which band we're working in
-        channel (int): ranges 0..(n_channels-1), cryo channel number
-
-        Opt Args:
-        ---------
-        channelorderfile(str): path to file containing order of channels
-
-        Ret:
+        """Returns subband number given a channel number
+        
+        Args
         ----
-        subband (int) : The subband the channel lives in
+        band : int
+            Which band we're working in.
+        channel : int
+            Ranges 0..(n_channels-1), cryo channel number.
+        channelorderfile : str or None, optional, default None
+            Path to file containing order of channels.
+
+        Returns
+        -------
+        subband : int
+            The subband the channel lives in.
         """
 
         n_subbands = self.get_number_sub_bands(band, yml=yml)
@@ -2263,11 +2268,24 @@ class SmurfUtilMixin(SmurfBase):
     def get_subband_centers(self, band, as_offset=True, hardcode=False,
             yml=None):
         """ returns frequency in MHz of subband centers
-        Args:
-        -----
-        band (int): which band
-        as_offset (bool): whether to return as offset from band center
-            (default is no, which returns absolute values)
+
+        Args
+        ----
+        band : int
+            Which band.
+        as_offset : bool, optional, default True
+            Whether to return as offset from band center.
+        hardcode : bool, optional, default False
+            ???
+        yml : str or None, optional, default None
+            ???
+
+        Returns
+        -------
+        subbands : ???
+            ???
+        subband_centers : ???
+            ???
         """
 
         if hardcode:
@@ -2293,18 +2311,20 @@ class SmurfUtilMixin(SmurfBase):
     def get_channels_in_subband(self, band, subband, channelorderfile=None):
         """
         Returns channels in subband
-        Args:
-        -----
-        band (int): which band
-        subband (int): subband number, ranges from 0..127
 
-        Opt Args:
-        ---------
-        channelorderfile (str): path to file specifying channel order
+        Args
+        ----
+        band : int
+            Which band.
+        subband : int
+            Subband number, ranges from 0..127.
+        channelorderfile : str or None, optional, default None
+            Path to file specifying channel order.
 
-        Returns:
-        --------
-        subband_chans (int array): The channels in the subband
+        Returns
+        -------
+        subband_chans : int array
+            The channels in the subband.
         """
 
         n_subbands = self.get_number_sub_bands(band)
@@ -2327,14 +2347,17 @@ class SmurfUtilMixin(SmurfBase):
         """
         Changes IQ to phase
 
-        Args:
-        -----
-        i (float array)
-        q (float arry)
+        Args
+        ----
+        i : float array
+            ???
+        q : float arry
+            ???
 
-        Returns:
-        --------
-        phase (float array) :
+        Returns
+        -------
+        phase : float array
+            ???
         """
         return np.unwrap(np.arctan2(q, i))
 
@@ -2343,13 +2366,15 @@ class SmurfUtilMixin(SmurfBase):
         """
         Converts hex string, which is an array of characters, into an int.
 
-        Args:
-        -----
-        s (character array) : An array of chars to be turned into a single int.
+        Args
+        ----
+        s : character array
+            An array of chars to be turned into a single int.
 
-        Returns:
-        --------
-        i (int64) : The 64 bit int
+        Returns
+        -------
+        i : numpy.int
+           The 64 bit int.
         """
         return np.int(''.join([chr(x) for x in s]),0)
 
@@ -2358,13 +2383,15 @@ class SmurfUtilMixin(SmurfBase):
         """
         Converts an int into a string of characters.
 
-        Args:
-        -----
-        i (int64) : A 64 bit int to convert into hex.
+        Args
+        ----
+        i : int
+            A 64 bit int to convert into hex.
 
-        Returns:
-        --------
-        s (char array) : A character array representing the int
+        Returns
+        -------
+        s : char array
+            A character array representing the int.
         """
         # Must be array length 300
         s = np.zeros(300, dtype=int)
@@ -2384,17 +2411,18 @@ class SmurfUtilMixin(SmurfBase):
         group is set to +volt/2, while the negative DAC in the bias
         group is set to -volt/2.
 
-        Args:
-        -----
-        bias_group (int): The bias group
-        volt (float): The TES bias to command in volts.
-
-        Opt args:
-        --------
-        do_enable (bool) : Sets the enable bit. Only must be done
-                           once.  Default is True.
-        flip_polarity (bool) : Sets the voltage to volt*-1.  Default
-                               is False.
+        Args
+        ----
+        bias_group : int
+            The bias group.
+        volt : float
+            The TES bias to command in volts.
+        do_enable : bool, optional, default True
+            Sets the enable bit. Only must be done once.
+        flip_polarity : bool, optional, default False
+            Sets the voltage to volt*-1.
+        **kwargs : ???
+           ???
         """
 
         # Make sure the requested bias group is in the list of defined
@@ -2437,18 +2465,15 @@ class SmurfUtilMixin(SmurfBase):
         voltage of all DACs not assigned to a TES bias group are
         maintained.
 
-        Args:
-        -----
-        bias_group_volt_array (float array): the TES bias to command
-                                             in voltage for each
-                                             bipolar TES bias
-                                             group. Should be
-                                             (n_bias_groups,)
-
-        Opt args:
-        -----
-        do_enable (bool): Set the enable bit for both DACs for every
-                          TES bias group. Defaults to True.
+        Args
+        ----
+        bias_group_volt_array : float array
+            The TES bias to command in voltage for each bipolar TES
+            bias group. Should be (n_bias_groups,).
+        do_enable : bool, optional, default True
+            Set the enable bit for both DACs for every TES bias group.
+        **kwargs : ???
+            ???
         """
 
         n_bias_groups = self._n_bias_groups
@@ -2502,24 +2527,24 @@ class SmurfUtilMixin(SmurfBase):
         Returns the bias voltage in units of Volts for the requested
         TES bias group.
 
-        Args:
-        -----
-        bias_group (int) : The number of the bias group.  Asserts if
-                           bias_group requested is not defined in the
-                           pysmurf configuration file.
+        Args
+        ----
+        bias_group : int
+            The number of the bias group.  Asserts if bias_group
+            requested is not defined in the pysmurf configuration
+            file.
+        return_raw : bool, optional, default False
+            If True, returns pos and neg terminal values.
+        **kwargs : ???
+            ???
 
-        Opt Args:
-        ---------
-        return_raw (bool) : Default is False. If True, returns pos and
-                            neg terminal values.
-
-        Returns:
-        --------
-        val (float) : The bipolar output TES bias voltage for the
-                      requested bias group.  If return_raw=True, then
-                      returns a two element float array containing the
-                      output voltages of the two DACs assigned to the
-                      requested TES bias group.
+        Returns
+        -------
+        val : float
+            The bipolar output TES bias voltage for the requested bias
+            group.  If return_raw=True, then returns a two element
+            float array containing the output voltages of the two DACs
+            assigned to the requested TES bias group.
         """
         # Make sure the requested bias group is in the list of defined
         # bias groups.
@@ -2550,10 +2575,13 @@ class SmurfUtilMixin(SmurfBase):
         Returns array of bias voltages per bias group in units of volts.
         Currently hard coded to return the first 8 as (8,) array. I'm sorry -CY
 
-        Opt Args:
-        -----
-        return_raw (bool): Default is False. If True, returns +/- terminal
-            vals as separate arrays (pos, then negative)
+        Args
+        ----
+        return_raw : bool, optional, default False
+            If True, returns +/- terminal vals as separate arrays
+            (pos, then negative)
+        **kwargs : ???
+            ???
         """
 
         bias_order = self.bias_group_to_pair[:,0]
@@ -2592,10 +2620,12 @@ class SmurfUtilMixin(SmurfBase):
         resulting amplifier biases at the end with a short wait in
         case there's latency between setting and reading.
 
-        Opt Args:
-        ---------
-        bias_hemt (float): The HEMT bias voltage in units of volts
-        bias_50k (float): The 50K bias voltage in units of volts
+        Args
+        ----
+        bias_hemt : float or None, optional default None
+            The HEMT bias voltage in units of volts.
+        bias_50k : float or None, optional, default None
+            The 50K bias voltage in units of volts.
         """
 
         ########################################################################
@@ -2666,14 +2696,16 @@ class SmurfUtilMixin(SmurfBase):
         """
         Queries the amplifier biases
 
-        Opt Args:
-        ---------
-        write_log (bool) : Whether to write to the log. Default is True.
-
-        Ret:
+        Args
         ----
-        amplifier_bias (dict) : Returns a dict with the hemt and 50K gate
-            voltage and drain current.
+        write_log : bool, optional, default True
+            Whether to write to the log.
+
+        Returns
+        -------
+        amplifier_bias : dict
+            Returns a dict with the hemt and 50K gate voltage and
+            drain current.
         """
         # 4K
         hemt_Id_mA=self.get_hemt_drain_current()
@@ -2722,9 +2754,10 @@ class SmurfUtilMixin(SmurfBase):
         value for this offset (see hemt_Id_offset in the amplifier
         block).
 
-        Returns:
-        --------
-        cur (float): 4K HEMT amplifier drain current in mA.
+        Returns
+        -------
+        cur : float
+            4K HEMT amplifier drain current in mA.
         """
         # assumes circuit topology on rev C2 cryostat card
         # (PC-248-103-02-C02, sheet 3)
@@ -3956,8 +3989,8 @@ class SmurfUtilMixin(SmurfBase):
             continuous=True, **kwargs):
         """ Play a bipolar waveform on the bias group.
 
-        Parameters:
-        ------------
+        Args
+        ----
         bias_group : int
             The bias group
         waveform : float array
@@ -3967,6 +4000,8 @@ class SmurfUtilMixin(SmurfBase):
             for TES bias).
         continuous : bool, optional, default True
             Whether to play the TES waveform continuously.
+        **kwargs : ???
+            ???
         """
         bias_order = self.bias_group_to_pair[:,0]
         dac_positives = self.bias_group_to_pair[:,1]

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -32,33 +32,33 @@ class SmurfUtilMixin(SmurfBase):
             IQstream=1, single_channel_readout=1, debug=False, write_log=True):
         """ Takes raw debugging data
 
-        Args:
-        -----
+        Args
+        ----
         band : int
-            The band to take data on
-        single_channel_readout : int
-            Whether to look at one channel
-        channel : int
-            The channel to take debug data on in single_channel_mode
-        nsamp : int
-            The number of samples to take
-        filename : str
+            The band to take data on.
+        channel : int or None, optional, default None
+            The channel to take debug data on in single_channel_mode.
+        nsamp : int, optional, default 2**19
+            The number of samples to take.
+        filename : str or None, optional, default None
             The name of the file to save to.
-        IQstream : int
+        IQstream : int, optional, default 1
             Whether to take the raw IQ stream.
-        debug : bool
-            Whether to take data in debug mode. Defaults False.
-        write_log : bool
-            Whether to write lowlevel commands to the log file.
+        single_channel_readout : int, optional, default 1
+            Whether to look at one channel.
+        debug : bool, optional, default False
+            Whether to take data in debug mode.
+        write_log : bool, optional, default True
+            Whether to write low-level commands to the log file.
 
-        Returns:
-        --------
+        Returns
+        -------
         f : float array
-            The frequency response
+            The frequency response.
         df : float array
-            The frequency error
+            The frequency error.
         sync : float array
-            The sync count
+            The sync count.
         """
         # Set proper single channel readout
         if channel is not None:

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -32,8 +32,8 @@ class SmurfUtilMixin(SmurfBase):
             IQstream=1, single_channel_readout=1, debug=False, write_log=True):
         """ Takes raw debugging data
 
-        Args
-        ----
+        Args:
+        -----
         band : int
             The band to take data on
         single_channel_readout : int
@@ -51,8 +51,8 @@ class SmurfUtilMixin(SmurfBase):
         write_log : bool
             Whether to write lowlevel commands to the log file.
 
-        Returns
-        -------
+        Returns:
+        --------
         f : float array
             The frequency response
         df : float array
@@ -504,13 +504,13 @@ class SmurfUtilMixin(SmurfBase):
         Args
         ----
         filename : str
-            Path to file
+            Path to file.
         swapFdF : bool, optional, default False
             Whether the F and dF (or I/Q) streams are flipped.
         recast : bool, optional, default True
             Whether to recast from size n_channels_processed to
             n_channels.
-        truncate : bool, optional, default=True
+        truncate : bool, optional, default True
             Truncates the data if the number of elements returned is
             not an integer multiple of the sample rate.
 

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -452,19 +452,19 @@ class SmurfUtilMixin(SmurfBase):
         """ Reads a file taken with take_debug_data and processes it into data
         and header.
 
-        Parameters:
-        -----------
+        Args
+        ----
         filename : str
             Path to file
-        dtype : np dtype
-            datatype to cast to, defaults unsigned 32 bit int
+        dtype : numpy.dtype, optional, default numpy.uint32
+            datatype to cast to.
 
-        Returns:
-        --------
-        header : np array
-            The header information
-        data : np array
-            The resonator data
+        Returns
+        -------
+        header : numpy.ndarray
+            The header information.
+        data : numpy.ndarray
+            The resonator data.
         """
         n_chan = 2 # number of stream channels
         #header_size = 4 # 8 bytes in 16-bit word
@@ -501,27 +501,31 @@ class SmurfUtilMixin(SmurfBase):
     def decode_data(self, filename, swapFdF=False, recast=True, truncate=True):
         """ Take a dataset from take_debug_data and spit out results.
 
-        Parameters:
-        -----------
+        Args
+        ----
         filename : str
             Path to file
-        swapFdF : bool
-            Whether the F and dF (or I/Q) streams are flipped
-        recast : bool
-            Whether to recast from size n_channels_processed to n_channels.
-            Default True.
-        truncate : bool
-            Truncates the data if the number of elements returned is not an
-            integer multiple of the sample rate. Default True.
+        swapFdF : bool, optional, default False
+            Whether the F and dF (or I/Q) streams are flipped.
+        recast : bool, optional, default True
+            Whether to recast from size n_channels_processed to
+            n_channels.
+        truncate : bool, optional, default=True
+            Truncates the data if the number of elements returned is
+            not an integer multiple of the sample rate.
 
-        Returns:
-        --------
-        [f, df, sync] :
-            if iqStreamEnable = 0. f is the tracking frequency, df is the
-            frequency error, and sync is the synchronizing pulse
-        [I, Q, sync] :
-            if iqStreamEnable = 1. I, Q are the in phase and quadrature signal.
-            sync is the synchronizing pulse.
+        Returns
+        -------
+        f : numpy.ndarray
+            If iqStreamEnable = 0. f is the tracking frequency.
+            Otherwise if iqStreamEnable = 1. f is the demodulated
+            in-phase tracking component.
+        df : numpy.ndarray
+            If iqStreamEnable = 0. df is the tracking frequency error.
+            Otherwise if iqStreamEnable = 1. f is the demodulated
+            quadrature tracking component.
+        flux_ramp_strobe : numpy.ndarray
+            The synchronizing pulse.
         """
         n_proc = self.get_number_processed_channels()
         n_chan = self.get_number_channels()
@@ -1091,22 +1095,28 @@ class SmurfUtilMixin(SmurfBase):
         This was the most common data writing mode until the Rogue 4 update.
         Maintining this function for backwards compatibility.
 
-        Args:
-        -----
-        datafile (str): The full path to the data made by stream_data_on
-
-        Opt Args:
-        ---------
-        channel (int or int array): Channels to load.
-        unwrap (bool) : Whether to unwrap units of 2pi. Default is True.
-        downsample (int): The amount to downsample.
-        n_samp (int) : The number of samples to read.
-
-        Ret:
+        Args
         ----
-        t (float array): The timestamp data
-        d (float array): The resonator data in units of phi0
-        m (int array): The maskfile that maps smurf num to gcp num
+        datafile : str
+            The full path to the data made by stream_data_on.
+
+        channel : int or list of int or None, optional, default None
+            Channels to load.
+        unwrap : bool, optional, default True
+            Whether to unwrap units of 2pi.
+        downsample : int, optional, default 1
+            The amount to downsample.
+        n_samp : int or None, optional, default None
+            The number of samples to read.
+
+        Returns
+        -------
+        t : numpy.ndarray
+            The timestamp data.
+        d : numpy.ndarray
+            The resonator data in units of phi0.
+        m : numpy.ndarray 
+            The maskfile that maps smurf num to gcp num.
         """
         import struct
         try:
@@ -1211,21 +1221,23 @@ class SmurfUtilMixin(SmurfBase):
         data in the header is (dac_b - dac_a)/2. This function
         also takes care of the factor of 2 in the denominator.
 
-        Args:
-        -----
-        header (dict) : The header dictionary from read_stream_data.
-            This includes all the tes_byte data.
-
-        Opt Args:
-        ---------
-        as_volt (bool): Whether to return the data as voltage. If
-            False, returns as DAC units. Default True.
-        n_tes_bias (int) : The number of TES bias pairs. Default 15.
-
-        Ret:
+        Args
         ----
-        bias (int array) : The tes bias data. (dac_b - dac_a) in
-            voltage or DAC units depending on the as_volt opt arg.
+        header : dict
+            The header dictionary from read_stream_data.  This
+            includes all the tes_byte data.
+
+        as_volt : bool, optional, default True
+            Whether to return the data as voltage. If False, returns
+            as DAC units.
+        n_tes_bias : int, optional, default 15
+            The number of TES bias pairs.
+
+        Returns
+        -------
+        bias : numpy.ndarray
+            The tes bias data. (dac_b - dac_a) in voltage or DAC units
+            depending on the as_volt opt arg.
         """
         # Numbr of total elements
         n_els = len(header['tes_byte_0'])
@@ -1403,13 +1415,15 @@ class SmurfUtilMixin(SmurfBase):
         """
         Reads data directly off the DAC.  Checks for input saturation.
 
-        Args:
-        -----
-        band (int) : Which band.  Assumes dac number is band%4.
-
-        Ret:
+        Args
         ----
-        saturated (bool) : Flag if DAC is saturated.
+        band : int
+            Which band.  Assumes dac number is band%4.
+
+        Returns
+        -------
+        saturated : bool
+            Flag if DAC is saturated.
         """
         dac = self.read_dac_data(band, data_length=2**12, do_plot=False,
                   save_data=False, show_plot=False, save_plot=False)
@@ -1432,31 +1446,36 @@ class SmurfUtilMixin(SmurfBase):
         """
         Reads data directly off the ADC.
 
-        Args:
-        -----
-        band (int) : Which band.  Assumes adc number is band%4.
-        data_length (int): The number of samples
-
-        Opt Args:
-        ---------
-        hw_trigger (bool) : Whether to use the hardware trigger. If
-            False, uses an internal trigger.
-        do_plot (bool) : Whether or not to plot.  Default false.
-        save_data (bool) : Whether or not to save the data in a time
-            stamped file.  Default true.
-        timestamp (int) : ctime to timestamp the plot and data with
-            (if saved to file).  Default None, in which case it gets
-            the time stamp right before acquiring data.
-        show_plot (bool) : If do_plot is True, whether or not to show
-            the plot.
-        save_plot (bool) : Whether or not to save plot to file.
-            Default True.
-        plot_ylimits ([float,float]) : y-axis limit (amplitude) to
-            restrict plotting over.
-
-        Ret:
+        Args
         ----
-        dat (int array) : The raw ADC data.
+        band : int
+            Which band.  Assumes adc number is band%4.
+
+        data_length : int, optional, default 2**19
+            The number of samples.
+        hw_trigger : bool, optional, default False
+            Whether to use the hardware trigger. If False, uses an
+            internal trigger.
+        do_plot : bool, optional, default False
+            Whether or not to plot.
+        save_data : bool, optional, default True
+            Whether or not to save the data in a time stamped file.
+        timestamp : int or None, optional, default None
+            ctime to timestamp the plot and data with (if saved to
+            file).  If None, it gets the time stamp right before
+            acquiring data.
+        show_plot : bool, optional, default True
+            If do_plot is True, whether or not to show the plot.
+        save_plot : bool, optional, default True
+            Whether or not to save plot to file.
+        plot_ylimits : [float or None, float or None], optional,
+        default [None,None]
+            y-axis limit (amplitude) to restrict plotting over.
+
+        Returns
+        -------
+        dat : int array
+            The raw ADC data.
         """
         if timestamp is None:
             timestamp = self.get_timestamp()
@@ -3890,11 +3909,11 @@ class SmurfUtilMixin(SmurfBase):
             The bias group
         waveform : float array
             The waveform the play on the bias group.
-        do_enable : bool
-            Whether to enable the DACs (similar to what is resuired for TES
-            bias). Defualt True.
-        continuous : bool
-            Whether to play the TES waveform continuously. Default True.
+        do_enable : bool, optional, default True
+            Whether to enable the DACs (similar to what is required
+            for TES bias).
+        continuous : bool, optional, default True
+            Whether to play the TES waveform continuously.
         """
         bias_order = self.bias_group_to_pair[:,0]
         dac_positives = self.bias_group_to_pair[:,1]
@@ -3973,35 +3992,38 @@ class SmurfUtilMixin(SmurfBase):
         this with the TESs superconducting so it can look for an
         response is exactly the same amplitude as the input.
 
-        Parameters:
-        -----------
-        bias_groups : int array
-            The bias groups to search. If None, does the first 8 bias groups.
-            Default is None.
-        probe_freq : float
-            The frequency of the probe tone
-        probe_time : float
-            The length of time to probe each bias group in seconds. Default 3.
-        cutoff_frac : float
-            The fraction difference the response can be away from the expected
-            amplitude. Default .05.
-        make_plot : bool
-            Whether to make the plot. Default False.
-        save_plot :bool
-            Whether to save the plot. Default True.
-        show_plot : bool
-            Whether to show the plot. Default False
-        update_channel_assignment : bool
-            Whether to update the master channels assignment to contain the new
-            bias group information. Default True.
-        high_current_mode : bool
-            Whether to use high or low current mode. Default True.
+        Args
+        ----
+        bias_groups : int array or None, optional, default None
+            The bias groups to search. If None, does the first 8 bias
+            groups.
+        probe_freq : float, optional, default 2.5
+            The frequency of the probe tone.
+        probe_time : float, optional, default 3
+            The length of time to probe each bias group in seconds.
+        probe_amp : float, optional, default 0.1
+            Amplitude of the probe signal in volts.
+        make_plot : bool, optional, default False
+            Whether to make the plot.
+        show_plot : bool, optional, default False
+            Whether to show the plot.
+        save_plot : bool, optional, default True
+            Whether to save the plot.
+        cutoff_frac : float, optional, default 0.05
+            The fraction difference the response can be away from the
+            expected amplitude.
+        update_channel_assignment : bool, optional, default True
+            Whether to update the master channels assignment to
+            contain the new bias group information.
+        high_current_mode : bool, optional, default True 
+            Whether to use high or low current mode.
 
-        Returns:
-        --------
-        channels_dict (dict) : A dictionary where the first key is
-            the bias group that is being probed. In each is the
-            band, channnel pairs, and frequency of the channels.
+        Returns
+        -------
+        channels_dict : dict of {int : dict of {str : numpy.ndarray} }
+            A dictionary where the first key is the bias group that is
+            being probed. In each is the band, channnel pairs, and
+            frequency of the channels.
         """
         # Check if probe frequency is too high
         flux_ramp_freq = self.get_flux_ramp_freq() * 1.0E3

--- a/python/pysmurf/client/util/tools.py
+++ b/python/pysmurf/client/util/tools.py
@@ -118,13 +118,14 @@ def utf8_to_str(d):
     int arrays. This function changes them from UTF8 to a
     string
 
-    Args:
-    -----
-    d (int array) : An integer array with each element equal to
-        a character
-
-    Ret:
+    Args
     ----
-    d_str (str) : The string associated with input d
+    d : int array
+        An integer array with each element equal to a character.
+
+    Returns
+    -------
+    str
+        The string associated with input d.
     """
     return ''.join([str(s, encoding='UTF-8') for s in d])

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -191,7 +191,7 @@ class PcieCard():
     according to the communication type used.
 
     If the PCIe card is present in the system:
-    
+
     * All the RSSI connection lanes which point to the target IP
       address will be closed.
     * If PCIe communication type is used:

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -195,6 +195,10 @@ class PcieCard():
     * All the RSSI connection lanes which point to the target IP
       address will be closed.
     * If PCIe communication type is used:
+      * Verify that the DeviceId are correct for the RSSI (ID = 0) and
+        the DATA (ID = 1) devices.
+      * The RSSI connection is open in the specific lane. Also, when
+        the the server is closed, the RSSI connection is closed.
 
     If the PCIe card is not present:
 

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -191,11 +191,13 @@ class PcieCard():
     according to the communication type used.
 
     If the PCIe card is present in the system:
+    
     * All the RSSI connection lanes which point to the target IP
       address will be closed.
     * If PCIe communication type is used:
 
     If the PCIe card is not present:
+
     * If PCIe communication type is used, the program is terminated.
     * If ETH communication type is used, then this class does not do
       anything.

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -194,10 +194,6 @@ class PcieCard():
     * All the RSSI connection lanes which point to the target IP
       address will be closed.
     * If PCIe communication type is used:
-      * Verify that the DeviceId are correct for the RSSI (ID = 0) and
-        the DATA (ID = 1) devices.
-      * The RSSI connection is open in the specific lane. Also, when
-        the the server is closed, the RSSI connection is closed.
 
     If the PCIe card is not present:
     * If PCIe communication type is used, the program is terminated.

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -187,26 +187,26 @@ class PcieCard():
     """
     Class to setup the PCIe card devices.
 
-    This class takes care of setting up both PCIe card devices according to the
-    communication type used.
+    This class takes care of setting up both PCIe card devices
+    according to the communication type used.
 
     If the PCIe card is present in the system:
-    - All the RSSI connection lanes which point to the target IP address will
-      be closed.
-    - If PCIe communication type is used:
-        - Verify that the DeviceId are correct for the RSSI (ID = 0) and the DATA
-          (ID = 1) devices.
-        - the RSSI connection is open in the specific lane. Also, when the the server
-          is closed, the RSSI connection is closed.
-    -
+    * All the RSSI connection lanes which point to the target IP
+      address will be closed.
+    * If PCIe communication type is used:
+      * Verify that the DeviceId are correct for the RSSI (ID = 0) and
+        the DATA (ID = 1) devices.
+      * the RSSI connection is open in the specific lane. Also, when
+        the the server is closed, the RSSI connection is closed.
 
     If the PCIe card is not present:
-    - If PCIe communication type is used, the program is terminated.
-    - If ETH communication type is used, then this class does not do anything.
+    * If PCIe communication type is used, the program is terminated.
+    * If ETH communication type is used, then this class does not do
+      anything.
 
-    This class must be used in a 'with' block in order to ensure that the
-    RSSI connection is close correctly during exit even in the case of an
-    exception condition.
+    This class must be used in a 'with' block in order to ensure that
+    the RSSI connection is close correctly during exit even in the
+    case of an exception condition.
     """
 
     def __init__(self, comm_type, lane, ip_addr, dev_rssi, dev_data):

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -196,7 +196,7 @@ class PcieCard():
     * If PCIe communication type is used:
       * Verify that the DeviceId are correct for the RSSI (ID = 0) and
         the DATA (ID = 1) devices.
-      * the RSSI connection is open in the specific lane. Also, when
+      * The RSSI connection is open in the specific lane. Also, when
         the the server is closed, the RSSI connection is closed.
 
     If the PCIe card is not present:

--- a/python/pysmurf/core/emulators/_DataFromFile.py
+++ b/python/pysmurf/core/emulators/_DataFromFile.py
@@ -86,9 +86,10 @@ class DataMaster(rogue.interfaces.stream.Master):
         frame with the SMuRF header, with only the first channel
         containing the data point.
 
-        Args:
-        -----
-        - file_name (str) : path to the input data file
+        Args
+        ----
+        file_name : str
+            Path to the input data file.
         """
         if not file_name:
             print("ERROR: Must define a data file first!")
@@ -113,9 +114,10 @@ class DataMaster(rogue.interfaces.stream.Master):
         one channel. The SMuRF header will be only partially filled, containing
         only the number of channels, and a the frame counter words.
 
-        Args:
-        -----
-        - data (int) : input data (must be of type int16)
+        Args
+        ----
+        data : int
+            Input data (must be of type int16).
         """
 
         # Request a frame to hold 1 data point

--- a/python/pysmurf/core/transmitters/_DataToFile.py
+++ b/python/pysmurf/core/transmitters/_DataToFile.py
@@ -76,9 +76,10 @@ class DataSlave(rogue.interfaces.stream.Slave):
         content of the data buffer (self._data) to the output file,
         one data point on each line as text.
 
-        Args:
-        -----
-        - file_name (str) : path to the output data file.
+        Args
+        ----
+        file_name : str
+            Path to the output data file.
         """
         if not file_name:
             print("ERROR: Must define a data file first!")
@@ -95,12 +96,13 @@ class DataSlave(rogue.interfaces.stream.Slave):
 
     def _acceptFrame(self, frame):
         """
-        Args:
         Receive a frame with SMuRF data. The first channel is appended
         to the data buffer.
 
-        -----
-        frame (rogue.interfaces.stream.Frame) : a frame with SMuRF data.
+        Args
+        ----
+        frame : rogue.interfaces.stream.Frame
+            A frame with SMuRF data.
         """
         with frame.lock():
             data = bytearray(4)
@@ -126,8 +128,9 @@ class MetaSlave(rogue.interfaces.stream.Slave):
         """
         Receive a frame with metadata. The frame is discarded.
 
-        Args:
-        -----
-        frame (rogue.interfaces.stream.Frame) : a frame with metadata
+        Args
+        ----
+        frame : rogue.interfaces.stream.Frame
+            A frame with metadata.
         """
         pass

--- a/python/pysmurf/core/utilities/_SetupGroups.py
+++ b/python/pysmurf/core/utilities/_SetupGroups.py
@@ -27,7 +27,7 @@ def setupGroups(root, VariableGroups):
     ----
     VariableGroups : dict
         Each entry must have the form '<Rogue device or Variable>' : {'groups' : [<list of groups>], 'pollInterval': <poll interval> }
-    
+
         The 'groups' entry provides a list of groups to add the
         Device/Variable to.  If the path points to a device, the group
         will be added recursively to all devices and variables deeper

--- a/python/pysmurf/core/utilities/_SetupGroups.py
+++ b/python/pysmurf/core/utilities/_SetupGroups.py
@@ -23,24 +23,20 @@ def setupGroups(root, VariableGroups):
     """
     Set variable groups.
 
-    Args:
-    -----
-    VariableGroups (dict) : each entry must have the form
-                            '<Rogue device or Variable>' :
-                                {'groups' : [<list of groups>],
-                                 'pollInterval': <poll interval> }
-
-                            The 'groups' entry provides a list of groups to add the Device/Variable to.
-                            If the path points to a device, the group will be added recursively to all
-                            devices and variables deeper in the path.
-                            The 'pollInterval' entry provides an optional value which will be used to update
-                            the polling interface if the path points to a variable. The poll interval value
-                            is in seconds. Use None to leave interval unchanged, 0 to disable polling.
-                            If this argument is 'None' then nothing will be done.
-
-    Ret:
-    -----
-    None
+    Args
+    ----
+    VariableGroups : dict
+        Each entry must have the form '<Rogue device or Variable>' : {'groups' : [<list of groups>], 'pollInterval': <poll interval> }
+    
+        The 'groups' entry provides a list of groups to add the
+        Device/Variable to.  If the path points to a device, the group
+        will be added recursively to all devices and variables deeper
+        in the path.  The 'pollInterval' entry provides an optional
+        value which will be used to update the polling interface if
+        the path points to a variable. The poll interval value is in
+        seconds. Use None to leave interval unchanged, 0 to disable
+        polling.  If this argument is 'None' then nothing will be
+        done.
     """
 
     if VariableGroups:

--- a/python/pysmurf/core/utilities/_SmurfPublisher.py
+++ b/python/pysmurf/core/utilities/_SmurfPublisher.py
@@ -41,7 +41,7 @@ class SmurfPublisher(object):
         """The Publisher should normally be instantiated with just the
         script_id, e.g.:
 
-          pub = Publisher('tuning_script')
+        >>> pub = Publisher('tuning_script')
 
         Configuration options - these should be set in the options
         dictionary, or through environment variables using the
@@ -164,17 +164,17 @@ class SmurfPublisher(object):
         """
         Publishes file info so it can be picked up by the pysmurf-archiver.
 
-        Args:
-        -----
-        path (str):
-            full path to file.
-        type (str):
+        Args
+        ----
+        path : str
+            Full path to file.
+        type : str
             Type of data file, e.g. "tuning" or "config_snapshot"
-        format (str):
+        format : str, optional, default ''
             File extension. E.g. "npy" or "txt"
-        timestamp (float):
+        timestamp : float or None, optional, default None
             Unix timestamp when file was created.
-        plot (bool):
+        plot : bool, optional, default False
             True if file is a plot
         """
         if timestamp is None:


### PR DESCRIPTION
## Issue
This PR resolves issue https://github.com/slaclab/pysmurf/issues/362 and is a necessary step towards resolving https://github.com/slaclab/pysmurf/issues/382.

## Description

This PR, like many of my PRs, incorporates too many changes.  Here's an attempted list at what it does:
- Fixes readthedocs interface & automated builds.
- Adds docstrings that were missing to a lot of things in the base module.
- Resolves all sphinx_build warnings and errors in master (over 600).  PR branch is named badly, as if it only fixes the sphinx_build warnings and errors in smurf_control ; I just fixed them all.
- Upgrades 3-rd party schema code from 0.7.0 to 0.7.1.
- Lots of small fixes to formatting, spacing, and other trivial problems found by pylint.
- First step towards a refactor of how the smurf_control class loads parameters from the pysmurf configuration file.  Instead of loading parameters into inconsistently named instance attributes in the SmurfControl class instance, they are now loaded into python property objects in a new mixin class named SmurfConfigPropertiesMixin.  Only partially implemented.
- Adds core code and a user guide template (with some very limited info for developers on how to write docstrings that comply with the PyNumpy docstring standard.

## Does this PR break any interface?
- [ ] Yes
- [x] No

This code should not break any pysmurf interfaces, but it does make some major interface changes which could potentially break some important things.

### Which interface changed?

The interface between the SmurfControl class and the pysmurf configuration file.  Also the interface between pysmurf and the automated documentation builds.

### What was the interface before the change

The interface between the SmurfControl class and the pysmurf configuration file used to be implemented piecemeal using inconsistently named class instance attributes.

pysmurf docstrings previously had no consistent formatting, and the existing formatting did not conform to any of the parsable standards.  The core code documentation was not being generated automatically, and there was no higher level documentation for pysmurf.

### What will be the new interface after the change

pysmurf configuration file parameters are now loaded into python property objects in a new mixin class named SmurfConfigPropertiesMixin.  Only partially implemented.  This allows them to be documented by adding docstrings to the properties' getter functions.

All sphinx_build warnings and errors are resolved by this PR.  Most of the work was reformatting our docstrings into the numpy docstring format.  Added documentation generation for the core code, and an outline higher level documentation.