### PR TITLE
Determine which bays are on from hardware, not pysmurf cfg.

### DIFF
--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -79,15 +79,16 @@ class SmurfBase:
             self.log('Offline mode')
 
 
-        # Setting paths for easier commands - Is there a better way to do this
-        # than just hardcoding paths? This needs to be cleaned up somehow
+        # Setting paths for easier commands - Is there a better way to
+        # do this than just hardcoding paths? This needs to be cleaned
+        # up somehow
 
         self.epics_root = epics_root
 
         self.amcc = self.epics_root + ':AMCc:'
 
         self.smurf_application = self.amcc + 'SmurfApplication:'
-        
+
         self.smurf_processor = self.amcc + 'SmurfProcessor:'
         self.channel_mapper = self.smurf_processor + 'ChannelMapper:'
         self.frame_rx_stats = self.smurf_processor + 'FrameRxStats:'

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -85,6 +85,9 @@ class SmurfBase:
         self.epics_root = epics_root
 
         self.amcc = self.epics_root + ':AMCc:'
+
+        self.smurf_application = self.amcc + 'SmurfApplication:'
+        
         self.smurf_processor = self.amcc + 'SmurfProcessor:'
         self.channel_mapper = self.smurf_processor + 'ChannelMapper:'
         self.frame_rx_stats = self.smurf_processor + 'FrameRxStats:'

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -137,7 +137,6 @@ class SmurfControl(SmurfCommandMixin,
                 smurf_cmd_mode=smurf_cmd_mode, no_dir=no_dir,
                 **kwargs)
 
