### PR TITLE
Add travis job to test documentation build for errors and warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,17 @@ jobs:
         - flake8 --count python/
 
     # Test stages
+    ## Documentation automatic build tests
+    - stage: tests
+      name: "Documentation Build Tests"
+      install:
+        # Install pysmurf
+        - pip3 install .
+      script:
+        # Try to build the documentation
+        - cd docs/
+        - make html
+
     ## Server tests
     - stage: tests
       name: "Server Tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ jobs:
       install:
         # Install pysmurf
         - pip3 install .
+        # Install sphinx
+        - pip3 install sphinx
       script:
         # Try to build the documentation
         - cd docs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
       script:
         # Try to build the documentation
         - cd docs/
-        - make html
+        - make html SPHINXOPTS="-W --keep-going -n"
 
     ## Server tests
     - stage: tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ jobs:
     - stage: tests
       name: "Documentation Build Tests"
       install:
+        # Install requirements
+        - pip3 install -r requirements.txt
         # Install pysmurf
         - pip3 install .
         # Install sphinx

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
       script:
         # Try to build the documentation
         - cd docs/
-        - make html SPHINXOPTS="-W --keep-going -n"
+        - make html SPHINXOPTS="-W --keep-going"
 
     ## Server tests
     - stage: tests

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -223,7 +223,7 @@ latex_documents = [
 #latex_use_modindex = True
 
 # Modules to mock up
-autodoc_mock_imports = ['pyrogue','smurf','rogue','CryoDet','CryoDevBoard']
+autodoc_mock_imports = ['pyrogue','smurf','rogue','CryoDet','CryoDevBoard','pysmurf.core.devices._UdpReceiver']
 
 
 # Source code links

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -195,10 +195,8 @@ class PcieCard():
     * All the RSSI connection lanes which point to the target IP
       address will be closed.
     * If PCIe communication type is used:
-      * Verify that the DeviceId are correct for the RSSI (ID = 0) and
-        the DATA (ID = 1) devices.
-      * The RSSI connection is open in the specific lane. Also, when
-        the the server is closed, the RSSI connection is closed.
+      * Verify that the DeviceId are correct for the RSSI (ID = 0) and the DATA (ID = 1) devices.
+      * The RSSI connection is open in the specific lane. Also, when the the server is closed, the RSSI connection is closed.
 
     If the PCIe card is not present:
 


### PR DESCRIPTION
## Issue
This PR resolves #382 

## Description
This PR adds a travis job under the test stage to run the sphinx documentation build and to fail on errors and warnings.

## Does this PR break any interface?
- [ ] Yes
- [X] No
