### PR TITLE
Fixes docstrings to have valid reStructuredText (RST)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -34,3 +34,10 @@ exclude = __init__.py, rogue_plugin.py
 # E741 do not use variables name I
 #############################################################
 ignore = E116,E128,E131,E201,E202,E203,E211,E221,E222,E225,E226,E227,E228,E231,E241,E251,E261,E262,E265,E266,E272,E302,E303,E305,E306,E501,W504,E741
+rst-roles =
+    class,
+    func,
+    ref,
+rst-directives =
+    envvar,
+    exception,

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,7 @@ jobs:
         - pip3 install flake8-rst-docstrings
       script:
         # Run Flake8
-        - flake8 \
-            --rst-roles class,func,ref \
-            --rst-directives envvar,exception \
-            --count python/
+        - flake8 --count python/
 
     # Test stages
     ## Documentation automatic build tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,14 @@ jobs:
     ## Flake8 checks
     - stage: checks
       name: "Flake8 Checks"
+      install:
+        - pip3 install flake8-rst-docstrings
       script:
         # Run Flake8
-        - flake8 --count python/
+        - flake8 \
+            --rst-roles class,func,ref \
+            --rst-directives envvar,exception \
+            --count python/
 
     # Test stages
     ## Documentation automatic build tests

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -46,19 +46,21 @@ class SmurfBase:
     def __init__(self, log=None, epics_root=None, offline=False,
                  pub_root=None, script_id=None, **kwargs):
         """
-        Opt Arguments
-        --------------
-        log (log file) : The log file to write to. If None, creates a new log
-            file.
-        epics_root (str) : The name of the epics root. For example "test_epics".
-        offline (bool) : Whether to run in offline mode (no rogue) or not. This
+        Args
+        ----
+        log : log file or None, optional, default None
+            The log file to write to. If None, creates a new log file.
+        epics_root : str or None, optional, default None
+            The name of the epics root. For example "test_epics".
+        offline : bool, optional, default False
+            Whether to run in offline mode (no rogue) or not. This
             will break many things. Default is False.
-        pub_root (str):
-            Root of environment vars to set publisher options. If None, the
-            default root will be "SMURFPUB_".
-        script_id (str):
-            Script id included with publisher messages. For example, the
-            script or operation name.
+        pub_root : str or None, optional, default None
+            Root of environment vars to set publisher options. If
+            None, the default root will be "SMURFPUB_".
+        script_id : str or None, optional, default None
+            Script id included with publisher messages. For example,
+            the script or operation name.
         """
 
         # Set up logging

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -57,7 +57,7 @@ class SmurfBase:
             will break many things. Default is False.
         pub_root : str or None, optional, default None
             Root of environment vars to set publisher options. If
-            None, the default root will be "SMURFPUB_".
+            None, the default root will be `SMURFPUB_`.
         script_id : str or None, optional, default None
             Script id included with publisher messages. For example,
             the script or operation name.

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -19,9 +19,25 @@ from pysmurf.client.util.pub import Publisher
 from .logger import SmurfLogger
 
 class SmurfBase:
-    '''
+    """
     Base class for common things
-    '''
+
+    Args
+    ----
+    log : log file or None, optional, default None
+        The log file to write to. If None, creates a new log file.
+    epics_root : str or None, optional, default None
+        The name of the epics root. For example "test_epics".
+    offline : bool, optional, default False
+        Whether to run in offline mode (no rogue) or not. This
+        will break many things. Default is False.
+    pub_root : str or None, optional, default None
+        Root of environment vars to set publisher options. If
+        None, the default root will be `SMURFPUB_`.
+    script_id : str or None, optional, default None
+        Script id included with publisher messages. For example,
+        the script or operation name.
+    """
 
     _base_args = ['verbose', 'logfile', 'log_timestamp', 'log_prefix',
                   'load_configs', 'log', 'layout']
@@ -46,21 +62,6 @@ class SmurfBase:
     def __init__(self, log=None, epics_root=None, offline=False,
                  pub_root=None, script_id=None, **kwargs):
         """