-
     def initialize(self, data_dir=None, name=None,
                    make_logfile=True, setup=False,
                    smurf_cmd_mode=False, no_dir=False, publish=False,
@@ -329,8 +328,8 @@ class SmurfControl(SmurfCommandMixin,
         for i, k in enumerate(bm_keys):
             self.bad_mask[i] = bm_config[k]
 
-        # Which MicrowaveMuxCore[#] blocks are being used?
-        self.bays = None
+        # Which bays were enabled on pysmurf server startup?
+        self.bays = self.which_bays()
 
         # Dictionary for frequency response
         self.freq_resp = {}
@@ -407,10 +406,6 @@ class SmurfControl(SmurfCommandMixin,
         smurf_init_config = self.config.get('init')
         bands = smurf_init_config['bands']
 
-        # determine which bays to configure from the
-        # bands requested and the band-to-bay
-        # correspondence
-        self.bays = np.unique([self.band_to_bay(band) for band in bands])
         # Right now, resetting both DACs in both MicrowaveMuxCore blocks,
         # but may want to determine at runtime which are actually needed and
         # only reset the DAC in those.

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -236,7 +236,7 @@ class SmurfControl(SmurfCommandMixin,
                 self.log.set_logfile(None)
 
         # Which bays were enabled on pysmurf server startup?
-        self.bays = self.which_bays()                
+        self.bays = self.which_bays()
 
         # Crate/carrier configuration details that won't change.
         self.crate_id=self.get_crate_id()
@@ -352,7 +352,7 @@ class SmurfControl(SmurfCommandMixin,
 
         # Compare usable bands to bands defined in pysmurf
         # configuration file.
-        
+
         # Check if an unusable band is defined in the pysmurf cfg
         # file.
         for band in bands:

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -181,85 +181,88 @@ class SmurfCommandMixin(SmurfBase):
     #### Start SmurfApplication gets/sets
     _smurf_version = 'SmurfVersion'
 
-    def get_smurf_version(self, as_str=True, **kwargs):
+    def get_pysmurf_version(self, **kwargs):
         r"""Returns the pysmurf version.
+
+        Alias for `pysmurf.__version__`.
 
         Args
         ----
-        as_str : bool, optional, default True
-            If True, return type is a str, otherwise return type is a
-            1D numpy.ndarray with `numpy.uint8` type UTF-8 byte array.
         \**kwargs
-            Arbitrary keyword arguments to pass on to the internal
-            :func:`_caget` call.
+            Arbitrary keyword arguments.  Passed to directly to the
+            `_caget` call.
 
         Returns
         -------
-        ret : str or numpy.ndarray
-            pysmurf version.  Return type is `str` if `as_str` is True
-            (the default behavior).  If `as_str` is False, return type
-            is a 1D numpy.ndarray with `numpy.uint8` type UTF-8 byte
-            array.
+        str
+            pysmurf version.
         """
-        ret = self._caget(self.smurf_application +
-                          self._smurf_version, **kwargs)
-        if as_str:
-            ret = tools.utf8_to_str(ret)
-        return ret
+        return self._caget(self.smurf_application +
+                           self._smurf_version, as_string=True,
+                           **kwargs)
 
     _smurf_directory = 'SmurfDirectory'
 
-    def get_smurf_directory(self, as_str=True, **kwargs):
-        """Returns path to the pysmurf python files.
+    def get_pysmurf_directory(self, **kwargs):
+        r"""Returns path to the pysmurf python files.
 
-        ???
+        Path to the files from which the pysmurf module was loaded.
+        Alias for `pysmurf__file__`.
+
+        Args
+        ----
+        \**kwargs
+            Arbitrary keyword arguments.  Passed to directly to the
+            `_caget` call.
 
         Returns
         -------
-        ret : str
-            ???
+        str
+            Path to pysmurf files.
         """
-        ret = self._caget(self.smurf_application +
-                          self._smurf_directory, **kwargs)
-        if as_str:
-            ret = tools.utf8_to_str(ret)
-        return ret
+        return self._caget(self.smurf_application +
+                           self._smurf_directory, as_string=True,
+                           **kwargs)
     
     _smurf_startup_script = 'StartupScript'
 
-    def get_smurf_startup_script(self, as_str=True, **kwargs):
-        """Returns path to the pysmurf server startup script.
+    def get_smurf_startup_script(self, **kwargs):
+        r"""Returns path to the pysmurf server startup script.
 
-        ???
+        Args
+        ----
+        \**kwargs
+            Arbitrary keyword arguments.  Passed to directly to the
+            `_caget` call.
 
         Returns
         -------
-        ret : str
-            ???
+        str
+            Path to pysmurf server startup script.
         """
-        ret = self._caget(self.smurf_application +
-                          self._smurf_startup_script, **kwargs)
-        if as_str:
-            ret = tools.utf8_to_str(ret)
-        return ret
-    
+        return self._caget(self.smurf_application +
+                           self._smurf_startup_script, as_string=True,
+                           **kwargs)
+
     _smurf_startup_arguments = 'StartupArguments'
 
-    def get_smurf_startup_args(self, as_str=True, **kwargs):
-        """Returns pysmurf server startup arguments.
+    def get_smurf_startup_args(self, **kwargs):
+        r"""Returns pysmurf server startup arguments.
 
-        ???
+        Args
+        ----
+        \**kwargs
+            Arbitrary keyword arguments.  Passed to directly to the
+            `_caget` call.
 
         Returns
         -------
-        ret : str
-            ???
+        str
+            pysmurf server startup arguments.
         """
-        ret = self._caget(self.smurf_application +
-                          self._smurf_startup_arguments, **kwargs)
-        if as_str:
-            ret = tools.utf8_to_str(ret)
-        return ret
+        return self._caget(self.smurf_application +
+                           self._smurf_startup_arguments,
+                           as_string=True, **kwargs)
     
     #### End SmurfApplication gets/sets
     

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -223,7 +223,7 @@ class SmurfCommandMixin(SmurfBase):
         return self._caget(self.smurf_application +
                            self._smurf_directory, as_string=True,
                            **kwargs)
-    
+
     _smurf_startup_script = 'StartupScript'
 
     def get_smurf_startup_script(self, **kwargs):
@@ -263,9 +263,9 @@ class SmurfCommandMixin(SmurfBase):
         return self._caget(self.smurf_application +
                            self._smurf_startup_arguments,
                            as_string=True, **kwargs)
-    
+
     #### End SmurfApplication gets/sets
-    
+
     _rogue_version = 'RogueVersion'
 
     def get_rogue_version(self, **kwargs):

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -183,7 +183,7 @@ class SmurfCommandMixin(SmurfBase):
         \**kwargs
             Arbitrary keyword arguments to pass on to the internal
             :func:`_caget` call.
-        
+
         Returns
         -------
         ret : str or numpy.ndarray
@@ -204,7 +204,7 @@ class SmurfCommandMixin(SmurfBase):
         """Returns path to the pysmurf python files.
 
         ???
-        
+
         Returns
         -------
         ret : str
@@ -222,7 +222,7 @@ class SmurfCommandMixin(SmurfBase):
         """Returns path to the pysmurf server startup script.
 
         ???
-        
+
         Returns
         -------
         ret : str
@@ -240,7 +240,7 @@ class SmurfCommandMixin(SmurfBase):
         """Returns pysmurf server startup arguments.
 
         ???
-        
+
         Returns
         -------
         ret : str

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -173,14 +173,24 @@ class SmurfCommandMixin(SmurfBase):
     _smurf_version = 'SmurfVersion'
 
     def get_smurf_version(self, as_str=True, **kwargs):
-        """???
+        r"""Returns the pysmurf version.
 
-        ???
+        Args
+        ----
+        as_str : bool, optional, default True
+            If True, return type is a str, otherwise return type is a
+            1D numpy.ndarray with `numpy.uint8` type UTF-8 byte array.
+        \**kwargs
+            Arbitrary keyword arguments to pass on to the internal
+            :func:`_caget` call.
         
         Returns
         -------
-        ret : str
-            ???
+        ret : str or numpy.ndarray
+            pysmurf version.  Return type is `str` if `as_str` is True
+            (the default behavior).  If `as_str` is False, return type
+            is a 1D numpy.ndarray with `numpy.uint8` type UTF-8 byte
+            array.
         """
         ret = self._caget(self.smurf_application +
                           self._smurf_version, **kwargs)
@@ -191,7 +201,7 @@ class SmurfCommandMixin(SmurfBase):
     _smurf_directory = 'SmurfDirectory'
 
     def get_smurf_directory(self, as_str=True, **kwargs):
-        """???
+        """Returns path to the pysmurf python files.
 
         ???
         
@@ -209,7 +219,7 @@ class SmurfCommandMixin(SmurfBase):
     _smurf_startup_script = 'StartupScript'
 
     def get_smurf_startup_script(self, as_str=True, **kwargs):
-        """???
+        """Returns path to the pysmurf server startup script.
 
         ???
         
@@ -227,7 +237,7 @@ class SmurfCommandMixin(SmurfBase):
     _smurf_startup_arguments = 'StartupArguments'
 
     def get_smurf_startup_args(self, as_str=True, **kwargs):
-        """???
+        """Returns pysmurf server startup arguments.
 
         ???
         

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -169,6 +169,81 @@ class SmurfCommandMixin(SmurfBase):
         return ret
 
 
+    #### Start SmurfApplication gets/sets
+    _smurf_version = 'SmurfVersion'
+
+    def get_smurf_version(self, as_str=True, **kwargs):
+        """???
+
+        ???
+        
+        Returns
+        -------
+        ret : str
+            ???
+        """
+        ret = self._caget(self.smurf_application +
+                          self._smurf_version, **kwargs)
+        if as_str:
+            ret = tools.utf8_to_str(ret)
+        return ret
+
+    _smurf_directory = 'SmurfDirectory'
+
+    def get_smurf_directory(self, as_str=True, **kwargs):
+        """???
+
+        ???
+        
+        Returns
+        -------
+        ret : str
+            ???
+        """
+        ret = self._caget(self.smurf_application +
+                          self._smurf_directory, **kwargs)
+        if as_str:
+            ret = tools.utf8_to_str(ret)
+        return ret
+    
+    _smurf_startup_script = 'StartupScript'
+
+    def get_smurf_startup_script(self, as_str=True, **kwargs):
+        """???
+
+        ???
+        
+        Returns
+        -------
+        ret : str
+            ???
+        """
+        ret = self._caget(self.smurf_application +
+                          self._smurf_startup_script, **kwargs)
+        if as_str:
+            ret = tools.utf8_to_str(ret)
+        return ret
+    
+    _smurf_startup_arguments = 'StartupArguments'
+
+    def get_smurf_startup_args(self, as_str=True, **kwargs):
+        """???
+
+        ???
+        
+        Returns
+        -------
+        ret : str
+            ???
+        """
+        ret = self._caget(self.smurf_application +
+                          self._smurf_startup_arguments, **kwargs)
+        if as_str:
+            ret = tools.utf8_to_str(ret)
+        return ret
+    
+    #### End SmurfApplication gets/sets
+    
     _rogue_version = 'RogueVersion'
 
     def get_rogue_version(self, as_str=True, **kwargs):

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2075,9 +2075,47 @@ class SmurfUtilMixin(SmurfBase):
 
         return ret
 
-    def which_bands(self):
+    def which_bays(self):
+        r"""Which carrier AMC bays are enabled.
+
+        Returns which AMC bays were enabled on pysmurf server startup.
+        Each SMuRF carrier has two AMC bays, indexed bay 0 and bay 1.
+        If looking an installed carrier from the front of a crate, bay
+        0 is on the right and bay 1 is on the left.
+
+        A bay is enabled if the `--disable-bay#` argument is not
+        provided as a startup argument to the pysmurf server on
+        startup, where # the bay number, either 0 or 1.  The pysmurf
+        server startup arguments are returned by the
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.smurf_command.get_smurf_startup_args`
+        routine.
+
+        Returns
+        -------
+        bays : list of int
+            Which bays were enabled on pysmurf server startup.  Will
+            be either [0] (bay 0), [1] (bay 1), or [0,1] (both bays 0
+            and 1).
         """
-        Encodes which bands the fw being used was built for.
+        # What arguments were passed to the pysmurf server on startup?
+        smurf_startup_args=self.get_smurf_startup_args()
+        
+        # Bays are enabled unless --disable-bay{bay} is provided to
+        # the pysmurf server on startup.
+        bays=[]
+        for bay in [0,1]:
+            if f'--disable-bay{bay}' not in smurf_startup_args:
+                bays.append(bay)
+        
+        return bays
+    
+    def which_bands(self):
+        """Which bands the carrier firmware was built for.
+
+        Returns
+        -------
+        bands : list of int
+            Which bands the carrier firmware was built for.
         """
         build_dsp_g=self.get_build_dsp_g()
         bands=[b for b,x in enumerate(bin(build_dsp_g)[2:]) if x=='1']

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2094,22 +2094,20 @@ class SmurfUtilMixin(SmurfBase):
         Returns
         -------
         bays : list of int
-            Which bays were enabled on pysmurf server startup.  Will
-            be either [0] (bay 0), [1] (bay 1), or [0,1] (both bays 0
-            and 1).
+            Which bays were enabled on pysmurf server startup.
         """
         # What arguments were passed to the pysmurf server on startup?
         smurf_startup_args=self.get_smurf_startup_args()
-        
+
         # Bays are enabled unless --disable-bay{bay} is provided to
         # the pysmurf server on startup.
         bays=[]
         for bay in [0,1]:
             if f'--disable-bay{bay}' not in smurf_startup_args:
                 bays.append(bay)
-        
+
         return bays
-    
+
     def which_bands(self):
         """Which bands the carrier firmware was built for.
 

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2079,15 +2079,16 @@ class SmurfUtilMixin(SmurfBase):
         r"""Which carrier AMC bays are enabled.
 
         Returns which AMC bays were enabled on pysmurf server startup.
-        Each SMuRF carrier has two AMC bays, indexed bay 0 and bay 1.
-        If looking an installed carrier from the front of a crate, bay
-        0 is on the right and bay 1 is on the left.
+        Each SMuRF carrier has two AMC bays, indexed by an integer,
+        either 0 or 1.  If looking at an installed carrier from the
+        front of a crate, bay 0 is on the right and bay 1 is on the
+        left.
 
         A bay is enabled if the `--disable-bay#` argument is not
-        provided as a startup argument to the pysmurf server on
-        startup, where # the bay number, either 0 or 1.  The pysmurf
-        server startup arguments are returned by the
-        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.smurf_command.get_smurf_startup_args`
+        provided as a startup argument to the pysmurf server where #
+        is the bay number, either 0 or 1.  The pysmurf server startup
+        arguments are returned by the
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_smurf_startup_args`
         routine.
 
         Returns


### PR DESCRIPTION
## Issue
Resolves issue https://github.com/slaclab/pysmurf/issues/398.

## Description

pysmurf has been guessing at which AMC bays are usable by which bands are present in the pysmurf cfg file.  This PR adds a `which_bays` routine to utils which parses the pysmurf server startup arguments to determine which bays were disabled on startup.

- Adds `get_pysmurf_version`, `get_pysmurf_directory`, `get_smurf_startup_script`, and `get_smurf_startup_args` routines to `smurf_command` module for querying SmurfApplication registers.
- Adds a `which_bays` routine to `smurf_utils` module which determines which AMC bays were enabled on pysmurf server startup by parsing the pysmurf server startup options (using the new `get_smurf_startup_script` routine) for the presence of the `--disable-bay0` and `--disable-bay1` options.
- Adds warnings to `smurf_control.initialize` if either the user has bands defined in their pysmurf cfg file that aren't usable (ie belong to an AMC bay that isn't enabled) or if they are missing the definition of a band that is usable.

## Does this PR break any interface?
- [ ] Yes
- [x] No