-        Args
-        ----
-        log : log file or None, optional, default None
-            The log file to write to. If None, creates a new log file.
-        epics_root : str or None, optional, default None
-            The name of the epics root. For example "test_epics".
-        offline : bool, optional, default False
-            Whether to run in offline mode (no rogue) or not. This
-            will break many things. Default is False.
-        pub_root : str or None, optional, default None
-            Root of environment vars to set publisher options. If
-            None, the default root will be `SMURFPUB_`.
-        script_id : str or None, optional, default None
-            Script id included with publisher messages. For example,
-            the script or operation name.
         """
 
         # Set up logging

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -81,10 +81,6 @@ class SmurfControl(SmurfCommandMixin,
               'shm-smrf-sp01'
     validate_config : bool, optional, default True
               Whether to check if the input config file is correct.
-    **kwargs
-              These parameters will be passed to the pysmurf
-              :func:`~SmurfControl.initialize` routine.  AND TO MIXIN
-              AND OTHER INHERITED CLASS CONSTRUCTORS.
 
     Attributes
     ----------
@@ -168,9 +164,6 @@ class SmurfControl(SmurfCommandMixin,
               Whether to send messages to the OCS publisher.
         payload_size : int, optional, default 2048
               The payload size to set on setup.
-        **kwargs
-              These parameters will be passed to the pysmurf
-              :func:`~SmurfControl.setup` routine.
 
         See Also
         --------

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -202,11 +202,6 @@ class SmurfIVMixin(SmurfBase):
         phase_excursion_min : float, optional, default 1.0
             Minimum change in phase to be analyzed, defined as
             abs(phase_max - phase_min). Units radians.
-
-        Returns
-        -------
-        path : str
-            ???
         """
 
         original_biases = self.get_tes_bias_bipolar_array()
@@ -329,8 +324,6 @@ class SmurfIVMixin(SmurfBase):
         channel : int array or None, optional, default None
             Which channels to analyze. Defaults to all the channels
             that are on and exceed phase_excursion_min.
-        band : int or None, optional, default None
-            ???
         datafile : str or None, optional, default None
             The full path to the data. This is used for offline mode
             where the data was copied to a new directory. The
@@ -576,7 +569,6 @@ class SmurfIVMixin(SmurfBase):
         resp : float array
             The TES phase response in radians. Of length n_pts (not
             the same as n_steps).
-
         make_plot : bool, optional, default True
             Whether to make the plot.
         show_plot : bool, optional, default False
@@ -601,12 +593,8 @@ class SmurfIVMixin(SmurfBase):
             Whether the data was taken in high current mode. This is
             important for knowing what current actually enters the
             cryostat.
-        bias group : ??? or None, optional, default None
-            ???
         grid_on : bool, optional, default False
             Whether to plot with grids on.
-        R_op_target : float, optional, default 0.007
-            ???
         pA_per_phi0 : float or None, optional, default None
             The conversion for phi0 to pA. If None, attempts to read
             it from the config file.
@@ -615,17 +603,9 @@ class SmurfIVMixin(SmurfBase):
             from config.
         plotname_append : str, optional, default ''
             An optional string to append the plot names.
-        **kwargs : ???
-            ???
 
         Returns
         -------
-        R : float array
-            ???
-        R_n : float
-            ???
-        idx : int array
-            ???
         R_sh : float
             Shunt resistance.
         """

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -59,10 +59,6 @@ class SmurfNoiseMixin(SmurfBase):
             Extends the scipy.signal.welch detrend.
         fs : float or None, optional, default None
             Sample frequency. If None, reads it in.
-        low_freq : numpy.ndarray, optional, default numpy.array([0.1,1.0])
-            ???
-        high_freq : numpy.ndarray, optional, default numpy.array([1.0,10.0])
-            ???
         make_channel_plot : bool, optional, default True
             Whether to make the individual channel plots.
         make_summary_plot : bool, optional, default True
@@ -71,8 +67,6 @@ class SmurfNoiseMixin(SmurfBase):
             Whether to save the band averaged data as a text file.
         show_plot : bool, optional, default False
             Show the plot on the screen.
-        grid_on : bool, optional, default False
-            ???
         datafile : str or None, optional, default None
             If data has already been taken, can point to a file to
             bypass data taking and just analyze.
@@ -86,8 +80,6 @@ class SmurfNoiseMixin(SmurfBase):
             Whether to reset the filter before taking data.
         reset_unwrapper : bool, optional, default True
             Whether to reset the unwrapper before taking data.
-        return_noise_params : bool, optional, default False
-            ???
         plotname_append : str, optional, default ''
             Appended to the default plot filename.
 
@@ -473,8 +465,6 @@ class SmurfNoiseMixin(SmurfBase):
         bias : float array or None, optional, default None
             The array of bias values to step through. If None, uses
             values in defined by bias_high, bias_low, and step_size.
-        high_current_mode : bool, optional, default True
-            ???
         overbias_voltage : float, optional, default 9.0
             Voltage to set the overbias in volts.
         meas_time : float, optional, default 30.0
@@ -490,17 +480,9 @@ class SmurfNoiseMixin(SmurfBase):
             The sample frequency.
         show_plot : bool, optional, default False
             Whether to show analysis plots.
-        cool_wait : float, optional, default 30.0
-            ???
-        psd_ylim : tuple of float, optional, default (10.0,1000.0)
-            ???
-        make_timestream_plot : bool, optional, default False
-            ???
         only_overbias_once : bool, optional, default False
             Whether or not to overbias right before each TES bias
             step.
-        overbias_wait : float, optional, default 1.0
-            ???
         """
         if bias is None:
             if step_size > 0:
@@ -522,10 +504,7 @@ class SmurfNoiseMixin(SmurfBase):
             step_size=1, amplitudes=None, meas_time=30., analyze=False,
             channel=None, nperseg=2**13, detrend='constant', fs=None,
             show_plot=False, make_timestream_plot=False, psd_ylim=None):
-        """???
-
-        ???
-
+        """
         Args
         ----
         band : int
@@ -585,8 +564,6 @@ class SmurfNoiseMixin(SmurfBase):
         only_overbias_once : bool, optional, default False
             Whether to only overbias at the beginning of the
             measurement (as opposed to between every step).
-        **kwargs : ???
-            ???
         """
         if fs is None:
             fs = self.get_sample_frequency()
@@ -1444,11 +1421,6 @@ class SmurfNoiseMixin(SmurfBase):
             The band number.
         meas_time : float, optional, default 10.0
             The measurement time per resonator in seconds.
-
-        Returns
-        -------
-        ret : ???
-            ???
         """
         timestamp = self.get_timestamp()
 
@@ -1486,17 +1458,6 @@ class SmurfNoiseMixin(SmurfBase):
         ----
         ret : dict
             The returned values from noise_all_vs_noise_solo.
-        fs : float or None, optional, default None
-            ???
-        nperseg : int, optional, defualt 2**10
-            ???
-        make_channel_plot : bool, optional, default False
-            ???
-
-        Returns
-        -------
-        wl_diff : ???
-            ???
         """
         if fs is None:
             fs = self.fs
@@ -1616,12 +1577,8 @@ class SmurfNoiseMixin(SmurfBase):
             Whether to save the plot.
         show_plot : bool, optional, default False
             Whether to how the plot.
-        make_timestream_plot : bool, optional, default False
-            ???
         data_timestamp : str or None, optional, default None
             The string used as a save name.
-        psd_ylim : ???, optional, default (10.0,1000.0)
-            ???
         bias_group : int or int array or None, optional, default None
             Which bias groups were used.
         smooth_len : int, optional, default 11

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -159,10 +159,6 @@ class SmurfTuneMixin(SmurfBase):
             Whether to make a plot per subband. This is very slow.
         n_scan : int, optional, default 5
             The number of scans to take and average.
-        subband_plot_with_slow : bool, optional, default False
-            ???
-        drive : int or None, optional, default None
-            ???
         grad_cut : float, optional, default 0.05
             The value of the gradient of phase to look for resonances.
         freq_min : float, optional, default -2.5e8
@@ -174,8 +170,6 @@ class SmurfTuneMixin(SmurfBase):
         amp_cut : float, optional, default 0.5
             The distance from the median value to decide whether
             there is a resonance.
-        use_slow_eta : bool, optional, default False
-            ???
 
         Returns
         -------
@@ -1224,8 +1218,6 @@ class SmurfTuneMixin(SmurfBase):
             The timestamp of the data.
         res_num : int or None, optional, default None
             The resonator number.
-        use_slow_eta : bool, optional, default False
-            ???.
 
         Returns
         -------
@@ -1342,8 +1334,6 @@ class SmurfTuneMixin(SmurfBase):
             The eta parameter.
         eta_mag : complex or None, optional, default None
             The amplitude of the eta parameter.
-        peak_freq : ??? or None, optional, default None
-            ???
         eta_phase_deg : float or None, optional, default None
             The angle of the eta parameter in degrees.
         r2 : float or None, optional, default None
@@ -1352,8 +1342,6 @@ class SmurfTuneMixin(SmurfBase):
             Whether to save the plot.
         plotname_append : str, optional, default ''
             Appended to the default plot filename.
-        show_plot : bool, optional, default False
-            ???
         timestamp : str or None, optional, default None
             The timestamp to name the file.
         res_num : int or None, optional, default None
@@ -1362,12 +1350,6 @@ class SmurfTuneMixin(SmurfBase):
             The band number to label the plot.
         sk_fit : float array or None, optional, default None
             The fit parameters for the skewed lorentzian.
-        f_slow : ??? or None, optional, default None
-            ???
-        resp_slow : ??? or None, optional, default None
-            ???
-        channel : ??? or None, optional, default None
-            ???
         """
         if timestamp is None:
             timestamp = self.get_timestamp()
@@ -1509,8 +1491,6 @@ class SmurfTuneMixin(SmurfBase):
             The frequency to search for a subband.
         band : int
             The band to identify.
-        as_offset : bool, optional, default True
-            ???
 
         Returns
         -------
@@ -1622,8 +1602,6 @@ class SmurfTuneMixin(SmurfBase):
             subband center.
         channel_per_subband : int, optional, default 4
             The number of channels to assign per subband.
-        as_offset : bool, optional, default True
-            ???
         min_offset : float, optional, default 0.1
             The minimum offset between two resonators in MHz.  If
             closer, then both are ignored.
@@ -1893,8 +1871,6 @@ class SmurfTuneMixin(SmurfBase):
             Whether to check r2 and Q values.
         min_gap : float or None, optional, default None
             The minimum distance between resonators.
-        write_log : bool, optional, default False
-            ???
         """
         n_channels = self.get_number_channels(band)
 
@@ -2161,19 +2137,6 @@ class SmurfTuneMixin(SmurfBase):
             The frequency to sweep.
         df_sweep : float, optional, default 0.002
             The frequency step size.
-        delta_freq : float, optional, default 0.01
-            ???
-        lock_max_derivative : bool, optional, default False
-            ???
-
-        Returns
-        -------
-        f_sweep : array
-            ???
-        resp : array
-            ???
-        eta : array
-            ???
         """
         subband, offset = self.freq_to_subband(band, freq)
         f_sweep = np.arange(offset-f_sweep_half, offset+f_sweep_half, df_sweep)
@@ -2397,17 +2360,11 @@ class SmurfTuneMixin(SmurfBase):
             Whether to save plots.
         show_plot : bool, optional, default True
             Whether to display the plot.
-        nsamp : int, optional, default 2**19
-            ???
         lms_freq_hz : float or None, optional, default None
             The frequency of the tracking algorithm.
         meas_lms_freq : bool, optional, default False
             Whether or not to try to estimate the carrier rate using
             the flux_mod2 function.  lms_freq_hz must be None.
-        meas_flux_ramp_amp : bool, optional, default False
-            ???
-        nphi0 : ???, optional, default 4
-            ???
         flux_ramp : bool, optional, default True
             Whether to turn on flux ramp.
         fraction_full_scale : float or None, optional, default None
@@ -2421,10 +2378,6 @@ class SmurfTuneMixin(SmurfBase):
         lms_gain : int or None, optional, default None
             The tracking gain parameters. Default is the value in the
             config table.
-        return_data : bool, optional, default True
-            ???
-        new_epics_root : ??? or None, optional, default None
-            ???
         feedback_start_frac : float or None, optional, default None
             The fraction of the full flux ramp at which to stop
             applying feedback in each flux ramp cycle.  Must be in
@@ -2904,16 +2857,10 @@ class SmurfTuneMixin(SmurfBase):
     def set_fixed_flux_ramp_bias(self,fractionFullScale,debug=True,
             do_config=True):
         """
-        ???
-
         Args
         -----
         fractionFullScale : float
             Fraction of full flux ramp scale to output from [-1,1].
-        debug : bool, optional, default True
-            ???
-        do_config : bool, optional, default True
-            ???
         """
 
         # fractionFullScale must be between [0,1]
@@ -2984,8 +2931,6 @@ class SmurfTuneMixin(SmurfBase):
         fraction_full_scale : float
             The amplitude of the flux ramp as a fraction of the
             maximum possible value.
-        df_range : float, optional, default 0.1
-            ???
         band : int, optional, default 2
             The band to setup the flux ramp on.
         write_log : bool, optional, default False

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -1449,7 +1449,6 @@ class SmurfUtilMixin(SmurfBase):
         ----
         band : int
             Which band.  Assumes adc number is band%4.
-
         data_length : int, optional, default 2**19
             The number of samples.
         hw_trigger : bool, optional, default False
@@ -1467,8 +1466,7 @@ class SmurfUtilMixin(SmurfBase):
             If do_plot is True, whether or not to show the plot.
         save_plot : bool, optional, default True
             Whether or not to save plot to file.
-        plot_ylimits : [float or None, float or None], optional,
-        default [None,None]
+        plot_ylimits : [float or None, float or None], optional, default [None,None]
             y-axis limit (amplitude) to restrict plotting over.
 
         Returns
@@ -1552,7 +1550,6 @@ class SmurfUtilMixin(SmurfBase):
         ----
         band : int
             Which band.  Assumes dac number is band%4.
-
         data_length : int, optional, default 2**19
             The number of samples.
         hw_trigger : bool, optional, default False
@@ -1570,8 +1567,7 @@ class SmurfUtilMixin(SmurfBase):
             If do_plot is True, whether or not to show the plot.
         save_plot : bool, optional, default True
             Whether or not to save plot to file.
-        plot_ylimits : list of float or list of None, optional,
-        default [None,None]
+        plot_ylimits : list of float or list of None, optional, default [None,None]
             2-element list of y-axis limits (amplitude) to restrict
             plotting over.
 
@@ -1660,10 +1656,6 @@ class SmurfUtilMixin(SmurfBase):
             The amount of data to take.
         band : int, optional, default 0
             which band to get data on.
-        debug : bool, optional, default False
-            ???
-        write_log : bool, optional, default False
-            ???
         """
 
         bay=self.band_to_bay(band)
@@ -1700,14 +1692,8 @@ class SmurfUtilMixin(SmurfBase):
 
         Args
         ----
-        bay : int
-            ???
         size : int
             The buffer size in number of points.
-        debug : bool, optional, default False
-            ???
-        write_log : bool, optional, default False
-            ???
         """
         # Change DAQ data buffer size
 
@@ -1812,8 +1798,6 @@ class SmurfUtilMixin(SmurfBase):
         ----
         band : int
            The band whose feedback to toggle.
-        ***kwargs : ???
-           ???
         """
 
         # current vals?
@@ -1863,8 +1847,6 @@ class SmurfUtilMixin(SmurfBase):
         ----
         band : int
             The band that is to be turned off.
-        **kwards : ???
-            ???
         """
         self.set_amplitude_scales(band, 0, **kwargs)
         self.set_feedback_enable_array(band, np.zeros(512, dtype=int), **kwargs)
@@ -2127,8 +2109,6 @@ class SmurfUtilMixin(SmurfBase):
             The band the channel is in.
         channel : int or None, optional, default none
             The channel number.
-        yml : str or None, optional, default None
-            ???
 
         Returns
         -------
@@ -2215,11 +2195,6 @@ class SmurfUtilMixin(SmurfBase):
         ----
         channelorderfile : str or None, optional, default None
             Path to a file that contains one channel per line.
-
-        Returns
-        -------
-        processed_channels : int array
-            ???
         """
         n_proc = self.get_number_processed_channels()
         n_chan = self.get_number_channels()
@@ -2274,17 +2249,6 @@ class SmurfUtilMixin(SmurfBase):
             Which band.
         as_offset : bool, optional, default True
             Whether to return as offset from band center.
-        hardcode : bool, optional, default False
-            ???
-        yml : str or None, optional, default None
-            ???
-
-        Returns
-        -------
-        subbands : ???
-            ???
-        subband_centers : ???
-            ???
         """
 
         if hardcode:
@@ -2345,18 +2309,6 @@ class SmurfUtilMixin(SmurfBase):
     def iq_to_phase(self, i, q):
         """
         Changes IQ to phase
-
-        Args
-        ----
-        i : float array
-            ???
-        q : float arry
-            ???
-
-        Returns
-        -------
-        phase : float array
-            ???
         """
         return np.unwrap(np.arctan2(q, i))
 
@@ -2420,8 +2372,6 @@ class SmurfUtilMixin(SmurfBase):
             Sets the enable bit. Only must be done once.
         flip_polarity : bool, optional, default False
             Sets the voltage to volt*-1.
-        **kwargs : ???
-           ???
         """
 
         # Make sure the requested bias group is in the list of defined
@@ -2471,8 +2421,6 @@ class SmurfUtilMixin(SmurfBase):
             bias group. Should be (n_bias_groups,).
         do_enable : bool, optional, default True
             Set the enable bit for both DACs for every TES bias group.
-        **kwargs : ???
-            ???
         """
 
         n_bias_groups = self._n_bias_groups
@@ -2534,8 +2482,6 @@ class SmurfUtilMixin(SmurfBase):
             file.
         return_raw : bool, optional, default False
             If True, returns pos and neg terminal values.
-        **kwargs : ???
-            ???
 
         Returns
         -------
@@ -2579,8 +2525,6 @@ class SmurfUtilMixin(SmurfBase):
         return_raw : bool, optional, default False
             If True, returns +/- terminal vals as separate arrays
             (pos, then negative)
-        **kwargs : ???
-            ???
         """
 
         bias_order = self.bias_group_to_pair[:,0]
@@ -2952,8 +2896,6 @@ class SmurfUtilMixin(SmurfBase):
         ----
         bias_group : int
             The bias group(s) to set to high current mode.
-        write_log : bool, optional, default False
-            ???
         """
         old_relay = self.get_cryo_card_relays()
         old_relay = self.get_cryo_card_relays()  # querey twice to ensure update
@@ -2986,8 +2928,6 @@ class SmurfUtilMixin(SmurfBase):
         ----
         bias_group : int
             The bias group to set to low current mode.
-        write_log : bool, optional, default False
-            ???
         """
         old_relay = self.get_cryo_card_relays()
         old_relay = self.get_cryo_card_relays()  # querey twice to ensure update
@@ -3225,8 +3165,6 @@ class SmurfUtilMixin(SmurfBase):
             The number of poles in the filter.
         cutoff_freq : float
             The filter cutoff frequency.
-        write_log : bool, optional, default False
-            ???
         """
         # Get flux ramp frequency
         flux_ramp_freq = self.get_flux_ramp_freq()*1.0E3
@@ -3405,12 +3343,6 @@ class SmurfUtilMixin(SmurfBase):
             level.
         plot_channels : int array or None, optional, default None
            The channels to plot.
-        grid_mode : bool, optional, default False
-            ???
-        gcp_wait : float, optional, default 0.5
-            ???
-        gcp_between : float, optional, default 1.0
-            ???
         dat_file : str or None, optional, default None
             Filename to read bias-bump data from; if provided, data is
             read from file instead of being measured live.
@@ -3842,8 +3774,6 @@ class SmurfUtilMixin(SmurfBase):
         drive : int
             The amplitude for the fixed tone (0-15 in recent fw
             revisions).
-        quiet : bool, optional, ddefault False
-            ???
         """
 
         # Find which band the requested frequency falls into.
@@ -4052,8 +3982,6 @@ class SmurfUtilMixin(SmurfBase):
             for TES bias).
         continuous : bool, optional, default True
             Whether to play the TES waveform continuously.
-        **kwargs : ???
-            ???
         """
         bias_order = self.bias_group_to_pair[:,0]
         dac_positives = self.bias_group_to_pair[:,1]
@@ -4098,8 +4026,6 @@ class SmurfUtilMixin(SmurfBase):
         ----
         bias_group : int
             The bias group.
-        **kwargs : ???
-            ???
         """
         # https://confluence.slac.stanford.edu/display/SMuRF/SMuRF+firmware#SMuRFfirmware-RTMDACarbitrarywaveforms
         # Target the two bipolar DACs assigned to this bias group:

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -195,10 +195,8 @@ class PcieCard():
     * All the RSSI connection lanes which point to the target IP
       address will be closed.
     * If PCIe communication type is used:
-      * Verify that the DeviceId are correct for the RSSI (ID = 0) and
-        the DATA (ID = 1) devices.
-      * The RSSI connection is open in the specific lane. Also, when
-        the the server is closed, the RSSI connection is closed.
+      * Verify that the DeviceId are correct for the RSSI (ID = 0) and the DATA (ID = 1) devices.
+      * The RSSI connection is open in the specific lane. Also, when the the server is closed, the RSSI connection is closed.
 
     If the PCIe card is not present:
 

--- a/python/pysmurf/core/devices/_SmurfProcessor.py
+++ b/python/pysmurf/core/devices/_SmurfProcessor.py
@@ -199,11 +199,15 @@ class SmurfProcessor(pyrogue.Device):
 
     Args
     ----
-    name        (str)            : Name of the device
-    description (str)            : Description of the device
-    root        (pyrogue.Root)   : The pyrogue root. The configuration status of
-                                   this root will go to the data file as metadata.
-    txDevice    (pyrogue.Device) : A packet transmitter device
+    name : str
+        Name of the device.
+    description : str
+        Description of the device.
+    root : pyrogue.Root or None, optional, default None
+        The pyrogue root. The configuration status of this root will
+        go to the data file as metadata.
+    txDevice : pyrogue.Device or None, optional, default None
+        A packet transmitter device.
     """
     def __init__(self, name, description, root=None, txDevice=None, **kwargs):
         pyrogue.Device.__init__(self, name=name, description=description, **kwargs)


### PR DESCRIPTION
## Issue

This PR is required to issue resolve https://github.com/slaclab/pysmurf/issues/395.

## Description

This PR fixes some minor RST errors throughout the pysmurf client and core docstrings.  After this PR is merged, we will pass the flake8 checks added by the flake8-rst-docstrings which validates the RST in all docstrings.

```
pip3 install flake8-rst-docstrings
flake8 --rst-roles class,func,ref --rst-directives envvar,exception
```

and we should add the flake8-rst-docstrings extension in the travis flake8 checks to maintain compliance.

## Does this PR break any interface?
- [ ] Yes
- [x] No