### PR TITLE
Comprehensive docstrings for SmurfConfig class.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -38,6 +38,7 @@ rst-roles =
     class,
     func,
     ref,
+    meth,
 rst-directives =
     envvar,
     exception,

--- a/.flake8
+++ b/.flake8
@@ -42,3 +42,7 @@ rst-roles =
 rst-directives =
     envvar,
     exception,
+# enforces fstrings only
+extend-ignore =
+    # Ignore f-strings, we like them:
+    SFS301,

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = __init__.py, rogue_plugin.py
+exclude = __init__.py, rogue_plugin.py, _version.py
 #############################################################
 # Note: Command to remove white space at the end of lines
 # $ find . -type f -name "*.py" -print0 | xargs -0 sed -i 's/\s*$//g'
@@ -39,6 +39,7 @@ rst-roles =
     func,
     ref,
     meth,
+    attr,
 rst-directives =
     envvar,
     exception,

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
     - stage: checks
       name: "Flake8 Checks"
       install:
-        - pip3 install flake8-rst-docstrings
+        - pip3 install flake8-rst-docstrings flake8-sfs
       script:
         # Run Flake8
         - flake8 --count python/

--- a/python/pysmurf/client/base/logger.py
+++ b/python/pysmurf/client/base/logger.py
@@ -14,7 +14,8 @@ import sys
 __all__ = ['Logger', 'SmurfLogger']
 
 class Logger(object):
-    """Basic prioritized logger, by M. Hasselfield"""
+    """Basic prioritized logger, by M. Hasselfield."""
+    
     def __init__(self, verbosity=0, indent=True, logfile=None):
         self.v = verbosity
         self.indent = indent

--- a/python/pysmurf/client/base/logger.py
+++ b/python/pysmurf/client/base/logger.py
@@ -15,7 +15,7 @@ __all__ = ['Logger', 'SmurfLogger']
 
 class Logger(object):
     """Basic prioritized logger, by M. Hasselfield."""
-    
+
     def __init__(self, verbosity=0, indent=True, logfile=None):
         self.v = verbosity
         self.indent = indent

--- a/python/pysmurf/client/base/logger.py
+++ b/python/pysmurf/client/base/logger.py
@@ -89,7 +89,7 @@ class SmurfLogger(Logger):
             return 0
         v = self.levels.get(v, v)
         if not isinstance(v, int):
-            raise ValueError('Unrecognized logging level {}'.format(v))
+            raise ValueError(f'Unrecognized logging level {v}')
         return v
 
     def format(self, s, level=0):
@@ -97,12 +97,12 @@ class SmurfLogger(Logger):
         Format the input for writing to the logfile.
         """
         if self.prefix:
-            s = '{}{}'.format(self.prefix, s)
+            s = f'{self.prefix}{s}'
         else:
-            s = '{}'.format(s)
+            s = f'{s}'
         if self.timestamp:
             stamp = dt.datetime.now().strftime('%Y-%m-%d %H:%M:%S%Z')
-            s = '[ {} ]  {}'.format(stamp, s)
+            s = f'[ {stamp} ]  {s}'
         return super(SmurfLogger, self).format(s, self.get_level(level))
 
     # root argument added as hack so that MPI/non-MPI code can get along

--- a/python/pysmurf/client/base/schema.py
+++ b/python/pysmurf/client/base/schema.py
@@ -3,6 +3,7 @@ obtained from config-files, forms, external services or command-line
 parsing, converted from JSON/YAML (or something else) to Python data-types."""
 
 # pylint: skip-file
+# flake8: noqa
 
 import re
 

--- a/python/pysmurf/client/base/schema.py
+++ b/python/pysmurf/client/base/schema.py
@@ -2,6 +2,8 @@
 obtained from config-files, forms, external services or command-line
 parsing, converted from JSON/YAML (or something else) to Python data-types."""
 
+# pylint: skip-file
+
 import re
 
 try:

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -22,7 +22,7 @@ import re
 import numpy as np
 
 class SmurfConfig:
-    """Initialize, read, or dump a pysmurf config file.
+    """Read, manipulate or write a pysmurf config file.
 
     Class for loading pysmurf configuration files.  In addition to
     functions for reading and writing pysmurf configuration files,
@@ -51,25 +51,25 @@ class SmurfConfig:
     Args
     ----
     filename : str or None, optional, default None
-       Path to pysmurf configuration file to load.
+        Path to pysmurf configuration file to load.
     validate : bool, optional, default True
-       Whether or not to run `schema` validation on the pysmurf
-       configuration file data.  If `schema` validation fails, a
-       `SchemaError` exception will be raised.
+        Whether or not to run `schema` validation on the pysmurf
+        configuration file data.  If `schema` validation fails, a
+        `SchemaError` exception will be raised.
 
     Attributes
     ----------
     filename : str or None
-       Path to loaded pysmurf configuration file.  `None` if no pysmurf
-       configuration file has been loaded.
+        Path to loaded pysmurf configuration file.  `None` if no pysmurf
+        configuration file has been loaded.
     config : dict or None
-       Dictionary of pysmurf configuration data.  `None` if no pysmurf
-       configuration file has been loaded.
+        Dictionary of pysmurf configuration data.  `None` if no pysmurf
+        configuration file has been loaded.
 
     See Also
     --------
     :meth:`validate_config`
-       Run schema validation on loaded configuration dictionary.
+        Run `schema` validation on loaded configuration dictionary.
 
     References
     ----------
@@ -85,7 +85,8 @@ class SmurfConfig:
         if self.filename is not None:
             self.read(update=True, validate=validate)
 
-    def read_json(self, filename, comment_char='#'):
+    @staticmethod
+    def read_json(filename, comment_char='#'):
         """Read a pysmurf configuration file.
 
         Opens configuration file at the path provided by the
@@ -97,26 +98,26 @@ class SmurfConfig:
         Args
         ----
         filename : str
-           Path to pysmurf configuration file to load.
+            Path to pysmurf configuration file to load.
         comment_char : str, optional, default '#'
-           Comments that start with this character will be ignored.
+            Comments that start with this character will be ignored.
 
         Returns
         -------
         loaded_config : dict
-           Dictionary of loaded pysmurf configuration parameters.
+            Dictionary of loaded pysmurf configuration parameters.
 
         Raises
         ------
         FileNotFoundError
-           Raised if the configuration file does not exist.
+            Raised if the configuration file does not exist.
         JSONDecodeError
-           Raised if the loaded configuration file data is not in JSON
-           format.
+            Raised if the loaded configuration file data is not in JSON
+            format.
         """
         no_comments = []
         try:
-            with open(self.filename) as config_file:
+            with open(filename) as config_file:
                 for _, line in enumerate(config_file):
 
                     if line.lstrip().startswith(comment_char):
@@ -141,16 +142,32 @@ class SmurfConfig:
         return loaded_config
 
     def read(self, update=False, validate=True):
-        """Read config file and update the configuration.
+        """Read config file and update the config dictionary.
+
+        Reads raw configuration parameters from configuration file at
+        the path specified by the `filename` class instance attribute
+        using the :meth:`read_json` method.
+
+        If the `validate` argument is `True` (which is the default
+        behavior), the loaded configuration parameter dictionary, the
+        loaded configuration parameters are validated using the
+        :meth:`validate_config` routine.  If successful and the `update`
 
         Args
         ----
         update : bool, optional, default False
-           Whether or not to update the configuration.
+            Whether or not to update the configuration.
         validate : bool, optional, default True
-           Whether or not to run `schema` validation on the pysmurf
-           configuration file data.  If `schema` validation fails, a
-           `SchemaError` exception will be raised.
+            Whether or not to run `schema` validation on the pysmurf
+            configuration file data.  If `schema` validation fails, a
+            `SchemaError` exception will be raised.
+
+        See Also
+        --------
+        :meth:`read_json`
+            Reads raw configuration file into a dictionary.
+        :meth:`validate_config`
+            Run `schema` validation on loaded configuration dictionary.
         """
         loaded_config = self.read_json(self.filename)
 
@@ -171,9 +188,9 @@ class SmurfConfig:
         Args
         ----
         key : any
-           Key to update in the config dictionary.
+            Key to update in the config dictionary.
         val : any
-           Value to assign to the given key
+            Value to assign to the given key
         """
         self.config[key] = val
 
@@ -183,7 +200,7 @@ class SmurfConfig:
         Args
         ----
         outputfile : str
-           The name of the file to save the configuration to.
+            The name of the file to save the configuration to.
         """
         ## dump current config to outputfile ##
         with io.open(outputfile, 'w', encoding='utf8') as out_file:
@@ -196,13 +213,13 @@ class SmurfConfig:
         Args
         ----
         key : any
-           Key to check for in configuration dictionary.
+            Key to check for in configuration dictionary.
 
         Returns
         -------
         bool
-           Returns True if key is in the configuration dictionary,
-           False if it is not.
+            Returns True if key is in the configuration dictionary,
+            False if it is not.
         """
         if key in self.config:
             return True
@@ -214,14 +231,14 @@ class SmurfConfig:
         Args
         ----
         key : any
-           Key whose configuration entry to retrieve.
+            Key whose configuration entry to retrieve.
 
         Returns
         -------
         any or None
-           Returns value for requested key from configuration
-           dictionary.  Returns `None` if key is not present in the
-           config dictionary.
+            Returns value for requested key from configuration
+            dictionary.  Returns `None` if key is not present in the
+            config dictionary.
         """
         if self.has(key):
             return self.config[key]
@@ -233,16 +250,16 @@ class SmurfConfig:
         Args
         ----
         key : any
-           Key in config dictionary.
+            Key in config dictionary.
         subkey : any
-           Subkey in config dictionary.
+            Subkey in config dictionary.
 
         Returns
         -------
         any or None
-           Returns value for requested subkey from configuration
-           dictionary.  Returns `None` if either key or subkey are not
-           present in the config dictionary.
+            Returns value for requested subkey from configuration
+            dictionary.  Returns `None` if either key or subkey are not
+            present in the config dictionary.
         """
         if self.has(key):
             sub_dict = self.config[key]
@@ -261,11 +278,11 @@ class SmurfConfig:
         Args
         ----
         key : any
-           Key in config dictionary.
+            Key in config dictionary.
         subkey : any
-           Subkey in config dictionary
+            Subkey in config dictionary
         val : any
-           Value to write.
+            Value to write.
         """
         try:
             self.config[key][subkey] = val
@@ -306,20 +323,20 @@ class SmurfConfig:
         Args
         ----
         loaded_config : dict
-           Dictionary of pysmurf configuration parameters to run
-           `schema` validation on.
+            Dictionary of pysmurf configuration parameters to run
+            `schema` validation on.
 
         Returns
         -------
         validated_config : dict
-           Dictionary of validated configuration parameters.
-           Parameter values are conditioned by `schema` to conform to
-           the specified types.
+            Dictionary of validated configuration parameters.
+            Parameter values are conditioned by `schema` to conform to
+            the specified types.
 
         Raises
         ------
         SchemaError
-           Raised if the configuration data fails `schema` validation.
+            Raised if the configuration data fails `schema` validation.
 
         """
         # Import useful schema objects

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -22,22 +22,23 @@ import re
 import numpy as np
 
 class SmurfConfig:
-    """Initialize, read, or dump a SMuRF config file.
+    """Initialize, read, or dump a pysmurf config file.
 
     Class for loading pysmurf configuration files.  In addition to
     functions for reading and writing pysmurf configuration files,
-    contains helper functions for manipulating configuration
-    variables, which are stored internally in a class instance
-    attribute `config` dictionary.
+    contains helper functions for manipulating configuration variables
+    which are stored internally in a class instance attribute `config`
+    dictionary.
 
-    pysmurf configuration files must be in the JSON format [1]_.  On
+    pysmurf configuration files must be in the JSON format [1]_ .  On
     instantiation, attempts to read the pysmurf configuration file at
-    the path provided by the `filename` argument into a the `config`
-    class instance attribute as a dictionary.  If the `filename`
-    argument is not provided, the `config` attribute is None.
+    the path provided by the `filename` argument into the `config`
+    dictionary class instance attribute.  If the `filename` argument
+    is not provided, no configuration file is loaded and the `config`
+    attribute is `None`.
 
     If a pysmurf configuration file is successfully loaded and the
-    `validate_config` constructor argument is True (which is the
+    :func:`validate_config` constructor argument is True (which is the
     default behavior), the parameters in the configuration file will
     be validated using the 3rd party `schema` python library [2]_
     using the rules specified in the :func:`validate_config` member
@@ -50,10 +51,12 @@ class SmurfConfig:
     - Checks that all mandatory configuration variables are defined.
     - Conditions all configuration variables into the correct type
       (e.g. `float`, `int`, `str`, etc.).
-    - Automatically fill in the values for missing optional
-      parameters.
-    - Checks if parameters have valid values (e.g., some parameters can
-      only be zero or 1, or must be in a predefined interval, etc.).
+    - Automatically fills in the values for missing optional
+      parameters.  Optional parameters are typically parameters which
+      almost never change from SMuRF system to SMuRF system.
+    - Checks if parameters have valid values (e.g., some parameters
+      can only be either 0 or 1, or must be in a predefined interval,
+      etc.).
     - Performs validation of some known higher level configuration
       data interdependencies (e.g. prevents the user from defining an
       RTM DAC as both a TES bias and an RF amplifier bias).
@@ -69,7 +72,7 @@ class SmurfConfig:
     Args
     ----
     filename : str or None, optional, default None
-       Path to pysmurf configuration file.
+       Path to pysmurf configuration file to load.
     validate_config : bool, optional, default True
        Whether or not to run `schema` validation on the pysmurf
        configuration file data.  If `schema` validation fails, a
@@ -78,10 +81,10 @@ class SmurfConfig:
     Attributes
     ----------
     filename : str or None
-       Path to loaded pysmurf configuration file.  None if no pysmurf
+       Path to loaded pysmurf configuration file.  `None` if no pysmurf
        configuration file has been loaded.
     config : dict or None
-       Dictionary of pysmurf configuration data.  None if no pysmurf
+       Dictionary of pysmurf configuration data.  `None` if no pysmurf
        configuration file has been loaded.
 
     See Also

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -197,39 +197,52 @@ class SmurfConfig:
         ----
         key : any
            Key to check for in configuration dictionary.
+
+        Returns
+        -------
+        bool
+           Returns True if key is in the configuration dictionary,
+           False if it is not.
         """
         if key in self.config:
             return True
-
         return False
 
     def get(self, key):
         """Return entry in config dictionary for requested key.
 
-        Returns `None` if the key not present in config dictionary.
-
         Args
         ----
         key : any
            Key whose configuration entry to retrieve.
+
+        Returns
+        -------
+        any or None
+           Returns value for requested key from configuration
+           dictionary.  Returns `None` if key is not present in the
+           config dictionary.
         """
         if self.has(key):
             return self.config[key]
-
         return None
 
     def get_subkey(self, key, subkey):
         """Get config dictionary subkey value.
-
-        Get the subkey value. A dumb thing that just formats strings for you.
-        Will return None if it can't find stuff
 
         Args
         ----
         key : any
            Key in config dictionary.
         subkey : any
-           config dictionary subkey.
+           Subkey in config dictionary.
+
+        Returns
+        -------
+        any or None
+           Returns value for requested subkey from configuration
+           dictionary.  Returns `None` if either key or subkey are not
+           present in the config dictionary.
         """
         if self.has(key):
             sub_dict = self.config[key]
@@ -243,14 +256,16 @@ class SmurfConfig:
             return None
 
     def update_subkey(self, key, subkey, val):
-        """
-        More dumb wrappers for nested dictionaries.
+        """Set config dictionary subkey value.
 
         Args
         ----
-          key (any): key in config
-          subkey (any): config subkey
-          val (any): value to write
+        key : any
+           Key in config dictionary.
+        subkey : any
+           Subkey in config dictionary
+        val : any
+           Value to write.
         """
         try:
             self.config[key][subkey] = val
@@ -601,9 +616,10 @@ class SmurfConfig:
         # RF lab at SLAC where they've been testing with an ASIS
         # crate.  Shawn has yet to have this work for him.  Newer fw
         # versions will have OT protection enabled in the fw.
-        schema_dict[Optional('ultrascale_temperature_limit_degC',
-                             default=None)] = \
-                    And(Use(float), lambda f: 0 <= f <= 99)
+        schema_dict[
+            Optional('ultrascale_temperature_limit_degC',
+                     default=None)] = And(Use(float),
+                                          lambda f: 0 <= f <= 99)
         #### Done specifying thermal schema
 
         #### Start specifying timing-related schema
@@ -697,18 +713,29 @@ class SmurfConfig:
         #### Done specifying smurf2mce
 
         #### Start specifying directories
-        schema_dict[Optional("default_data_dir",
-                             default="/data/smurf_data")] = \
-                    And(str, os.path.isdir, user_has_write_access)
-        schema_dict[Optional("smurf_cmd_dir",
-                             default="/data/smurf_data/smurf_cmd")] = \
-                    And(str, os.path.isdir, user_has_write_access)
-        schema_dict[Optional("tune_dir",
-                             default="/data/smurf_data/tune")] = \
-                    And(str, os.path.isdir, user_has_write_access)
-        schema_dict[Optional("status_dir",
-                             default="/data/smurf_data/status")] = \
-                    And(str, os.path.isdir, user_has_write_access)
+        schema_dict[
+            Optional(
+                "default_data_dir",
+                default="/data/smurf_data")] = And(str,
+                                                   os.path.isdir,
+                                                   user_has_write_access)
+        schema_dict[
+            Optional(
+                "smurf_cmd_dir",
+                default="/data/smurf_data/smurf_cmd")] = And(str,
+                                                             os.path.isdir,
+                                                             user_has_write_access)
+        schema_dict[
+            Optional("tune_dir",
+                     default="/data/smurf_data/tune")] = And(str,
+                                                             os.path.isdir,
+                                                             user_has_write_access)
+        schema_dict[
+            Optional(
+                "status_dir",
+                default="/data/smurf_data/status")] = And(str,
+                                                          os.path.isdir,
+                                                          user_has_write_access)
         #### Done specifying directories
 
         ##### Done building validation schema
@@ -727,10 +754,10 @@ class SmurfConfig:
         bias_group_to_pair = validated_config['bias_group_to_pair']
         tes_bias_group_dacs = np.ndarray.flatten(
             np.array([bg2p[1] for bg2p in bias_group_to_pair.items()]))
-        assert (len(np.unique(tes_bias_group_dacs)) == \
-                len(tes_bias_group_dacs)), \
-        'Configuration failed - DACs may not be assigned to ' + \
-            'multiple TES bias groups.'
+        assert (len(np.unique(tes_bias_group_dacs)) ==
+                len(tes_bias_group_dacs)), (
+                    'Configuration failed - DACs may not be ' +
+                    'assigned to multiple TES bias groups.')
 
         # Check that the DAC specified as the 50K gate driver
         # isn't also defined as one of the DACs in a TES bias group

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -38,7 +38,7 @@ class SmurfConfig:
     attribute is `None`.
 
     If a pysmurf configuration file is successfully loaded and the
-    `validate_config` constructor argument is True (which is the
+    `validate` constructor argument is True (which is the
     default behavior), the parameters in the configuration file will
     be validated using the 3rd party `schema` python library [#schema]_
     using the rules specified in the
@@ -67,14 +67,14 @@ class SmurfConfig:
     the cause of the `SchemaError` exception before the configuration
     file can be loaded and used.
 
-    If `validate_config` is False, the pysmurf configuration data will
+    If `validate` is False, the pysmurf configuration data will
     be loaded without `schema` validation.
 
     Args
     ----
     filename : str or None, optional, default None
        Path to pysmurf configuration file to load.
-    validate_config : bool, optional, default True
+    validate : bool, optional, default True
        Whether or not to run `schema` validation on the pysmurf
        configuration file data.  If `schema` validation fails, a
        `SchemaError` exception will be raised.
@@ -90,8 +90,8 @@ class SmurfConfig:
 
     See Also
     --------
-    :meth:`validate_config` : Run schema validation on loaded configuration dictionary.
-    :meth:`read_json`
+    :meth:`validate_config`
+       Run schema validation on loaded configuration dictionary.
 
     References
     ----------
@@ -100,15 +100,15 @@ class SmurfConfig:
 
     """
 
-    def __init__(self, filename=None, validate_config=True):
+    def __init__(self, filename=None, validate=True):
         """SmurfConfig constructor."""
         self.filename = filename
         self.config = None
         if self.filename is not None:
-            self.read(update=True, validate_config=validate_config)
+            self.read(update=True, validate=validate)
 
     def read_json(self, filename, comment_char='#'):
-        """Reads a pysmurf configuration file.
+        """Read a pysmurf configuration file.
 
         Opens configuration file at the path provided by the
         `filename` argument, strips off all lines that start with the
@@ -122,7 +122,7 @@ class SmurfConfig:
            Path to pysmurf configuration file to load.
         comment_char : str, optional, default '#'
            Comments that start with this character will be ignored.
-           
+
         Returns
         -------
         loaded_config : dict
@@ -134,7 +134,7 @@ class SmurfConfig:
            Raised if the configuration file does not exist.
         JSONDecodeError
            Raised if the loaded configuration file data is not in JSON
-           format [#json]_.
+           format.
         """
         no_comments = []
         try:
@@ -151,22 +151,22 @@ class SmurfConfig:
                     else:
                         # will pass on to json parser
                         no_comments.append(line)
-        except FileNotFoundError as error:
+        except FileNotFoundError:
             print('No configuration file found at' +
                   f' filename={filename}')
             raise
-            
+
         loaded_config = json.loads('\n'.join(no_comments))
         return loaded_config
 
-    def read(self, update=False, validate_config=True):
-        """Reads config file and updates the configuration.
+    def read(self, update=False, validate=True):
+        """Read config file and update the configuration.
 
         Args
         ----
         update : bool, optional, default False
            Whether or not to update the configuration.
-        validate_config : bool, optional, default True
+        validate : bool, optional, default True
            Whether or not to run `schema` validation on the pysmurf
            configuration file data.  If `schema` validation fails, a
            `SchemaError` exception will be raised.
@@ -174,7 +174,7 @@ class SmurfConfig:
         loaded_config = self.read_json(self.filename)
 
         # validate
-        if validate_config:
+        if validate:
             validated_config = self.validate_config(loaded_config)
 
             if update:
@@ -185,12 +185,14 @@ class SmurfConfig:
             self.config = loaded_config
 
     def update(self, key, val):
-        """Updates a single key in the config
+        """Update a single key in the config dictionary.
 
-           Args
-           ----
-              key (any): key to update in the config dictionary
-              val (any): value to assign to the given key
+        Args
+        ----
+        key : any
+           Key to update in the config dictionary.
+        val : any
+           Value to assign to the given key
         """
         self.config[key] = val
 
@@ -220,12 +222,14 @@ class SmurfConfig:
         return False
 
     def get(self, key):
-        """Returns configuration entry for requested key.  Returns
-           None if key not present in configuration.
+        """Return entry in config dictionary for requested key.
+        
+        Returns `None` if the key not present in config dictionary.
 
-           Args
-           ----
-              key (any): key whose configuration entry to retrieve.
+        Args
+        ----
+        key : any
+           Key whose configuration entry to retrieve.
         """
 
         if self.has(key):
@@ -234,14 +238,17 @@ class SmurfConfig:
         return None
 
     def get_subkey(self, key, subkey):
-        """
+        """Get config dictionary subkey value.
+
         Get the subkey value. A dumb thing that just formats strings for you.
         Will return None if it can't find stuff
 
         Args
         ----
-          key (any): key in config
-          subkey (any): config subkey
+        key : any
+           Key in config dictionary.
+        subkey : any
+           config dictionary subkey.
         """
 
         if self.has(key):

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -35,7 +35,7 @@ class SmurfConfig:
     def read_json(self, filename, comment_char='#'):
         """Reads a json config file
         """
-        no_comments=[]
+        no_comments = []
         with open(self.filename) as config_file:
             for idx, line in enumerate(config_file):
                 if line.lstrip().startswith(comment_char):
@@ -44,7 +44,7 @@ class SmurfConfig:
                 elif comment_char in line:
                     # there's a comment character on this line.
                     # ignore it and everything that follows
-                    line=line.split('#')[0]
+                    line = line.split('#')[0]
                     no_comments.append(line)
                 else:
                     # will pass on to json parser
@@ -60,7 +60,7 @@ class SmurfConfig:
            ----
               update (bool): Whether or not to update the configuration.
         """
-        loaded_config=self.read_json(self.filename)
+        loaded_config = self.read_json(self.filename)
 
         # validate
         if validate_config:
@@ -92,7 +92,7 @@ class SmurfConfig:
         """
         ## dump current config to outputfile ##
         with io.open(outputfile, 'w', encoding='utf8') as out_file:
-            str_ = json.dumps(self.config, indent = 4, separators = (',', ': '))
+            str_ = json.dumps(self.config, indent=4, separators=(',', ': '))
             out_file.write(str_)
 
     def has(self, key):
@@ -161,7 +161,7 @@ class SmurfConfig:
             self.config[key] = {} # initialize an empty dictionary first
             self.config[key][subkey] = val
 
-    def validate_config(self,loaded_config):
+    def validate_config(self, loaded_config):
         # Import useful schema objects
         # Try to import them from the system package. If it fails, then
         # import the local copy available in this repository.
@@ -175,90 +175,91 @@ class SmurfConfig:
         # file, like which bands are being used.  This also gets used
         # to construct the init:bands list, from which band_# are
         # present.
-        band_schema = Schema({ 'init' : { Regex('band_[0-7]') : {} } },ignore_extra_keys=True)
+        band_schema = Schema({'init' : {Regex('band_[0-7]') : {}}}, ignore_extra_keys=True)
         band_validated = band_schema.validate(loaded_config)
 
         # Build list of bands from which band_[0-7] blocks are present.  Will
         # use this to build the rest of the validation schema.
         r = re.compile("band_([0-7])")
-        bands=sorted([int(m.group(1)) for m in (r.match(s) for s in band_validated['init'].keys()) if m])
+        bands = sorted([int(m.group(1)) for m in (r.match(s) for s in
+                                                  band_validated['init'].keys()) if m])
 
         ###################################################
         ##### Building full validation schema
-        schema_dict={}
+        schema_dict = {}
 
         # Only used if none specified in pysmurf instantiation
         schema_dict['epics_root'] = And(str, len)
 
         #### Start specifiying init schema
         # init must be present
-        schema_dict['init']={}
+        schema_dict['init'] = {}
 
         # Explicitly sets dspEnable to this value in pysmurf setup.  Shouldn't
         # be necessary if defaults.yml is properly configured (dspEnable can
         # be set there, instead).
-        schema_dict['init'][Optional('dspEnable', default=1)] = And(int,lambda n: n in (0,1))
+        schema_dict['init'][Optional('dspEnable', default=1)] = And(int, lambda n: n in (0, 1))
 
         # Each band has a configuration block in init.
 
         # Default data_out_mux definitions.  Should match fw.
-        default_data_out_mux_dict={}
-        default_data_out_mux_dict[0]=[2,3]
-        default_data_out_mux_dict[1]=[0,1]
-        default_data_out_mux_dict[2]=[6,7]
-        default_data_out_mux_dict[3]=[8,9]
-        default_data_out_mux_dict[4]=[2,3]
-        default_data_out_mux_dict[5]=[0,1]
-        default_data_out_mux_dict[6]=[6,7]
-        default_data_out_mux_dict[7]=[8,9]
+        default_data_out_mux_dict = {}
+        default_data_out_mux_dict[0] = [2, 3]
+        default_data_out_mux_dict[1] = [0, 1]
+        default_data_out_mux_dict[2] = [6, 7]
+        default_data_out_mux_dict[3] = [8, 9]
+        default_data_out_mux_dict[4] = [2, 3]
+        default_data_out_mux_dict[5] = [0, 1]
+        default_data_out_mux_dict[6] = [6, 7]
+        default_data_out_mux_dict[7] = [8, 9]
 
         for band in bands:
             schema_dict['init']['band_%d'%band] = {
 
                 # Swap IQ channels on input
-                Optional('iq_swap_in', default=0): And(int,lambda n: n in (0,1)),
+                Optional('iq_swap_in', default=0): And(int, lambda n: n in (0, 1)),
                 # Swap IQ channels on output
-                Optional('iq_swap_out', default=0): And(int,lambda n: n in (0,1)),
+                Optional('iq_swap_out', default=0): And(int, lambda n: n in (0, 1)),
 
                 # Global feedback enable
-                Optional('feedbackEnable', default=1): And(int,lambda n: n in (0,1)),
+                Optional('feedbackEnable', default=1): And(int, lambda n: n in (0, 1)),
                 # Global feedback polarity
-                Optional('feedbackPolarity', default=1): And(int,lambda n: n in (0,1)),
+                Optional('feedbackPolarity', default=1): And(int, lambda n: n in (0, 1)),
                 # Global feedback gain (might no longer be used in dspv3).
-                "feedbackGain" :  And(int,lambda n: 0 <= n < 2**16),
+                "feedbackGain" :  And(int, lambda n: 0 <= n < 2**16),
                 # Global feedback gain (might no longer be used in dspv3).
-                "feedbackLimitkHz" : And(Use(float),lambda f: 0 < f),
+                "feedbackLimitkHz" : And(Use(float), lambda f: 0 < f),
 
                 # Number of cycles to delay phase reference
-                'refPhaseDelay': And(int,lambda n: 0 <= n < 2**4),
+                'refPhaseDelay': And(int, lambda n: 0 <= n < 2**4),
                 # Finer phase reference delay, 307.2MHz clock ticks.  This
                 # goes in the opposite direction as refPhaseDelay.
-                'refPhaseDelayFine': And(int,lambda n: 0 <= n < 2**8),
+                'refPhaseDelayFine': And(int, lambda n: 0 <= n < 2**8),
 
                 # RF attenuator on SMuRF output.  UC=up convert.  0.5dB steps.
-                'att_uc': And(int,lambda n: 0 <= n < 2**5),
+                'att_uc': And(int, lambda n: 0 <= n < 2**5),
                 # RF attenuator on SMuRF input.  DC=down convert.  0.5dB steps.
-                'att_dc': And(int,lambda n: 0 <= n < 2**5),
+                'att_dc': And(int, lambda n: 0 <= n < 2**5),
                 # Tone amplitude.  3dB steps.
-                'amplitude_scale': And(int,lambda n: 0 <= n < 2**4),
+                'amplitude_scale': And(int, lambda n: 0 <= n < 2**4),
 
                 # data_out_mux
-                Optional("data_out_mux",default=default_data_out_mux_dict[band]) \
-                  : And([ Use(int) ], list, lambda l: len(l)==2 and l[0]!=l[1] and all(ll>= 0 and ll<= 9 for ll in l) ),
+                Optional("data_out_mux", default=default_data_out_mux_dict[band]) \
+                  : And([Use(int)], list, lambda l: len(l) == 2 and l[0] != l[1] and all(ll >= 0 and ll <= 9 for ll in l)),
 
                 # Matches system latency for LMS feedback (9.6 MHz
                 # ticks, use multiples of 52).  For dspv3 to adjust to
                 # match refPhaseDelay*4 (ignore refPhaseDelayFine for
                 # this).  If not provided and lmsDelay=None, sets to
                 # lmsDelay = 4 x refPhaseDelay.
-                Optional('lmsDelay',default=None) : And(int,lambda n: 0 <= n < 2**5),
+                Optional('lmsDelay', default=None) : And(int, lambda n: 0 <= n < 2**5),
 
                 # Adjust trigRstDly such that the ramp resets at the flux ramp
                 # glitch.  2.4 MHz ticks.
-                'trigRstDly': And(int,lambda n: 0 <= n < 2**7),
+                'trigRstDly': And(int, lambda n: 0 <= n < 2**7),
 
                 # LMS gain, powers of 2
-                'lmsGain': And(int,lambda n: 0 <= n < 2**3),
+                'lmsGain': And(int, lambda n: 0 <= n < 2**3),
             }
         #### Done specifying init schema
 
@@ -267,10 +268,10 @@ class SmurfConfig:
         # doing basic validation here - not checking if they're distinct, for
         # instance.
         schema_dict["attenuator"] = {
-            'att1' : And(int,lambda n: 0 <= n < 4),
-            'att2' : And(int,lambda n: 0 <= n < 4),
-            'att3' : And(int,lambda n: 0 <= n < 4),
-            'att4' : And(int,lambda n: 0 <= n < 4)
+            'att1' : And(int, lambda n: 0 <= n < 4),
+            'att2' : And(int, lambda n: 0 <= n < 4),
+            'att3' : And(int, lambda n: 0 <= n < 4),
+            'att4' : And(int, lambda n: 0 <= n < 4)
         }
         #### Done specifying attenuator schema
 
@@ -285,8 +286,8 @@ class SmurfConfig:
             except ValueError:
                 return False
 
-        schema_dict["pic_to_bias_group"] = { And(str,RepresentsInt) : int }
-        schema_dict["bias_group_to_pair"] = { And(str,RepresentsInt) : [ int, int ] }
+        schema_dict["pic_to_bias_group"] = {And(str, RepresentsInt) : int}
+        schema_dict["bias_group_to_pair"] = {And(str, RepresentsInt) : [int, int]}
         #### Done specifying cryostat card schema
 
         #### Start specifiying amplifier
@@ -298,7 +299,7 @@ class SmurfConfig:
             # to volts for the 4K amplifier gate.  Units are volts/bit.  An
             # important dependency is the voltage division on the cryostat
             # card, which can be different from cryostat card to cryostat card
-            "bit_to_V_hemt" : And(Use(float),lambda f: 0 < f ),
+            "bit_to_V_hemt" : And(Use(float), lambda f: 0 < f),
             # The 4K amplifier drain current is measured before a voltage
             # regulator, which also draws current.  An accurate measurement of
             # the 4K drain current requires subtracting the current drawn by
@@ -313,23 +314,23 @@ class SmurfConfig:
             # BOM for cryostat card revision C02 (PC-248-103-02-C02).
             # The resistor on that revision of the cryostat card is
             # R44.
-            Optional('hemt_Vd_series_resistor', default=200): And(float,lambda f: f>0),
+            Optional('hemt_Vd_series_resistor', default=200): And(float, lambda f: f > 0),
             # The resistance, in Ohm, of the resistor that is inline
             # with the 50K amplifier drain voltage source which is
             # used to infer the 50K amplifier drain current.  The
             # default value of 10 Ohm is the standard value in the BOM
             # for cryostat card revision C02 (PC-248-103-02-C02).  The
             # resistor on that revision of the cryostat card is R54.
-            Optional('50K_amp_Vd_series_resistor', default=10): And(float,lambda f: f>0),
+            Optional('50K_amp_Vd_series_resistor', default=10): And(float, lambda f: f > 0),
             # 50K amplifier gate voltage, in volts.
             "LNA_Vg" : Use(float),
             # Which RTM DAC is wired to the gate of the 50K amplifier.
-            "dac_num_50k" : And(int,lambda n: 1 <= n <= 32),
+            "dac_num_50k" : And(int, lambda n: 1 <= n <= 32),
             # Conversion from bits (the digital value the RTM DAC is set to)
             # to volts for the 50K amplifier gate.  Units are volts/bit.  An
             # important dependency is the voltage division on the cryostat
             # card, which can be different from cryostat card to cryostat card
-            "bit_to_V_50k" : And(Use(float),lambda f: 0 < f ),
+            "bit_to_V_50k" : And(Use(float), lambda f: f > 0),
             # Software limit on the minimum gate voltage that can be set for the 4K amplifier.
             "hemt_gate_min_voltage" : Use(float),
             # Software limit on the maximum gate voltage that can be set for the 4K amplifier.
@@ -338,83 +339,84 @@ class SmurfConfig:
         #### Done specifiying amplifier
 
         #### Start specifying chip-to-frequency schema
-        schema_dict[Optional('chip_to_freq',default={})] = {
+        schema_dict[Optional('chip_to_freq', default={})] = {
             # [chip lower frequency, chip upper frequency] in GHz
-            Optional(str) : And([ Use(float) ], list, lambda l: len(l) == 2 and
-                l[0]<l[1] and all(ll >= 4 and ll<= 8 for ll in l) )
+            Optional(str) : And([Use(float)], list, lambda l: len(l) == 2 and
+                                l[0] < l[1] and all(ll >= 4 and ll <= 8 for ll in l))
         }
         #### Done specifying chip-to-frequency schema
 
         #### Start specifying tune parameter schema
         schema_dict['tune_band'] = {
-            "grad_cut" : And(Use(float),lambda f: 0 < f),
-            "amp_cut" : And(Use(float),lambda f: 0 < f),
+            "grad_cut" : And(Use(float), lambda f: f > 0),
+            "amp_cut" : And(Use(float), lambda f: f > 0),
 
-            Optional('n_samples',default=2**18) : And(int,lambda n: 0 < n),
+            Optional('n_samples', default=2**18) : And(int, lambda n: n > 0),
             # Digitizer sampling rate is 614.4 MHz, so biggest range of
             # frequencies user could possibly be interested in is between
             # -614.4MHz/2 and 614.4MHz/2, or -307.2MHz to +307.2MHz.
-            Optional('freq_max', default=250.e6) : And(Use(float),lambda f: -307.2e6 <= f <= 307.2e6),
-            Optional('freq_min', default=-250.e6) : And(Use(float),lambda f: -307.2e6 <= f <= 307.2e6),
+            Optional('freq_max', default=250.e6) : And(Use(float), lambda f: -307.2e6 <= f <= 307.2e6),
+            Optional('freq_min', default=-250.e6) : And(Use(float), lambda f: -307.2e6 <= f <= 307.2e6),
 
-            'fraction_full_scale' : And(Use(float),lambda f: 0 < f <=1.),
+            'fraction_full_scale' : And(Use(float), lambda f: 0 < f <= 1.),
             'reset_rate_khz' : And(Use(float), lambda f: 0 <= f <= 100),
-            Optional('default_tune',default=None) : And(str,os.path.isfile)
+            Optional('default_tune', default=None) : And(str, os.path.isfile)
         }
 
         ## Add tuning params that must be specified per band.
-        per_band_tuning_params= [
-            ( 'lms_freq',And(Use(float),lambda f: 0 < f) ),
-            ( 'delta_freq',And(Use(float),lambda f: 0 < f) ),
-            ( 'feedback_start_frac',And(Use(float),lambda f: 0 <= f <= 1) ),
-            ( 'feedback_end_frac',And(Use(float),lambda f: 0 <= f <= 1) ),
-            ( 'gradient_descent_gain',And(Use(float),lambda f: 0 < f) ),
-            ( 'gradient_descent_averages',And(Use(int),lambda n: 0 < n) ),
-            ( 'gradient_descent_converge_hz',And(Use(float),lambda f: 0 < f) ),
-            ( 'gradient_descent_momentum',And(Use(int),lambda n: 0 <= n) ),
-            ( 'gradient_descent_step_hz',And(Use(float),lambda f: 0 < f) ),
-            ( 'gradient_descent_beta',And(Use(float),lambda f: 0 <= f <= 1) ),
-            ( 'eta_scan_averages',And(Use(int),lambda n: 0 < n) ),
-            ( 'eta_scan_del_f', And(Use(int), lambda n: 0 < n) ),
-            ( 'eta_scan_amplitude', And(Use(int), lambda n: 0 < n) ),
+        per_band_tuning_params = [
+            ('lms_freq', And(Use(float), lambda f: f > 0)),
+            ('delta_freq', And(Use(float), lambda f: f > 0)),
+            ('feedback_start_frac', And(Use(float), lambda f: 0 <= f <= 1)),
+            ('feedback_end_frac', And(Use(float), lambda f: 0 <= f <= 1)),
+            ('gradient_descent_gain', And(Use(float), lambda f: f > 0)),
+            ('gradient_descent_averages', And(Use(int), lambda n: n > 0)),
+            ('gradient_descent_converge_hz', And(Use(float), lambda f: f > 0)),
+            ('gradient_descent_momentum', And(Use(int), lambda n: n >= 0)),
+            ('gradient_descent_step_hz', And(Use(float), lambda f: f > 0)),
+            ('gradient_descent_beta', And(Use(float), lambda f: 0 <= f <= 1)),
+            ('eta_scan_averages', And(Use(int), lambda n: n > 0)),
+            ('eta_scan_del_f', And(Use(int), lambda n: n > 0)),
+            ('eta_scan_amplitude', And(Use(int), lambda n: n > 0)),
         ]
 
         for band in bands:
-            for (p,v) in per_band_tuning_params:
-                if band==bands[0]:
-                    schema_dict['tune_band'][p]={}
+            for (p, v) in per_band_tuning_params:
+                if band == bands[0]:
+                    schema_dict['tune_band'][p] = {}
                 schema_dict['tune_band'][p][str(band)] = v
         ## Done adding tuning params that must be specified per band.
 
         #### Done specifying tune parameter schema
 
         #### Start specifying bad mask
-        schema_dict[Optional('bad_mask', default = {})] = {
+        schema_dict[Optional('bad_mask', default={})] = {
             # Why are these indexed by integers that are also strings?
             # I don't think the keys here are used at all.
-            Optional(str) : And([ Use(float) ], list, lambda l: len(l) == 2 and
-                l[0]<l[1] and all(ll >= 4000 and ll<= 8000 for ll in l) )
+            Optional(str) : And([Use(float)], list, lambda l: len(l) == 2 and
+                                l[0] < l[1] and all(ll >= 4000 and ll <= 8000 for ll in l))
         }
         #### Done specifying bad mask
 
         #### Start specifying TES-related
         # TES shunt resistance
-        schema_dict["R_sh"] = And(Use(float),lambda f: 0 < f )
+        schema_dict["R_sh"] = And(Use(float), lambda f: 0 < f)
 
         # Round-trip resistance on TES bias lines, in low current mode.
         # Includes the resistance on the cryostat cards, and cable resistance.
-        schema_dict["bias_line_resistance"] = And(Use(float),lambda f: 0 < f )
+        schema_dict["bias_line_resistance"] = And(Use(float), lambda f: 0 < f)
 
         # Ratio between the current per DAC unit in high current mode to the
         # current in low current mode.  Constained to be greater than or equal
         # to 1 since otherwise what does high current mode EVEN MEAN.
-        schema_dict["high_low_current_ratio"] = And(Use(float),lambda f: 1 <= f )
+        schema_dict["high_low_current_ratio"] = And(Use(float), lambda f: 1 <= f)
 
         # If 1, TES biasing will *always* be in high current mode.
-        schema_dict[Optional('high_current_mode_bool', default=0)] = And(int,lambda n: n in (0,1))
+        schema_dict[Optional('high_current_mode_bool', default=0)] = And(int, lambda n: n in (0, 1))
 
         # All SMuRF bias groups with TESs connected.
-        schema_dict["all_bias_groups"] = And([ int ], list, lambda l: all(ll >= 0 and ll < 16 for ll in l))
+        schema_dict["all_bias_groups"] = And([int], list, lambda l:
+                                             all(ll >= 0 and ll < 16 for ll in l))
         #### Done specifying TES-related
 
         #### Start specifying flux ramp-related
@@ -422,9 +424,9 @@ class SmurfConfig:
             # 0x1 selects fast flux ramp, 0x0 selects slow flux ramp.  The
             # slow flux ramp only existed on the first rev of RTM boards,
             # C0, and wasn't ever really used.
-            Optional("select_ramp", default=1) : And(int,lambda n: n in (0,1)),
+            Optional("select_ramp", default=1) : And(int, lambda n: n in (0, 1)),
             # 20 bits for the C0 RTMs, 32 bits for the C1 RTMs.
-            "num_flux_ramp_counter_bits" : And(int,lambda n: n in (20,32))
+            "num_flux_ramp_counter_bits" : And(int, lambda n: n in (20, 32))
         }
         #### Done specifying flux-ramp related
 
@@ -432,12 +434,12 @@ class SmurfConfig:
         # If all of a schema dictionary's keys are optional, must specify
         # them both in the schema key for that dictionary, and in the
         # schema for that dictionary.
-        constants_default_dict={ 'pA_per_phi0' : 9e6 }
-        cdd_key=Optional("constant",default=constants_default_dict)
-        schema_dict[cdd_key]={}
+        constants_default_dict = {'pA_per_phi0' : 9e6}
+        cdd_key = Optional("constant", default=constants_default_dict)
+        schema_dict[cdd_key] = {}
         # Assumes all constants default values are floats
         for key, value in constants_default_dict.items():
-            schema_dict[cdd_key][Optional(key,default=value)] = Use(float)
+            schema_dict[cdd_key][Optional(key, default=value)] = Use(float)
         #### Done specifying constants schema
 
         #### Start thermal schema
@@ -450,7 +452,7 @@ class SmurfConfig:
         # RF lab at SLAC where they've been testing with an ASIS
         # crate.  Shawn has yet to have this work for him.  Newer fw
         # versions will have OT protection enabled in the fw.
-        schema_dict[Optional('ultrascale_temperature_limit_degC',default=None)] = And(Use(float),lambda f: 0 <= f <= 99)
+        schema_dict[Optional('ultrascale_temperature_limit_degC', default=None)] = And(Use(float), lambda f: 0 <= f <= 99)
         #### Done specifying thermal schema
 
         #### Start specifying timing-related schema
@@ -461,19 +463,19 @@ class SmurfConfig:
             #   flux_ramp_start_mode=0
             # "backplane" : takes timing from timing master through
             #   backplane.  Also sets flux_ramp_start_mode=1.
-            "timing_reference" : And(str,lambda s: s in ('ext_ref','backplane'))
+            "timing_reference" : And(str, lambda s: s in ('ext_ref', 'backplane'))
         }
         #### Done specifying timing-related schema
 
         #### Start specifying smurf2mce
         # System should be smart enough to determine fs on the fly.
-        schema_dict["fs"] = And(Use(float),lambda f: 0 < f )
+        schema_dict["fs"] = And(Use(float), lambda f: 0 < f)
 
         def userHasWriteAccess(dirpath):
-            return os.access(dirpath,os.W_OK)
+            return os.access(dirpath, os.W_OK)
 
         def fileDirExistsAndUserHasWriteAccess(file_path):
-            filedir_path=os.path.dirname(file_path)
+            filedir_path = os.path.dirname(file_path)
             if not os.path.isdir(filedir_path):
                 return False
             elif not userHasWriteAccess(filedir_path):
@@ -482,29 +484,29 @@ class SmurfConfig:
                 return True
 
         def isValidPort(port_number):
-            return (1 <= int(port_number) <= 65535)
+            return 1 <= int(port_number) <= 65535
         # Some documentation on some of these parameters is here -
         # https://confluence.slac.stanford.edu/display/SMuRF/SMURF2MCE
         schema_dict["smurf_to_mce"] = {
             # smurf2mce configuration files.  pysmurf generates these
             # files on the fly, so just need to make sure the directory #
             # exists and is writeable
-            Optional("smurf_to_mce_file",default="/data/smurf2mce_config/smurf2mce.cfg") \
-               : And(str,fileDirExistsAndUserHasWriteAccess),
-            Optional("mask_file",default="/data/smurf2mce_config/mask.txt") \
-               : And(str,fileDirExistsAndUserHasWriteAccess),
+            Optional("smurf_to_mce_file", default="/data/smurf2mce_config/smurf2mce.cfg") \
+               : And(str, fileDirExistsAndUserHasWriteAccess),
+            Optional("mask_file", default="/data/smurf2mce_config/mask.txt") \
+               : And(str, fileDirExistsAndUserHasWriteAccess),
 
             # Whether or not to dynamically generate the gcp mask
             # everytime you stream data based on which channels have tones
             # assigned and on.
-            Optional('static_mask',default=0) : And(int,lambda n: n in (0,1)),
+            Optional('static_mask', default=0) : And(int, lambda n: n in (0, 1)),
 
             # 0 means use MCE sync word to determine when data is sent
             # Any positive number means average that many SMuRF frames
             #    before sending out the averaged frame
             # Any negative number means "please crash horribly". Same for
             #    anything that isn't a number
-            'num_averages' : And(int,lambda n: n>=0),
+            'num_averages' : And(int, lambda n: n >= 0),
 
             # The “file_name_extend” parameter now makes a new file every
             # “data_frames” frames.  Then files are written as long as the
@@ -512,41 +514,41 @@ class SmurfConfig:
             #  <file_name>.part_00000
             #  <file_name>.part_00001
             #  ...
-            'file_name_extend' : And(int,lambda n: n in (0,1)),
+            'file_name_extend' : And(int, lambda n: n in (0, 1)),
 
             # 0 in this field disables file writing
             # Setting a positive number causes a new file to be written
             #    after that many AVERAGED frames.
             # Setting a negative number causes the program to crash
             #    horribly
-            'data_frames' : And(int,lambda n: n>=0),
+            'data_frames' : And(int, lambda n: n >= 0),
 
             # Optional kludge to account for a circshift offset.
             # Implemented to get arounda bug in channel number in early
             # versions of the DSPv3 fw (specifically, fw version
             # mitch_4_30).  If not specified, no offset is applied.
-            Optional('mask_channel_offset',default=0) : Use(int),
+            Optional('mask_channel_offset', default=0) : Use(int),
 
             # This is the port used for communication. Must match the port
             # set at the receive end
-            Optional('port_number',default='3334') : And(str,RepresentsInt,isValidPort),
+            Optional('port_number', default='3334') : And(str, RepresentsInt, isValidPort),
 
             # Could and should improve validation on this one if it's ever
             # used again.  This default is also ridiculous.
             Optional('receiver_ip', default='tcp://192.168.3.1:3334') : str,
 
             # Filter params
-            'filter_freq' : And(Use(float),lambda f: f>0),
-            'filter_order' : And(int,lambda n: n>=0),
-            Optional('filter_gain',default=1.0) : Use(float)
+            'filter_freq' : And(Use(float), lambda f: f > 0),
+            'filter_order' : And(int, lambda n: n >= 0),
+            Optional('filter_gain', default=1.0) : Use(float)
         }
         #### Done specifying smurf2mce
 
         #### Start specifying directories
-        schema_dict[Optional("default_data_dir",default="/data/smurf_data")] = And(str,os.path.isdir,userHasWriteAccess)
-        schema_dict[Optional("smurf_cmd_dir",default="/data/smurf_data/smurf_cmd")] = And(str,os.path.isdir,userHasWriteAccess)
-        schema_dict[Optional("tune_dir",default="/data/smurf_data/tune")] = And(str,os.path.isdir,userHasWriteAccess)
-        schema_dict[Optional("status_dir",default="/data/smurf_data/status")] = And(str,os.path.isdir,userHasWriteAccess)
+        schema_dict[Optional("default_data_dir", default="/data/smurf_data")] = And(str, os.path.isdir, userHasWriteAccess)
+        schema_dict[Optional("smurf_cmd_dir", default="/data/smurf_data/smurf_cmd")] = And(str, os.path.isdir, userHasWriteAccess)
+        schema_dict[Optional("tune_dir", default="/data/smurf_data/tune")] = And(str, os.path.isdir, userHasWriteAccess)
+        schema_dict[Optional("status_dir", default="/data/smurf_data/status")] = And(str, os.path.isdir, userHasWriteAccess)
         #### Done specifying directories
 
         ##### Done building validation schema
@@ -562,23 +564,23 @@ class SmurfConfig:
         # succeeds
 
         # Check that no DAC has been assigned to multiple TES bias groups
-        bias_group_to_pair=validated_config['bias_group_to_pair']
-        tes_bias_group_dacs=np.ndarray.flatten(np.array([bg2p[1] for bg2p in bias_group_to_pair.items()]))
-        assert ( len(np.unique(tes_bias_group_dacs)) == len(tes_bias_group_dacs) ), 'Configuration failed - DACs may not be assigned to multiple TES bias groups.'
+        bias_group_to_pair = validated_config['bias_group_to_pair']
+        tes_bias_group_dacs = np.ndarray.flatten(np.array([bg2p[1] for bg2p in bias_group_to_pair.items()]))
+        assert (len(np.unique(tes_bias_group_dacs)) == len(tes_bias_group_dacs)), 'Configuration failed - DACs may not be assigned to multiple TES bias groups.'
 
         # Check that the DAC specified as the 50K gate driver
         # isn't also defined as one of the DACs in a TES bias group
         # pair.
-        dac_num_50k=validated_config['amplifier']['dac_num_50k']
+        dac_num_50k = validated_config['amplifier']['dac_num_50k']
         # Taking the first element works because we already required
         # that no DAC show up in more than one TES bias group
         # definition.
-        assert (dac_num_50k not in tes_bias_group_dacs),'Configuration failed - DAC requested for driving 50K amplifier gate, %d, is also assigned to TES bias group %d.'%(int(dac_num_50k),int([bg2p[0] for bg2p in bias_group_to_pair.items() if dac_num_50k in bg2p[1]][0]))
+        assert (dac_num_50k not in tes_bias_group_dacs), 'Configuration failed - DAC requested for driving 50K amplifier gate, %d, is also assigned to TES bias group %d.'%(int(dac_num_50k), int([bg2p[0] for bg2p in bias_group_to_pair.items() if dac_num_50k in bg2p[1]][0]))
 
         ##### Done with higher level/composite validation.
         ###################################################
 
         # Splice in the sorted init:bands key before returning
-        validated_config['init']['bands']=bands
+        validated_config['init']['bands'] = bands
 
         return validated_config

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -197,11 +197,12 @@ class SmurfConfig:
         self.config[key] = val
 
     def write(self, outputfile):
-        """Dumps the current config to a file
+        """Dump the current config to a file.
 
-           Args
-           ----
-              outputfile (str): The name of the file to save the configuration to.
+        Args
+        ----
+        outputfile : str
+           The name of the file to save the configuration to.
         """
         ## dump current config to outputfile ##
         with io.open(outputfile, 'w', encoding='utf8') as out_file:
@@ -209,13 +210,13 @@ class SmurfConfig:
             out_file.write(str_)
 
     def has(self, key):
-        """Reports if configuration has requested key.
+        """Report if configuration has requested key.
 
-           Args
-           ----
-              key (any): key to check for in configuration dictionary.
+        Args
+        ----
+        key : any
+           Key to check for in configuration dictionary.
         """
-
         if key in self.config:
             return True
 
@@ -223,7 +224,7 @@ class SmurfConfig:
 
     def get(self, key):
         """Return entry in config dictionary for requested key.
-        
+
         Returns `None` if the key not present in config dictionary.
 
         Args
@@ -231,7 +232,6 @@ class SmurfConfig:
         key : any
            Key whose configuration entry to retrieve.
         """
-
         if self.has(key):
             return self.config[key]
 
@@ -250,7 +250,6 @@ class SmurfConfig:
         subkey : any
            config dictionary subkey.
         """
-
         if self.has(key):
             sub_dict = self.config[key]
             try:
@@ -272,7 +271,6 @@ class SmurfConfig:
           subkey (any): config subkey
           val (any): value to write
         """
-
         try:
             self.config[key][subkey] = val
         except TypeError:

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -105,8 +105,8 @@ class SmurfConfig:
 
         if key in self.config:
             return True
-        else:
-            return False
+        
+        return False
 
     def get(self, key):
         """Returns configuration entry for requested key.  Returns
@@ -119,8 +119,8 @@ class SmurfConfig:
 
         if self.has(key):
             return self.config[key]
-        else:
-            return None
+
+        return None
 
     def get_subkey(self, key, subkey):
         """
@@ -228,7 +228,7 @@ class SmurfConfig:
                 # Global feedback gain (might no longer be used in dspv3).
                 "feedbackGain" :  And(int, lambda n: 0 <= n < 2**16),
                 # Global feedback gain (might no longer be used in dspv3).
-                "feedbackLimitkHz" : And(Use(float), lambda f: 0 < f),
+                "feedbackLimitkHz" : And(Use(float), lambda f: f > 0),
 
                 # Number of cycles to delay phase reference
                 'refPhaseDelay': And(int, lambda n: 0 <= n < 2**4),
@@ -299,7 +299,7 @@ class SmurfConfig:
             # to volts for the 4K amplifier gate.  Units are volts/bit.  An
             # important dependency is the voltage division on the cryostat
             # card, which can be different from cryostat card to cryostat card
-            "bit_to_V_hemt" : And(Use(float), lambda f: 0 < f),
+            "bit_to_V_hemt" : And(Use(float), lambda f: f > 0),
             # The 4K amplifier drain current is measured before a voltage
             # regulator, which also draws current.  An accurate measurement of
             # the 4K drain current requires subtracting the current drawn by
@@ -400,16 +400,16 @@ class SmurfConfig:
 
         #### Start specifying TES-related
         # TES shunt resistance
-        schema_dict["R_sh"] = And(Use(float), lambda f: 0 < f)
+        schema_dict["R_sh"] = And(Use(float), lambda f: f > 0)
 
         # Round-trip resistance on TES bias lines, in low current mode.
         # Includes the resistance on the cryostat cards, and cable resistance.
-        schema_dict["bias_line_resistance"] = And(Use(float), lambda f: 0 < f)
+        schema_dict["bias_line_resistance"] = And(Use(float), lambda f: f > 0)
 
         # Ratio between the current per DAC unit in high current mode to the
         # current in low current mode.  Constained to be greater than or equal
         # to 1 since otherwise what does high current mode EVEN MEAN.
-        schema_dict["high_low_current_ratio"] = And(Use(float), lambda f: 1 <= f)
+        schema_dict["high_low_current_ratio"] = And(Use(float), lambda f: f >= 1)
 
         # If 1, TES biasing will *always* be in high current mode.
         schema_dict[Optional('high_current_mode_bool', default=0)] = And(int, lambda n: n in (0, 1))
@@ -469,7 +469,7 @@ class SmurfConfig:
 
         #### Start specifying smurf2mce
         # System should be smart enough to determine fs on the fly.
-        schema_dict["fs"] = And(Use(float), lambda f: 0 < f)
+        schema_dict["fs"] = And(Use(float), lambda f: f > 0)
 
         def userHasWriteAccess(dirpath):
             return os.access(dirpath, os.W_OK)

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -46,27 +46,6 @@ class SmurfConfig:
     configuration file data is valid, parameters are loaded into the
     `config` dictionary class instance attribute.
 
-    `schema` validation does several important things to data loaded
-    from the pysmurf configuration file:
-
-    - Checks that all mandatory configuration variables are defined.
-    - Conditions all configuration variables into the correct type
-      (e.g. `float`, `int`, `str`, etc.).
-    - Automatically fills in the values for missing optional
-      parameters.  Optional parameters are typically parameters which
-      almost never change from SMuRF system to SMuRF system.
-    - Checks if parameters have valid values (e.g., some parameters
-      can only be either 0 or 1, or must be in a predefined interval,
-      etc.).
-    - Performs validation of some known higher level configuration
-      data interdependencies (e.g. prevents the user from defining an
-      RTM DAC as both a TES bias and an RF amplifier bias).
-
-    If validation fails, `schema` will raise a `SchemaError` exception
-    and fail to load the configuration data, forcing the user to fix
-    the cause of the `SchemaError` exception before the configuration
-    file can be loaded and used.
-
     If `validate` is False, the pysmurf configuration data will
     be loaded without `schema` validation.
 
@@ -278,6 +257,52 @@ class SmurfConfig:
             self.config[key][subkey] = val
 
     def validate_config(self, loaded_config):
+        """Validate pysmurf configuration dictionary.
+        
+        Validates the parameters in the configuration dictionary
+        provided by the `loaded_config` argument using the 3rd party
+        `schema` python library.  If the configuration data is valid,
+        parameters are returned as a dictionary.
+        
+        `schema` validation does several important things to raw data
+        loaded from the pysmurf configuration file:
+        
+        - Checks that all mandatory configuration variables are defined.
+        - Conditions all configuration variables into the correct type
+        (e.g. `float`, `int`, `str`, etc.).
+        - Automatically fills in the values for missing optional
+        parameters.  Optional parameters are typically parameters which
+        almost never change from SMuRF system to SMuRF system.
+        - Checks if parameters have valid values (e.g., some parameters
+        can only be either 0 or 1, or must be in a predefined interval,
+        etc.).
+        - Performs validation of some known higher level configuration
+        data interdependencies (e.g. prevents the user from defining an
+        RTM DAC as both a TES bias and an RF amplifier bias).
+        
+        If validation fails, `schema` will raise a `SchemaError` exception
+        and fail to load the configuration data, forcing the user to fix
+        the cause of the `SchemaError` exception before the configuration
+        file can be loaded and used.        
+
+        Args
+        ----
+        loaded_config : dict
+           Dictionary of pysmurf configuration parameters to run
+           `schema` validation on.
+
+        Returns
+        -------
+        validated_config : dict
+           Dictionary of validated configuration parameters.
+           Parameter values are conditioned by `schema` to conform to
+           the specified types.
+
+        Raises
+        ------
+        SchemaError
+           Raised if the configuration data fails `schema` validation.
+        """
         # Import useful schema objects
         # Try to import them from the system package. If it fails, then
         # import the local copy available in this repository.

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -139,7 +139,7 @@ class SmurfConfig:
         no_comments = []
         try:
             with open(self.filename) as config_file:
-                for idx, line in enumerate(config_file):
+                for _, line in enumerate(config_file):
                     if line.lstrip().startswith(comment_char):
                         # line starts with comment character - remove it
                         continue
@@ -471,8 +471,10 @@ class SmurfConfig:
             # Digitizer sampling rate is 614.4 MHz, so biggest range of
             # frequencies user could possibly be interested in is between
             # -614.4MHz/2 and 614.4MHz/2, or -307.2MHz to +307.2MHz.
-            Optional('freq_max', default=250.e6) : And(Use(float), lambda f: -307.2e6 <= f <= 307.2e6),
-            Optional('freq_min', default=-250.e6) : And(Use(float), lambda f: -307.2e6 <= f <= 307.2e6),
+            Optional('freq_max', default=250.e6) : And(
+                Use(float), lambda f: -307.2e6 <= f <= 307.2e6),
+            Optional('freq_min', default=-250.e6) : And(
+                Use(float), lambda f: -307.2e6 <= f <= 307.2e6),
 
             'fraction_full_scale' : And(Use(float), lambda f: 0 < f <= 1.),
             'reset_rate_khz' : And(Use(float), lambda f: 0 <= f <= 100),

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -38,13 +38,13 @@ class SmurfConfig:
     attribute is `None`.
 
     If a pysmurf configuration file is successfully loaded and the
-    `validate_config` constructor argument is True (which is the
+    XYZ constructor argument is True (which is the
     default behavior), the parameters in the configuration file will
     be validated using the 3rd party `schema` python library [schema]_
     using the rules specified in the
-    :func:`~pysmurf.client.base.validate_config` member function.  If
-    the configuration file data is valid, parameters are loaded into
-    the `config` dictionary class instance attribute.
+    :func:`~pysmurf.client.base.smurf_config.validate_config` member
+    function.  If the configuration file data is valid, parameters are
+    loaded into the `config` dictionary class instance attribute.
 
     `schema` validation does several important things to data loaded
     from the pysmurf configuration file:

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -30,7 +30,7 @@ class SmurfConfig:
     which are stored internally in a class instance attribute
     dictionary named `config`.
 
-    pysmurf configuration files must be in the JSON format [#json]_ .
+    pysmurf configuration files must be in the JSON format [#json]_.
     On instantiation, attempts to read the pysmurf configuration file
     at the path provided by the `filename` argument into the `config`
     dictionary class instance attribute.  If the `filename` argument
@@ -42,7 +42,7 @@ class SmurfConfig:
     default behavior), the parameters in the configuration file will
     be validated using the 3rd party `schema` python library [#schema]_
     using the rules specified in the
-    :meth:`~.SmurfConfig.validate_config` member function.  If the
+    :meth:`validate_config` member function.  If the
     configuration file data is valid, parameters are loaded into the
     `config` dictionary class instance attribute.
 
@@ -90,8 +90,8 @@ class SmurfConfig:
 
     See Also
     --------
-    :meth:`~.SmurfConfig.validate_config` : Run schema validation on loaded
-       configuration dictionary.
+    :meth:`validate_config` : Run schema validation on loaded configuration dictionary.
+    :meth:`read_json`
 
     References
     ----------
@@ -116,9 +116,6 @@ class SmurfConfig:
         parses the remaining lines in the pysmurf configuration file
         into a dictionary using the `json.loads` routine.
 
-        .. warning::
-           The pysmurf configuration file must be in the JSON format.
-
         Args
         ----
         filename : str
@@ -137,7 +134,7 @@ class SmurfConfig:
            Raised if the configuration file does not exist.
         JSONDecodeError
            Raised if the loaded configuration file data is not in JSON
-           format.
+           format [#json]_.
         """
         no_comments = []
         try:

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -42,7 +42,7 @@ class SmurfConfig:
     default behavior), the parameters in the configuration file will
     be validated using the 3rd party `schema` python library [#schema]_
     using the rules specified in the
-    :func:`~SmurfConfig.validate_config` member function.  If the
+    :meth:`~.SmurfConfig.validate_config` member function.  If the
     configuration file data is valid, parameters are loaded into the
     `config` dictionary class instance attribute.
 
@@ -90,7 +90,7 @@ class SmurfConfig:
 
     See Also
     --------
-    :func:`validate_config` : Run schema validation on loaded
+    :meth:`~.SmurfConfig.validate_config` : Run schema validation on loaded
     configuration dictionary.
 
     References

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -40,7 +40,7 @@ class SmurfConfig:
     If a pysmurf configuration file is successfully loaded and the
     `validate_config` constructor argument is True (which is the
     default behavior), the parameters in the configuration file will
-    be validated using the 3rd party `schema` python library [schema]_
+    be validated using the 3rd party `schema` python library [#schema]_
     using the rules specified in the
     :func:`~SmurfConfig.validate_config` member function.  If the
     configuration file data is valid, parameters are loaded into the
@@ -96,7 +96,7 @@ class SmurfConfig:
     References
     ----------
     .. [json] https://www.json.org/json-en.html
-    .. [schema] https://github.com/keleshev/schema
+    .. [#schema] https://github.com/keleshev/schema
 
     """
 

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -30,7 +30,7 @@ class SmurfConfig:
     which are stored internally in a class instance attribute
     dictionary named `config`.
 
-    pysmurf configuration files must be in the JSON format [JSON]_.
+    pysmurf configuration files must be in the JSON format [json]_ .
     On instantiation, attempts to read the pysmurf configuration file
     at the path provided by the `filename` argument into the `config`
     dictionary class instance attribute.  If the `filename` argument
@@ -95,7 +95,7 @@ class SmurfConfig:
 
     References
     ----------
-    .. [JSON] https://www.json.org/json-en.html
+    .. [json] https://www.json.org/json-en.html
     .. [schema] https://github.com/keleshev/schema
 
     """

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -28,13 +28,13 @@ class SmurfConfig:
     functions for reading and writing pysmurf configuration files,
     contains helper functions for manipulating configuration variables
     which are stored internally in a class instance attribute
-    dictionary named `config`.
+    dictionary named :attr:`config`.
 
     pysmurf configuration files must be in the JSON format [#json]_.
     On instantiation, attempts to read the pysmurf configuration file
-    at the path provided by the `filename` argument into the `config`
-    dictionary class instance attribute.  If the `filename` argument
-    is not provided, no configuration file is loaded and the `config`
+    at the path provided by the `filename` argument into the
+    :attr:`config` dictionary.  If the `filename` argument is not
+    provided, no configuration file is loaded and the :attr:`config`
     attribute is `None`.
 
     If a pysmurf configuration file is successfully loaded and the
@@ -43,10 +43,10 @@ class SmurfConfig:
     validated using the 3rd party `schema` python library [#schema]_
     using the rules specified in the :meth:`validate_config` class
     method.  If the configuration file data is valid, parameters are
-    loaded into the `config` dictionary class instance attribute.
+    loaded into the :attr:`config` dictionary.
 
-    If `validate` is False, the pysmurf configuration data will
-    be loaded without `schema` validation.
+    If `validate` is False, the pysmurf configuration data will be
+    loaded without `schema` validation.  *Use at your own risk!*
 
     Args
     ----
@@ -60,11 +60,12 @@ class SmurfConfig:
     Attributes
     ----------
     filename : str or None
-        Path to loaded pysmurf configuration file.  `None` if no pysmurf
-        configuration file has been loaded.
+        Path to loaded pysmurf configuration file, or configuration
+        file to load.  `None` if no pysmurf configuration file has
+        been loaded.
     config : dict or None
-        Dictionary of pysmurf configuration data.  `None` if no pysmurf
-        configuration file has been loaded.
+        Loaded dictionary of pysmurf configuration data.  `None` if no
+        pysmurf configuration file has been loaded.
 
     See Also
     --------
@@ -197,7 +198,7 @@ class SmurfConfig:
         Args
         ----
         key : any
-            Key to update in the config dictionary.
+            Key to update in the :attr:`config` dictionary.
         val : any
             Value to assign to the given key
         """
@@ -205,6 +206,10 @@ class SmurfConfig:
 
     def write(self, outputfile):
         """Dump the current config to a file.
+
+        Writes the :attr:`config` dictionary to file at the path
+        provided by the `outputfile` argument using the `json.dumps`
+        routine.
 
         Args
         ----
@@ -222,12 +227,12 @@ class SmurfConfig:
         Args
         ----
         key : any
-            Key to check for in configuration dictionary.
+            Key to check for in :attr:`config` dictionary.
 
         Returns
         -------
         bool
-            Returns True if key is in the configuration dictionary,
+            Returns True if key is in the :attr:`config` dictionary,
             False if it is not.
         """
         if key in self.config:
@@ -240,14 +245,14 @@ class SmurfConfig:
         Args
         ----
         key : any
-            Key whose configuration entry to retrieve.
+            Key whose :attr:`config` dictionary entry to retrieve.
 
         Returns
         -------
         any or None
-            Returns value for requested key from configuration
+            Returns value for requested key from :attr:`config`
             dictionary.  Returns `None` if key is not present in the
-            config dictionary.
+            :attr:`config` dictionary.
         """
         if self.has(key):
             return self.config[key]
@@ -259,16 +264,16 @@ class SmurfConfig:
         Args
         ----
         key : any
-            Key in config dictionary.
+            Key in :attr:`config` dictionary.
         subkey : any
-            Subkey in config dictionary.
+            Subkey in :attr:`config` dictionary.
 
         Returns
         -------
         any or None
-            Returns value for requested subkey from configuration
-            dictionary.  Returns `None` if either key or subkey are not
-            present in the config dictionary.
+            Returns value for requested subkey from :attr:`config`
+            dictionary.  Returns `None` if either key or subkey are
+            not present in the :attr:`config` dictionary.
         """
         if self.has(key):
             sub_dict = self.config[key]
@@ -287,11 +292,11 @@ class SmurfConfig:
         Args
         ----
         key : any
-            Key in config dictionary.
+            Key in :attr:`config` dictionary.
         subkey : any
-            Subkey in config dictionary
+            Subkey in :attr:`config` dictionary
         val : any
-            Value to write.
+            Value to write to :attr:`config` dictionary subkey.
         """
         try:
             self.config[key][subkey] = val

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -30,7 +30,7 @@ class SmurfConfig:
     which are stored internally in a class instance attribute
     dictionary named `config`.
 
-    pysmurf configuration files must be in the JSON format [json]_ .
+    pysmurf configuration files must be in the JSON format [#json]_ .
     On instantiation, attempts to read the pysmurf configuration file
     at the path provided by the `filename` argument into the `config`
     dictionary class instance attribute.  If the `filename` argument
@@ -91,11 +91,11 @@ class SmurfConfig:
     See Also
     --------
     :meth:`~.SmurfConfig.validate_config` : Run schema validation on loaded
-    configuration dictionary.
+       configuration dictionary.
 
     References
     ----------
-    .. [json] https://www.json.org/json-en.html
+    .. [#json] https://www.json.org/json-en.html
     .. [#schema] https://github.com/keleshev/schema
 
     """

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -38,13 +38,14 @@ class SmurfConfig:
     attribute is `None`.
 
     If a pysmurf configuration file is successfully loaded and the
-    XYZ constructor argument is True (which is the
+    `validate_config` constructor argument is True (which is the
     default behavior), the parameters in the configuration file will
     be validated using the 3rd party `schema` python library [schema]_
     using the rules specified in the
-    :func:`~pysmurf.client.base.smurf_config.validate_config` member
-    function.  If the configuration file data is valid, parameters are
-    loaded into the `config` dictionary class instance attribute.
+    :func:`~pysmurf.client.base.smurf_config.SmurfConfig.validate_config`
+    member function.  If the configuration file data is valid,
+    parameters are loaded into the `config` dictionary class instance
+    attribute.
 
     `schema` validation does several important things to data loaded
     from the pysmurf configuration file:

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -38,14 +38,14 @@ class SmurfConfig:
     attribute is `None`.
 
     If a pysmurf configuration file is successfully loaded and the
-    `validate` constructor argument is True (which is the default
+    `validate` constructor argument is `True` (which is the default
     behavior), the parameters in the configuration file will be
     validated using the 3rd party `schema` python library [#schema]_
     using the rules specified in the :meth:`validate_config` class
     method.  If the configuration file data is valid, parameters are
     loaded into the :attr:`config` dictionary.
 
-    If `validate` is False, the pysmurf configuration data will be
+    If `validate` is `False`, the pysmurf configuration data will be
     loaded without `schema` validation.  *Use at your own risk!*
 
     Args
@@ -94,7 +94,8 @@ class SmurfConfig:
         `filename` argument, strips off all lines that start with the
         character provided by the `comment_char` argument, and then
         parses the remaining lines in the pysmurf configuration file
-        into a dictionary using the `json.loads` routine.
+        into a dictionary using the `json.loads` routine.  Any text
+        after the `comment_char` on a line is also ignored.
 
         Args
         ----
@@ -232,8 +233,8 @@ class SmurfConfig:
         Returns
         -------
         bool
-            Returns True if key is in the :attr:`config` dictionary,
-            False if it is not.
+            Returns `True` if key is in the :attr:`config` dictionary,
+            `False` if it is not.
         """
         if key in self.config:
             return True

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -169,18 +169,17 @@ class SmurfConfig:
         :meth:`validate_config`
             Run `schema` validation on loaded configuration dictionary.
         """
-        loaded_config = self.read_json(self.filename)
+        config = self.read_json(self.filename)
 
         # validate
         if validate:
-            validated_config = self.validate_config(loaded_config)
+            config = self.validate_config(config)
 
-            if update:
-                # put in some logic here to make sure parameters in experiment file match
-                # the parameters we're looking for
-                self.config = validated_config
-        else:
-            self.config = loaded_config
+        # only update config dictionary if update=True
+        if update:
+            self.config = config
+
+        return config
 
     def update(self, key, val):
         """Update a single key in the config dictionary.

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -42,10 +42,9 @@ class SmurfConfig:
     default behavior), the parameters in the configuration file will
     be validated using the 3rd party `schema` python library [schema]_
     using the rules specified in the
-    :func:`~pysmurf.client.base.smurf_config.SmurfConfig.validate_config`
-    member function.  If the configuration file data is valid,
-    parameters are loaded into the `config` dictionary class instance
-    attribute.
+    :func:`~SmurfConfig.validate_config` member function.  If the
+    configuration file data is valid, parameters are loaded into the
+    `config` dictionary class instance attribute.
 
     `schema` validation does several important things to data loaded
     from the pysmurf configuration file:

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -30,9 +30,9 @@ class SmurfConfig:
     which are stored internally in a class instance attribute
     dictionary named `config`.
 
-    pysmurf configuration files must be in the JSON format [1]_ .  On
-    instantiation, attempts to read the pysmurf configuration file at
-    the path provided by the `filename` argument into the `config`
+    pysmurf configuration files must be in the JSON format [JSON]_.
+    On instantiation, attempts to read the pysmurf configuration file
+    at the path provided by the `filename` argument into the `config`
     dictionary class instance attribute.  If the `filename` argument
     is not provided, no configuration file is loaded and the `config`
     attribute is `None`.
@@ -40,7 +40,7 @@ class SmurfConfig:
     If a pysmurf configuration file is successfully loaded and the
     `validate_config` constructor argument is True (which is the
     default behavior), the parameters in the configuration file will
-    be validated using the 3rd party `schema` python library [2]_
+    be validated using the 3rd party `schema` python library [schema]_
     using the rules specified in the
     :func:`~pysmurf.client.base.validate_config` member function.  If
     the configuration file data is valid, parameters are loaded into
@@ -95,8 +95,8 @@ class SmurfConfig:
 
     References
     ----------
-    .. [1] https://www.json.org/json-en.html
-    .. [2] https://github.com/keleshev/schema
+    .. [JSON] https://www.json.org/json-en.html
+    .. [schema] https://github.com/keleshev/schema
 
     """
 

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -145,13 +145,17 @@ class SmurfConfig:
         """Read config file and update the config dictionary.
 
         Reads raw configuration parameters from configuration file at
-        the path specified by the `filename` class instance attribute
-        using the :meth:`read_json` method.
+        the path specified by the :attr:`filename` class instance
+        attribute using the :meth:`read_json` method.
 
         If the `validate` argument is `True` (which is the default
-        behavior), the loaded configuration parameter dictionary, the
-        loaded configuration parameters are validated using the
-        :meth:`validate_config` routine.  If successful and the `update`
+        behavior), the loaded configuration parameters are validated
+        using the :meth:`validate_config` routine.
+
+        The :attr:`config` class instance attribute is only updated
+        with the loaded configuration parameters if the `update`
+        argument is `True` (it is `False` by default).  Either way,
+        the loaded configuration parameter dictionary is returned.
 
         Args
         ----
@@ -162,12 +166,18 @@ class SmurfConfig:
             configuration file data.  If `schema` validation fails, a
             `SchemaError` exception will be raised.
 
+        Returns
+        -------
+        config : dict
+            The loaded dictionary of pysmurf configuration parameters.
+
         See Also
         --------
         :meth:`read_json`
             Reads raw configuration file into a dictionary.
         :meth:`validate_config`
-            Run `schema` validation on loaded configuration dictionary.
+            Run `schema` validation on loaded configuration
+            dictionary.
         """
         config = self.read_json(self.filename)
 

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -21,7 +21,7 @@ class SmurfConfigPropertiesMixin:
     Defines properties used by pysmurf whose values are specified in
     the pysmurf configuration file.  More details on python properties
     can be found in the documentation for python "Built-in Functions"
-    [pyprop]_.
+    [#pyprop]_.
 
     The :class:`SmurfConfigPropertiesMixin` class has only one
     function :func:`copy_config_to_properties` which can populate the
@@ -74,7 +74,7 @@ class SmurfConfigPropertiesMixin:
 
     References
     ----------
-    .. [pyprop] https://docs.python.org/3/library/functions.html#property
+    .. [#pyprop] https://docs.python.org/3/library/functions.html#property
 
     """
 

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -21,7 +21,7 @@ class SmurfConfigPropertiesMixin:
     Defines properties used by pysmurf whose values are specified in
     the pysmurf configuration file.  More details on python properties
     can be found in the documentation for python "Built-in Functions"
-    [1]_.
+    [pyprop]_.
 
     The :class:`SmurfConfigPropertiesMixin` class has only one
     function :func:`copy_config_to_properties` which can populate the
@@ -74,7 +74,7 @@ class SmurfConfigPropertiesMixin:
 
     References
     ----------
-    .. [1] https://docs.python.org/3/library/functions.html#property
+    .. [pyprop] https://docs.python.org/3/library/functions.html#property
 
     """
 

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -24,14 +24,14 @@ class SmurfConfigPropertiesMixin:
     [#pyprop]_.
 
     The :class:`SmurfConfigPropertiesMixin` class has only one
-    function :func:`copy_config_to_properties` which can populate the
+    method :meth:`copy_config_to_properties` which can populate the
     properties from a provided
     :class:`~pysmurf.client.base.smurf_config.SmurfConfig` class
-    instance.  :func:`copy_config_to_properties` can be called by the
+    instance.  :meth:`copy_config_to_properties` can be called by the
     user at any time, but it is called once to populate all of the
     :class:`SmurfConfigPropertiesMixin` attributes by a call to the
     :func:`~pysmurf.client.base.smurf_control.SmurfControl.initialize`
-    function in the
+    method in the
     :class:`~pysmurf.client.base.smurf_control.SmurfControl`
     constructor (unless the
     :class:`~pysmurf.client.base.smurf_control.SmurfControl` instance

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -38,11 +38,11 @@ class SmurfConfigPropertiesMixin:
     is not instantiated with a configuration file).
 
     .. warning::
-        If a user changes the value of a property but then writes the
-        internal pysmurf configuration to disk with the
-        :func:`~pysmurf.client.base.smurf_control.SmurfControl.write_output()`
-        function, the value written to the file will not reflect the
-        user's change.
+       If a user changes the value of a property but then writes the
+       internal pysmurf configuration to disk with the
+       :func:`~pysmurf.client.base.smurf_control.SmurfControl.write_output()`
+       function, the value written to the file will not reflect the
+       user's change.
 
     Examples
     --------

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -344,14 +344,14 @@ class SmurfControl(SmurfCommandMixin,
         tune_band_cfg = self.config.get('tune_band')
         tune_band_keys = tune_band_cfg.keys()
         self.lms_gain = {}
-        for b in bands:
+        for band in bands:
             # Make band dictionaries
-            self.freq_resp[b] = {}
-            self.freq_resp[b]['lock_status'] = {}
-            self.lms_freq_hz[b] = tune_band_cfg['lms_freq'][str(b)]
+            self.freq_resp[band] = {}
+            self.freq_resp[band]['lock_status'] = {}
+            self.lms_freq_hz[band] = tune_band_cfg['lms_freq'][str(band)]
 
-            band_str = f'band_{b}'
-            self.lms_gain[b] = smurf_init_config[band_str]['lmsGain']
+            band_str = f'band_{band}'
+            self.lms_gain[band] = smurf_init_config[band_str]['lmsGain']
 
         # Load in tuning parameters, if present
         tune_band_cfg = self.config.get('tune_band')
@@ -501,11 +501,11 @@ class SmurfControl(SmurfCommandMixin,
         # (which don't seem to be affected by setting the DC
         # attenuators, at least for LB bands 2 and 3), then set all
         # the UC attenuators.
-        for b in bands:
-            self.set_att_uc(b, smurf_init_config[band_str]['att_uc'],
+        for band in bands:
+            self.set_att_uc(band, smurf_init_config[band_str]['att_uc'],
                             write_log=write_log)
-        for b in bands:
-            self.set_att_dc(b, smurf_init_config[band_str]['att_dc'],
+        for band in bands:
+            self.set_att_dc(band, smurf_init_config[band_str]['att_dc'],
                             write_log=write_log)
 
         # Things that have to be done for both AMC bays, regardless of whether or not an AMC
@@ -652,9 +652,9 @@ class SmurfControl(SmurfCommandMixin,
         Args
         ----
         key : any
-              The name of the key to update.
+            The name of the key to update.
         val : any
-              The value to assign to the key.
+            The value to assign to the key.
         """
         self.config.update_subkey('outputs', key, val)
 

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -21,14 +21,14 @@ import time
 
 import numpy as np
 
-from pysmurf.client.base.smurf_config import SmurfConfig as SmurfConfig
-from pysmurf.client.base.smurf_config_properties import SmurfConfigPropertiesMixin as SmurfConfigPropertiesMixin
-from pysmurf.client.command.smurf_atca_monitor import SmurfAtcaMonitorMixin as SmurfAtcaMonitorMixin
-from pysmurf.client.command.smurf_command import SmurfCommandMixin as SmurfCommandMixin
-from pysmurf.client.debug.smurf_iv import SmurfIVMixin as SmurfIVMixin
-from pysmurf.client.debug.smurf_noise import SmurfNoiseMixin as SmurfNoiseMixin
-from pysmurf.client.tune.smurf_tune import SmurfTuneMixin as SmurfTuneMixin
-from pysmurf.client.util.smurf_util import SmurfUtilMixin as SmurfUtilMixin
+from pysmurf.client.base.smurf_config import SmurfConfig
+from pysmurf.client.base.smurf_config_properties import SmurfConfigPropertiesMixin
+from pysmurf.client.command.smurf_atca_monitor import SmurfAtcaMonitorMixin
+from pysmurf.client.command.smurf_command import SmurfCommandMixin
+from pysmurf.client.debug.smurf_iv import SmurfIVMixin
+from pysmurf.client.debug.smurf_noise import SmurfNoiseMixin
+from pysmurf.client.tune.smurf_tune import SmurfTuneMixin
+from pysmurf.client.util.smurf_util import SmurfUtilMixin
 
 class SmurfControl(SmurfCommandMixin,
         SmurfAtcaMonitorMixin, SmurfUtilMixin, SmurfTuneMixin,
@@ -117,7 +117,7 @@ class SmurfControl(SmurfCommandMixin,
             self.config = SmurfConfig(cfg_file)
 
         # Save shelf manager - Should this be in the config?
-        self.shelf_manager=shelf_manager
+        self.shelf_manager = shelf_manager
 
         # In offline mode, epics root is not needed.
         if offline and epics_root is None:
@@ -179,7 +179,7 @@ class SmurfControl(SmurfCommandMixin,
         """
         if no_dir:
             print('Warning! Not making output directories!' +
-                'This will break may things!')
+                  'This will break may things!')
         elif smurf_cmd_mode:
             # Get data dir
             self.data_dir = self.config.get('smurf_cmd_dir')
@@ -237,8 +237,8 @@ class SmurfControl(SmurfCommandMixin,
                 self.log.set_logfile(None)
 
         # Crate/carrier configuration details that won't change.
-        self.crate_id=self.get_crate_id()
-        self.slot_number=self.get_slot_number()
+        self.crate_id = self.get_crate_id()
+        self.slot_number = self.get_slot_number()
 
         # Populate SmurfConfigPropertiesMixin properties with values
         # from loaded pysmurf configuration file.
@@ -257,7 +257,7 @@ class SmurfControl(SmurfCommandMixin,
         # Flux ramp hardware detail
         flux_ramp_cfg = self.config.get('flux_ramp')
         keys = flux_ramp_cfg.keys()
-        self.num_flux_ramp_counter_bits=flux_ramp_cfg['num_flux_ramp_counter_bits']
+        self.num_flux_ramp_counter_bits = flux_ramp_cfg['num_flux_ramp_counter_bits']
 
         # Mapping from chip number to frequency in GHz
         chip_cfg = self.config.get('chip_to_freq')
@@ -272,7 +272,7 @@ class SmurfControl(SmurfCommandMixin,
         self.channel_assignment_files = {}
         if not no_dir:
             for b in self.config.get('init').get('bands'):
-                all_channel_assignment_files=glob.glob(os.path.join(self.tune_dir,
+                all_channel_assignment_files = glob.glob(os.path.join(self.tune_dir,
                     '*channel_assignment_b{}.txt'.format(b)))
                 if len(all_channel_assignment_files):
                     self.channel_assignment_files['band_{}'.format(b)] = \
@@ -284,7 +284,7 @@ class SmurfControl(SmurfCommandMixin,
         # bias group to pair
         bias_group_cfg = self.config.get('bias_group_to_pair')
         # how many bias groups are there?
-        self._n_bias_groups=len(bias_group_cfg)
+        self._n_bias_groups = len(bias_group_cfg)
         keys = bias_group_cfg.keys()
         self.bias_group_to_pair = np.zeros((len(keys), 3), dtype=int)
         for i, k in enumerate(keys):
@@ -354,17 +354,17 @@ class SmurfControl(SmurfCommandMixin,
             self.lms_gain[b] = smurf_init_config[band_str]['lmsGain']
 
         # Load in tuning parameters, if present
-        tune_band_cfg=self.config.get('tune_band')
-        tune_band_keys=tune_band_cfg.keys()
+        tune_band_cfg = self.config.get('tune_band')
+        tune_band_keys = tune_band_cfg.keys()
         for cfg_var in ['gradient_descent_gain', 'gradient_descent_averages',
                         'gradient_descent_converge_hz', 'gradient_descent_step_hz',
                         'gradient_descent_momentum', 'gradient_descent_beta',
                         'eta_scan_del_f', 'eta_scan_amplitude',
-                        'eta_scan_averages','delta_freq']:
+                        'eta_scan_averages', 'delta_freq']:
             if cfg_var in tune_band_keys:
                 setattr(self, cfg_var, {})
                 for b in bands:
-                    getattr(self,cfg_var)[b]=tune_band_cfg[cfg_var][str(b)]
+                    getattr(self, cfg_var)[b] = tune_band_cfg[cfg_var][str(b)]
 
         if setup:
             self.setup(payload_size=payload_size, **kwargs)
@@ -390,14 +390,14 @@ class SmurfControl(SmurfCommandMixin,
         # If active, disable hardware logging while doing setup.
         if self._hardware_logging_thread is not None:
             self.log('Hardware logging is enabled.  Pausing for setup.',
-                (self.LOG_USER))
+                     (self.LOG_USER))
             self.pause_hardware_logging()
 
         # Thermal OT protection
         ultrascale_temperature_limit_degC = self.config.get('ultrascale_temperature_limit_degC')
         if ultrascale_temperature_limit_degC is not None:
             self.log('Setting ultrascale OT protection limit '+
-                f'to {ultrascale_temperature_limit_degC}C', self.LOG_USER)
+                     f'to {ultrascale_temperature_limit_degC}C', self.LOG_USER)
             # OT threshold in degrees C
             self.set_ultrascale_ot_threshold(
                 self.config.get('ultrascale_temperature_limit_degC'),
@@ -415,8 +415,8 @@ class SmurfControl(SmurfCommandMixin,
         # but may want to determine at runtime which are actually needed and
         # only reset the DAC in those.
         self.log('Toggling DACs')
-        dacs=[0,1]
-        for val in [1,0]:
+        dacs = [0, 1]
+        for val in [1, 0]:
             for bay in self.bays:
                 for dac in dacs:
                     self.set_dac_reset(bay, dac, val, write_log=write_log)
@@ -476,23 +476,23 @@ class SmurfControl(SmurfCommandMixin,
                 write_log=write_log, **kwargs)
 
             # Tuning defaults - only set if present in cfg
-            if hasattr(self,'gradient_descent_gain') and b in self.gradient_descent_gain.keys():
+            if hasattr(self, 'gradient_descent_gain') and b in self.gradient_descent_gain.keys():
                 self.set_gradient_descent_gain(b, self.gradient_descent_gain[b], write_log=write_log, **kwargs)
-            if hasattr(self,'gradient_descent_averages') and b in self.gradient_descent_averages.keys():
+            if hasattr(self, 'gradient_descent_averages') and b in self.gradient_descent_averages.keys():
                 self.set_gradient_descent_averages(b, self.gradient_descent_averages[b], write_log=write_log, **kwargs)
-            if hasattr(self,'gradient_descent_converge_hz') and b in self.gradient_descent_converge_hz.keys():
+            if hasattr(self, 'gradient_descent_converge_hz') and b in self.gradient_descent_converge_hz.keys():
                 self.set_gradient_descent_converge_hz(b, self.gradient_descent_converge_hz[b], write_log=write_log, **kwargs)
-            if hasattr(self,'gradient_descent_step_hz') and b in self.gradient_descent_step_hz.keys():
+            if hasattr(self, 'gradient_descent_step_hz') and b in self.gradient_descent_step_hz.keys():
                 self.set_gradient_descent_step_hz(b, self.gradient_descent_step_hz[b], write_log=write_log, **kwargs)
-            if hasattr(self,'gradient_descent_momentum') and b in self.gradient_descent_momentum.keys():
+            if hasattr(self, 'gradient_descent_momentum') and b in self.gradient_descent_momentum.keys():
                 self.set_gradient_descent_momentum(b, self.gradient_descent_momentum[b], write_log=write_log, **kwargs)
-            if hasattr(self,'gradient_descent_beta') and b in self.gradient_descent_beta.keys():
+            if hasattr(self, 'gradient_descent_beta') and b in self.gradient_descent_beta.keys():
                 self.set_gradient_descent_beta(b, self.gradient_descent_beta[b], write_log=write_log, **kwargs)
-            if hasattr(self,'eta_scan_averages') and b in self.eta_scan_averages.keys():
+            if hasattr(self, 'eta_scan_averages') and b in self.eta_scan_averages.keys():
                 self.set_eta_scan_averages(b, self.eta_scan_averages[b], write_log=write_log, **kwargs)
-            if hasattr(self,'eta_scan_amplitude') and b in self.eta_scan_amplitude.keys():
+            if hasattr(self, 'eta_scan_amplitude') and b in self.eta_scan_amplitude.keys():
                 self.set_eta_scan_amplitude(b, self.eta_scan_amplitude[b], write_log=write_log, **kwargs)
-            if hasattr(self,'eta_scan_del_f') and b in self.eta_scan_del_f.keys():
+            if hasattr(self, 'eta_scan_del_f') and b in self.eta_scan_del_f.keys():
                 self.set_eta_scan_del_f(b, self.eta_scan_del_f[b], write_log=write_log, **kwargs)
 
         # To work around issue where setting the UC attenuators is for
@@ -510,7 +510,7 @@ class SmurfControl(SmurfCommandMixin,
 
         # Things that have to be done for both AMC bays, regardless of whether or not an AMC
         # is plugged in there.
-        for bay in [0,1]:
+        for bay in [0, 1]:
             self.set_trigger_hw_arm(bay, 0, write_log=write_log)
 
         self.set_trigger_width(0, 10, write_log=write_log)  # mystery bit that makes triggering work
@@ -550,15 +550,15 @@ class SmurfControl(SmurfCommandMixin,
         # if no timing section present, assumes your defaults.yml
         # has set you up...good luck.
         if self.config.get('timing') is not None and self.config.get('timing').get('timing_reference') is not None:
-            timing_reference=self.config.get('timing').get('timing_reference')
+            timing_reference = self.config.get('timing').get('timing_reference')
 
             # check if supported
-            timing_options=['ext_ref','backplane']
-            assert (timing_reference in timing_options), 'timing_reference in cfg file (={}) not in timing_options={}'.format(timing_reference,str(timing_options))
+            timing_options = ['ext_ref', 'backplane']
+            assert (timing_reference in timing_options), 'timing_reference in cfg file (={}) not in timing_options={}'.format(timing_reference, str(timing_options))
 
             self.log(f'Configuring the system to take timing from {timing_reference}')
 
-            if timing_reference=='ext_ref':
+            if timing_reference == 'ext_ref':
                 for bay in self.bays:
                     self.log(f'Select external reference for bay {bay}')
                     self.sel_ext_ref(bay)
@@ -567,23 +567,23 @@ class SmurfControl(SmurfCommandMixin,
                 self.set_ramp_start_mode(0, write_log=write_log)
 
             # https://confluence.slac.stanford.edu/display/SMuRF/Timing+Carrier#TimingCarrier-Howtoconfiguretodistributeoverbackplanefromslot2
-            if timing_reference=='backplane':
+            if timing_reference == 'backplane':
                 # Set SMuRF carrier crossbar to use the backplane
                 # distributed timing.
                 # OutputConfig[1] = 0x2 configures the SMuRF carrier's
                 # FPGA to take the timing signals from the backplane
                 # (TO_FPGA = FROM_BACKPLANE)
                 self.log('Setting crossbar OutputConfig[1]=0x2 (TO_FPGA=FROM_BACKPLANE)')
-                self.set_crossbar_output_config(1,2)
+                self.set_crossbar_output_config(1, 2)
 
                 self.log('Waiting 1 sec for timing up-link...')
                 time.sleep(1)
 
                 # Check if link is up - just printing status to
                 # screen, not currently taking any action if it's not.
-                timingRxLinkUp=self.get_timing_link_up()
-                self.log(f'Timing RxLinkUp = {timingRxLinkUp}', self.LOG_USER if
-                         timingRxLinkUp else self.LOG_ERROR)
+                timing_rx_link_up = self.get_timing_link_up()
+                self.log(f'Timing RxLinkUp = {timing_rx_link_up}', self.LOG_USER if
+                         timing_rx_link_up else self.LOG_ERROR)
 
                 # Set LMK to use timing system as reference
                 for bay in self.bays:
@@ -640,8 +640,8 @@ class SmurfControl(SmurfCommandMixin,
 
         if as_int:
             return int(t)
-        else:
-            return t
+
+        return t
 
     def add_output(self, key, val):
         """Adds key/value pair to pysmurf configuration dictionary.

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -627,21 +627,22 @@ class SmurfControl(SmurfCommandMixin,
         Args
         ----
         as_int : bool, optional, default False
-              Whether to return the timestamp as an integer.
+            Whether to return the timestamp as an integer.  If False,
+            timestamp is returned as an integer.
 
         Returns
         -------
-        str or int
-              Timestamp as a string, unless optional argument
-              as_int=True, in which case returns timestamp as an
-              integer.
+        timestamp : str or int
+            Timestamp as a string, unless optional argument
+            as_int=True, in which case returns timestamp as an
+            integer.
         """
-        t = '{:10}'.format(int(time.time()))
+        timestamp = '{:10}'.format(int(time.time()))
 
         if as_int:
-            return int(t)
+            return int(timestamp)
 
-        return t
+        return timestamp
 
     def add_output(self, key, val):
         """Adds key/value pair to pysmurf configuration dictionary.

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -268,9 +268,9 @@ class SmurfControl(SmurfCommandMixin,
         if not no_dir:
             for b in self.config.get('init').get('bands'):
                 all_channel_assignment_files = glob.glob(os.path.join(self.tune_dir,
-                    '*channel_assignment_b{}.txt'.format(b)))
+                    f'*channel_assignment_b{b}.txt'))
                 if len(all_channel_assignment_files):
-                    self.channel_assignment_files['band_{}'.format(b)] = \
+                    self.channel_assignment_files[f'band_{b}'] = \
                         np.sort(all_channel_assignment_files)[-1]
 
         # bias groups available
@@ -444,7 +444,7 @@ class SmurfControl(SmurfCommandMixin,
 
         # The per band configs. May want to make available per-band values.
         for b in bands:
-            band_str = 'band_{}'.format(b)
+            band_str = f'band_{b}'
             self.set_iq_swap_in(b, smurf_init_config[band_str]['iq_swap_in'],
                 write_log=write_log, **kwargs)
             self.set_iq_swap_out(b, smurf_init_config[band_str]['iq_swap_out'],
@@ -572,7 +572,7 @@ class SmurfControl(SmurfCommandMixin,
 
             # check if supported
             timing_options = ['ext_ref', 'backplane']
-            assert (timing_reference in timing_options), 'timing_reference in cfg file (={}) not in timing_options={}'.format(timing_reference, str(timing_options))
+            assert (timing_reference in timing_options), f'timing_reference in cfg file (={timing_reference}) not in timing_options={timing_options}'
 
             self.log(f'Configuring the system to take timing from {timing_reference}')
 

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -655,7 +655,7 @@ class SmurfControl(SmurfCommandMixin,
             as_int=True, in which case returns timestamp as an
             integer.
         """
-        timestamp = '{:10}'.format(int(time.time()))
+        timestamp = f'{time.time():.0f}'
 
         if as_int:
             return int(timestamp)

--- a/python/pysmurf/client/command/smurf_atca_monitor.py
+++ b/python/pysmurf/client/command/smurf_atca_monitor.py
@@ -41,7 +41,7 @@ class SmurfAtcaMonitorMixin(SmurfBase):
             slot_number=self.slot_number
         if atca_epics_root is None:
             shelf_manager=self.shelf_manager
-        return self._caget('{}:Crate:Slot_{}:'.format(shelf_manager,slot_number) +
+        return self._caget(f'{shelf_manager}:Crate:Slot_{slot_number}:' +
                            self._board_temp_fpga,**kwargs)
 
     _board_temp_rtm = 'BoardTemp:RTM'
@@ -54,7 +54,7 @@ class SmurfAtcaMonitorMixin(SmurfBase):
             slot_number=self.slot_number
         if atca_epics_root is None:
             shelf_manager=self.shelf_manager
-        return self._caget('{}:Crate:Slot_{}:'.format(shelf_manager,slot_number) +
+        return self._caget(f'{shelf_manager}:Crate:Slot_{slot_number}:' +
                            self._board_temp_rtm,**kwargs)
 
     _board_temp_amc0 = 'BoardTemp:AMC0'
@@ -67,7 +67,7 @@ class SmurfAtcaMonitorMixin(SmurfBase):
             slot_number=self.slot_number
         if atca_epics_root is None:
             shelf_manager=self.shelf_manager
-        return self._caget('{}:Crate:Slot_{}:'.format(shelf_manager,slot_number) +
+        return self._caget(f'{shelf_manager}:Crate:Slot_{slot_number}:' +
                            self._board_temp_amc0,**kwargs)
 
     _board_temp_amc2 = 'BoardTemp:AMC2'
@@ -80,7 +80,7 @@ class SmurfAtcaMonitorMixin(SmurfBase):
             slot_number=self.slot_number
         if atca_epics_root is None:
             shelf_manager=self.shelf_manager
-        return self._caget('{}:Crate:Slot_{}:'.format(shelf_manager,slot_number) +
+        return self._caget(f'{shelf_manager}:Crate:Slot_{slot_number}:' +
                            self._board_temp_amc2,**kwargs)
 
     _junction_temp_fpga = 'JunctionTemp:FPG'
@@ -93,5 +93,5 @@ class SmurfAtcaMonitorMixin(SmurfBase):
             slot_number=self.slot_number
         if atca_epics_root is None:
             shelf_manager=self.shelf_manager
-        return self._caget('{}:Crate:Slot_{}:'.format(shelf_manager,slot_number) +
+        return self._caget(f'{shelf_manager}:Crate:Slot_{slot_number}:' +
                            self._junction_temp_fpga,**kwargs)

--- a/python/pysmurf/client/command/smurf_cmd.py
+++ b/python/pysmurf/client/command/smurf_cmd.py
@@ -47,33 +47,33 @@ def make_runfile(output_dir, row_len=60, num_rows=60, data_rate=60,
             # A bunch of replacements
             if "ctime=<replace>" in line:
                 timestamp = S.get_timestamp()
-                S.log('Adding ctime {}'.format(timestamp))
-                line = line.replace("ctime=<replace>", "ctime={}".format(timestamp))
+                S.log(f'Adding ctime {timestamp}')
+                line = line.replace("ctime=<replace>", f'ctime={timestamp}')
             elif "Date:<replace>" in line:
                 time_string = time.strftime("%a %b %d %H:%M:%S %Y",
                     time.localtime())
-                S.log('Adding date {}'.format(time_string))
-                line = line.replace('Date:<replace>', "Date: {}".format(time_string))
+                S.log(f'Adding date {time_string}')
+                line = line.replace('Date:<replace>', f'Date: {time_string}')
             elif "row_len : <replace>" in line:
-                S.log("Adding row_len {}".format(row_len))
+                S.log(f"Adding row_len {row_len}")
                 line = line.replace('row_len : <replace>',
-                    'row_len : {}'.format(row_len))
+                                    f'row_len : {row_len}')
             elif "num_rows : <replace>" in line:
-                S.log("Adding num_rows {}".format(num_rows))
+                S.log(f"Adding num_rows {num_rows}")
                 line = line.replace('num_rows : <replace>',
-                    'num_rows : {}'.format(num_rows))
+                                    f'num_rows : {num_rows}')
             elif "num_rows_reported : <replace>" in line:
-                S.log("Adding num_rows_reported {}".format(num_rows_reported))
+                S.log(f"Adding num_rows_reported {num_rows_reported}")
                 line = line.replace('num_rows_reported : <replace>',
-                    'num_rows_reported : {}'.format(num_rows_reported))
+                                    f'num_rows_reported : {num_rows_reported}')
             elif "data_rate : <replace>" in line:
-                S.log("Adding data_rate {}".format(data_rate))
+                S.log(f"Adding data_rate {data_rate}")
                 line = line.replace('data_rate : <replace>',
-                    'data_rate : {}'.format(data_rate))
+                                    f'data_rate : {data_rate}')
             line_holder.append(line)
 
     full_path = os.path.join(output_dir,
-        'smurf_status_{}.txt'.format(S.get_timestamp()))
+                             f'smurf_status_{S.get_timestamp()}.txt')
 
     #20181119 mod by dB to dump content of runfile, not path of runfile
     #print(full_path)
@@ -82,7 +82,7 @@ def make_runfile(output_dir, row_len=60, num_rows=60, data_rate=60,
     with open(full_path, "w") as f1:
         f1.writelines(line_holder)
 
-    S.log("Writing to {}".format(full_path))
+    S.log(f"Writing to {full_path}")
     sys.stdout.writelines(line_holder)
 
 def start_acq(S, num_rows, num_rows_reported, data_rate,
@@ -265,7 +265,7 @@ if __name__ == "__main__":
         S.tune(last_tune=True, make_plot=args.tune_make_plot)
 
     if args.use_tune is not None:
-        S.log('Loading old tune from file: {}'.format(args.use_tune))
+        S.log(f'Loading old tune from file: {args.use_tune}')
         S.tune(tune_file = args.use_tune, make_plot=args.tune_make_plot)
 
     if args.tune:
@@ -312,9 +312,9 @@ if __name__ == "__main__":
         iv_bias_low = args.iv_bias_low
         iv_bias_step = args.iv_bias_step
 
-        S.log('bias high {}'.format(iv_bias_high))
-        S.log('bias low {}'.format(iv_bias_low))
-        S.log('bias step {}'.format(iv_bias_step))
+        S.log(f'bias high {iv_bias_high}')
+        S.log(f'bias low {iv_bias_low}')
+        S.log(f'bias step {iv_bias_step}')
         # 20181223: CY took out IV biases in terms of current. Revert if you
         #  decide you want it back
 
@@ -332,7 +332,7 @@ if __name__ == "__main__":
                 high_current_mode=S.high_current_mode_bool,
                 bias_step=iv_bias_step, make_plot=False)
         else: # individual bias group
-            S.log('running slow IV on bias group {}'.format(args.bias_group))
+            S.log(f'running slow IV on bias group {args.bias_group}')
             S.slow_iv_all(bias_groups=np.array([args.bias_group]),
                 wait_time=args.iv_wait_time, bias_high=iv_bias_high,
                 bias_low=iv_bias_low,
@@ -348,9 +348,9 @@ if __name__ == "__main__":
     if args.plc:
         bias_high = np.zeros((8,))
         bias_high[S.all_groups] = args.iv_bias_high
-        S.log('plc bias high {}'.format(bias_high))
-        S.log('plc bias low {}'.format(S.get_tes_bias_bipolar_array()))
-        S.log('plc bias step {}'.format(args.iv_bias_step))
+        S.log(f'plc bias high {bias_high}')
+        S.log(f'plc bias low {S.get_tes_bias_bipolar_array()}')
+        S.log(f'plc bias step {args.iv_bias_step}')
 
         iv_bias_step = np.abs(args.iv_bias_step) * 1.5 # speed this up relative to other mce's
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -4056,7 +4056,7 @@ class SmurfCommandMixin(SmurfBase):
         sg.wait(epics_poll=epics_poll) # wait for change
         uc0=sg.get_values()[user_config0_pv]
         assert ( ( uc0 >> 0) & 1 ),(
-            'Failed to set averaging/clear bit high ' + 
+            'Failed to set averaging/clear bit high ' +
             f'(userConfig0={uc0})')
 
         # toggle bit back to low, keeping all other bits the same

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -67,7 +67,7 @@ class SmurfCommandMixin(SmurfBase):
             `epics.caput` call.
         """
         if new_epics_root is not None:
-            self.log('Temporarily using new epics root: {}'.format(new_epics_root))
+            self.log(f'Temporarily using new epics root: {new_epics_root}')
             old_epics_root = self.epics_root
             self.epics_root = new_epics_root
             cmd = cmd.replace(old_epics_root, self.epics_root)
@@ -77,8 +77,8 @@ class SmurfCommandMixin(SmurfBase):
 
         if wait_before is not None:
             if write_log:
-                self.log('Waiting {:3.2f} seconds before...'.format(wait_before),
-                    self.LOG_USER)
+                self.log(f'Waiting {wait_before:3.2f} seconds before...',
+                         self.LOG_USER)
             time.sleep(wait_before)
 
         if write_log:
@@ -92,7 +92,7 @@ class SmurfCommandMixin(SmurfBase):
 
         if wait_after is not None:
             if write_log:
-                self.log('Waiting {:3.2f} seconds after...'.format(wait_after),
+                self.log(f'Waiting {wait_after:3.2f} seconds after...',
                     self.LOG_USER)
             time.sleep(wait_after)
             if write_log:
@@ -104,7 +104,7 @@ class SmurfCommandMixin(SmurfBase):
         if new_epics_root is not None:
             self.epics_root = old_epics_root
             self.log('Returning back to original epics root'+
-                     ' : {}'.format(self.epics_root))
+                     f' : {self.epics_root}')
 
     def _caget(self, cmd, write_log=False, execute=True, count=None,
                log_level=0, enable_poll=False, disable_poll=False,
@@ -143,7 +143,7 @@ class SmurfCommandMixin(SmurfBase):
             The requested value.
         """
         if new_epics_root is not None:
-            self.log('Temporarily using new epics root: {}'.format(new_epics_root))
+            self.log(f'Temporarily using new epics root: {new_epics_root}')
             old_epics_root = self.epics_root
             self.epics_root = new_epics_root
             cmd = cmd.replace(old_epics_root, self.epics_root)
@@ -157,7 +157,7 @@ class SmurfCommandMixin(SmurfBase):
         # load the data from yml file if provided
         if yml is not None:
             if write_log:
-                self.log('Reading from yml file\n {}'.format(cmd))
+                self.log(f'Reading from yml file\n {cmd}')
             return tools.yaml_parse(yml, cmd)
 
         elif execute and not self.offline:
@@ -173,7 +173,7 @@ class SmurfCommandMixin(SmurfBase):
         if new_epics_root is not None:
             self.epics_root = old_epics_root
             self.log('Returning back to original epics root'+
-                     ' : {}'.format(self.epics_root))
+                     f' : {self.epics_root}')
 
         return ret
 
@@ -411,7 +411,7 @@ class SmurfCommandMixin(SmurfBase):
         """
         triggerPV=self.lmk.format(bay) + 'PwrUpSysRef'
         self._caput(triggerPV, 1, wait_after=5, **kwargs)
-        self.log('{} sent'.format(triggerPV), self.LOG_USER)
+        self.log(f'{triggerPV} sent', self.LOG_USER)
 
     _eta_scan_in_progress = 'etaScanInProgress'
 
@@ -532,7 +532,7 @@ class SmurfCommandMixin(SmurfBase):
         monitorPV=self._cryo_root(band) + self._eta_scan_in_progress
 
         self._caput(triggerPV, 1, wait_after=5, **kwargs)
-        self.log('{} sent'.format(triggerPV), self.LOG_USER)
+        self.log(f'{triggerPV} sent', self.LOG_USER)
 
         if sync_group:
             sg = SyncGroup([monitorPV])
@@ -647,7 +647,7 @@ class SmurfCommandMixin(SmurfBase):
         assert (bay in [0,1]),'bay must be an integer and in [0,1]'
         triggerPV=self.microwave_mux_core.format(bay) + self._selextref
         self._caput(triggerPV, 1, wait_after=5, **kwargs)
-        self.log('{} sent'.format(triggerPV), self.LOG_USER)
+        self.log(f'{triggerPV} sent', self.LOG_USER)
 
     # name changed in Rogue 4 from WriteState to SaveState.  Keeping
     # the write_state function for backwards compatibilty.
@@ -724,7 +724,7 @@ class SmurfCommandMixin(SmurfBase):
         # make sure file exists before setting
 
         if not os.path.exists(val):
-            self.log('Tone file {} does not exist!  Doing nothing!'.format(val),
+            self.log(f'Tone file {val} does not exist!  Doing nothing!',
                      self.LOG_ERROR)
             raise ValueError('Must provide a path to an existing tone file.')
 
@@ -754,7 +754,7 @@ class SmurfCommandMixin(SmurfBase):
             val=self.get_tone_file_path(bay)
 
 
-        self.log('Loading tone file : {}'.format(val),
+        self.log(f'Loading tone file : {val}',
                  self.LOG_USER)
         self._caput(self.dac_sig_gen.format(bay) + self._load_tone_file, val,
             **kwargs)
@@ -2674,7 +2674,7 @@ class SmurfCommandMixin(SmurfBase):
         self._caput(triggerPV,
                     1,
                     **kwargs)
-        self.log('{} sent'.format(triggerPV), self.LOG_USER)
+        self.log(f'{triggerPV} sent', self.LOG_USER)
 
     _dac_axil_addr = 'DacAxilAddr[{}]'
 
@@ -3110,12 +3110,12 @@ class SmurfCommandMixin(SmurfBase):
         nbits=self._rtm_slow_dac_nbits
         if val > 2**(nbits-1)-1:
             val = 2**(nbits-1)-1
-            self.log('Bias too high. Must be <= than 2^{}-1. Setting to '.format(nbits-1) +
-                'max value', self.LOG_ERROR)
+            self.log(f'Bias too high. Must be <= than 2^{nbits-1}-1.  ' +
+                     'Setting to max value', self.LOG_ERROR)
         elif val < -2**(nbits-1):
             val = -2**(nbits-1)
-            self.log('Bias too low. Must be >= than -2^{}. Setting to '.format(nbits-1) +
-                'min value', self.LOG_ERROR)
+            self.log(f'Bias too low. Must be >= than -2^{nbits-1}.  ' +
+                     'Setting to min value', self.LOG_ERROR)
         self._caput(self.rtm_spi_max_root +
                     self._rtm_slow_dac_data.format(dac), val, **kwargs)
 
@@ -3164,13 +3164,15 @@ class SmurfCommandMixin(SmurfBase):
         nbits=self._rtm_slow_dac_nbits
         val=np.array(val)
         if len(np.ravel(np.where(val > 2**(nbits-1)-1))) > 0:
-            self.log('Bias too high for some values. Must be <= 2^{}-1. Setting to '.format(nbits-1) +
-            'max value', self.LOG_ERROR)
+            self.log('Bias too high for some values. Must be ' +
+                     f'<= 2^{nbits-1}-1. Setting to max value',
+                     self.LOG_ERROR)
         val[np.ravel(np.where(val > 2**(nbits-1)-1))] = 2**(nbits-1)-1
 
         if len(np.ravel(np.where(val < - 2**(nbits-1)))) > 0:
-            self.log('Bias too low for some values. Must be >= -2^{}. Setting to '.format(nbits-1) +
-                     'min value', self.LOG_ERROR)
+            self.log('Bias too low for some values. Must be ' +
+                     f'>= -2^{nbits-1}. Setting to min value',
+                     self.LOG_ERROR)
         val[np.ravel(np.where(val < - 2**(nbits-1)))] = -2**(nbits-1)
 
         self._caput(self.rtm_spi_max_root + self._rtm_slow_dac_data_array, val, **kwargs)
@@ -3825,7 +3827,7 @@ class SmurfCommandMixin(SmurfBase):
             The cryo card relays
         """
         if write_log:
-            self.log('Writing relay using cryo_card object. {}'.format(relay))
+            self.log(f'Writing relay using cryo_card object. {relay}')
 
         if enable_poll:
             epics.caput(self.epics_root + self._global_poll_enable, True)
@@ -3851,7 +3853,7 @@ class SmurfCommandMixin(SmurfBase):
 
         if write_log:
             self.log('Setting delatch bit using cryo_card ' +
-                'object. {}'.format(bit))
+                     f'object. {bit}')
         self.C.delatch_bit(bit)
 
         if disable_poll:
@@ -4053,18 +4055,20 @@ class SmurfCommandMixin(SmurfBase):
         self.set_user_config0(uc0 | (1 << 0))
         sg.wait(epics_poll=epics_poll) # wait for change
         uc0=sg.get_values()[user_config0_pv]
-        assert ( ( uc0 >> 0) & 1 ),'Failed to set averaging/clear bit high (userConfig0=%d).'%uc0
+        assert ( ( uc0 >> 0) & 1 ),(
+            'Failed to set averaging/clear bit high ' + 
+            f'(userConfig0={uc0})')
 
         # toggle bit back to low, keeping all other bits the same
         self.set_user_config0(uc0 & ~(1 << 0))
         sg.wait(epics_poll=epics_poll) # wait for change
         uc0=sg.get_values()[user_config0_pv]
-        assert ( ~( uc0 >> 0) & 1 ),'Failed to set averaging/clear bit low after setting it high (userConfig0=%d).'%(uc0)
+        assert ( ~( uc0 >> 0) & 1 ),(
+            'Failed to set averaging/clear bit low after setting ' +
+            f'it high (userConfig0={uc0}).')
 
-        self.log('Successfully toggled averaging/clearing bit (userConfig[0]=%d).'%uc0,
-                 self.LOG_USER)
-
-
+        self.log('Successfully toggled averaging/clearing bit ' +
+                 f'(userConfig[0]={uc0}).',self.LOG_USER)
 
     # Triggering commands
     _trigger_width = 'EvrV2TriggerReg[{}]:Width'

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -117,10 +117,10 @@ class SmurfIVMixin(SmurfBase):
         time.sleep(wait_time) # loops are in pyrogue now, which are faster?
 
         datafile = self.stream_data_on()
-        self.log('writing to {}'.format(datafile))
+        self.log(f'writing to {datafile}')
 
         for b in bias:
-            self.log('Bias at {:4.3f}'.format(b))
+            self.log(f'Bias at {b:4.3f}')
             self.set_tes_bias_bipolar_array(b * bias_group_bool)
             time.sleep(wait_time) # loops are now in pyrogue, so no division
 
@@ -145,7 +145,7 @@ class SmurfIVMixin(SmurfBase):
         iv_raw_data['plot_dir'] = self.plot_dir
         fn_iv_raw_data = os.path.join(self.output_dir, basename +
             '_iv_raw_data.npy')
-        self.log('Writing IV metadata to {}.'.format(fn_iv_raw_data))
+        self.log(f'Writing IV metadata to {fn_iv_raw_data}.')
 
         path = os.path.join(self.output_dir, fn_iv_raw_data)
         np.save(path, iv_raw_data)
@@ -244,7 +244,7 @@ class SmurfIVMixin(SmurfBase):
         self.log('Starting TES bias ramp.', self.LOG_USER)
 
         datafile = self.stream_data_on()
-        self.log('writing to {}'.format(datafile))
+        self.log(f'Writing to {datafile}')
 
         # actually set the arrays
         for step in np.arange(np.shape(bias_sweep_array)[1]):
@@ -339,7 +339,7 @@ class SmurfIVMixin(SmurfBase):
         bias_line_resistance : float or None, optional, default None
             The resistance of the bias lines in Ohms.
         """
-        self.log('Analyzing from file: {}'.format(fn_iv_raw_data))
+        self.log(f'Analyzing from file: {fn_iv_raw_data}')
 
         # Extract data from dict
         iv_raw_data = np.load(fn_iv_raw_data, allow_pickle=True).item()
@@ -417,8 +417,8 @@ class SmurfIVMixin(SmurfBase):
                 if grid_on:
                     ax.grid()
 
-                ax.set_title('Band {}, Group {}, Ch {:03}'.format(np.unique(band),
-                    bias_group, ch))
+                ax.set_title(f'Band {np.unique(band)}, ' +
+                             f'Group {bias_group}, Ch {ch:03}')
                 plt.tight_layout()
 
                 bg_str = ""
@@ -506,36 +506,48 @@ class SmurfIVMixin(SmurfBase):
             rn_array_mOhm = np.array(rn_list)/1e-3
             ax_rn.hist(rn_array_mOhm, bins=20, color=color_hist)
             ax_rn.set_xlabel(r'$R_N$ [$\mathrm{m}\Omega$]')
-            ax_rn.axvline(rn_median/1e-3, linestyle='--', color=color_median,
-                label=r'Median = {:.0f}'.format(rn_median/1e-3) +
+            ax_rn.axvline(
+                rn_median/1e-3, linestyle='--',
+                color=color_median,
+                label=f'Median = {rn_median*1000.:.0f}' +
                 r' $\mathrm{m}\Omega$')
             ax_rn.legend(loc='best')
 
             ax_vbias.hist(v_bias_target_list, bins=20, color=color_hist)
-            ax_vbias.axvline(v_bias_target_median, linestyle='--',
-                        color=color_median,
-                        label='Median = {:.2f} V'.format(v_bias_target_median))
-            ax_vbias.set_xlabel(r'Commanded voltage bias [V] for $R = $' +
-                '{:.0f}'.format(R_op_target/1e-3) +
+            ax_vbias.axvline(
+                v_bias_target_median, linestyle='--',
+                color=color_median,
+                label=f'Median = {v_bias_target_median:.2f} V')
+            ax_vbias.set_xlabel(
+                r'Commanded voltage bias [V] for $R = $' +
+                f'{R_op_target*1000.:.0f}' +
                 r' $\mathrm{m}\Omega$')
             ax_vbias.legend(loc='best')
 
             ax_ptrans.hist(p_trans_list, bins=20, color=color_hist)
-            ax_ptrans.axvline(ptrans_median, linestyle='--', color=color_median,
-                label=r'Median = {:.1f} pW'.format(ptrans_median))
-            ax_ptrans.set_xlabel('In-transition electrical power [pW]')
+            ax_ptrans.axvline(
+                ptrans_median, linestyle='--',
+                color=color_median,
+                label=f'Median = {ptrans_median:.1f} pW')
+            ax_ptrans.set_xlabel(
+                'In-transition electrical power [pW]')
             ax_ptrans.legend(loc='best')
 
             ax_si.hist(si_target_list, bins=20)
-            ax_si.axvline(si_target_median, linestyle='--', color=color_median,
-                label='Median = {:.2f}'.format(si_target_median) +
+            ax_si.axvline(
+                si_target_median, linestyle='--',
+                color=color_median,
+                label=f'Median = {si_target_median:.2f}' +
                 r' $\mu\mathrm{V}^{-1}$')
-            ax_si.axvline(si_goal, linestyle='--', color=color_goal,
+            ax_si.axvline(
+                si_goal, linestyle='--',
+                color=color_goal,
                 label=r'$-\mathrm{med}(V_\mathrm{TES})^{-1} = $' +
-                '{:.2f}'.format(si_goal) +
+                f'{si_goal:.2f}' +
                 r' $\mu\mathrm{V}^{-1}$')
-            ax_si.set_xlabel(r'Responsivity [$\mu\mathrm{V}^{-1}$] at $R = $' +
-                '{:.0f}'.format(R_op_target/1e-3) +
+            ax_si.set_xlabel(
+                r'Responsivity [$\mu\mathrm{V}^{-1}$] at $R = $' +
+                f'{R_op_target*1000.:.0f}' +
                 r' $\mathrm{m}\Omega$')
             plt.legend(loc='best')
 
@@ -543,9 +555,11 @@ class SmurfIVMixin(SmurfBase):
             fig.subplots_adjust(top=0.925)
 
             # Title
-            plt.suptitle('{}, band {}, group{}'.format(basename,
-                np.unique(band),bias_group))
-            iv_hist_filename = os.path.join(plot_dir,
+            plt.suptitle(
+                f'{basename}, band {np.unique(band)}, ' +
+                f'group{bias_group}')
+            iv_hist_filename = os.path.join(
+                plot_dir,
                 f'{basename}_IV_hist{plotname_append}.png')
 
             # Save the figure
@@ -774,24 +788,26 @@ class SmurfIVMixin(SmurfBase):
             title = ""
             plot_name = "IV_curve"
             if band is not None:
-                title = title + 'Band {}'.format(band)
-                plot_name = plot_name + '_b{}'.format(band)
+                title = title + f'Band {band}'
+                plot_name = plot_name + f'_b{band}'
             if bias_group is not None:
-                title = title + ' BG {}'.format(bias_group)
-                plot_name = plot_name + '_bg{}'.format(bias_group)
+                title = title + f' BG {bias_group}'
+                plot_name = plot_name + f'_bg{bias_group}'
             if channel is not None:
-                title = title + ' Ch {:03}'.format(channel)
-                plot_name = plot_name + '_ch{:03}'.format(channel)
+                title = title + f' Ch {channel:03}'
+                plot_name = plot_name + f'_ch{channel:03}'
             if basename is None:
                 basename = self.get_timestamp()
             if band is not None and channel is not None:
                 if self.offline:
-                    self.log("Offline mode does not know resonator frequency." +
-                        " Not adding to title.")
+                    self.log(
+                        "Offline mode does not know resonator " +
+                        "frequency.  Not adding to title.")
                 else:
-                    title += ', {:.2f} MHz'.format(self.channel_to_freq(band, channel))
-            title += r', $R_\mathrm{sh}$ = ' + '${:.2f}$ '.format(R_sh*1.0E3) + \
-                r'$\mathrm{m}\Omega$'
+                    channel_freq=self.channel_to_freq(band, channel)
+                    title += f', {channel_freq:.2f} MHz'
+            title += (r', $R_\mathrm{sh}$ = ' + f'${R_sh*1.0E3:.2f}$ ' + 
+                      r'$\mathrm{m}\Omega$')
             plot_name = basename + '_' + plot_name
             title = basename + ' ' + title
             plot_name += plotname_append + '.png'
@@ -809,21 +825,27 @@ class SmurfIVMixin(SmurfBase):
             ax_ii.set_ylabel(r'$I_\mathrm{TES}$ $[\mu A]$')
 
             # Plot normal branch fit
-            ax_ii.plot(i_bias_bin, norm_fit[0] * i_bias_bin , linestyle='--',
+            ax_ii.plot(i_bias_bin, norm_fit[0] * i_bias_bin ,
+                       linestyle='--',
                        color=color_norm, label=r'$R_N$' +
-                       '  = ${:.0f}$'.format(R_n/1e-3) +
+                       f'  = ${R_n*1000.:.0f}$' +
                        r' $\mathrm{m}\Omega$')
             # Plot superconducting branch fit
-            ax_ii.plot(i_bias_bin[:sc_idx],
-                sc_fit[0] * i_bias_bin[:sc_idx] + sc_fit[1], linestyle='--',
-                color=color_sc, label=r'$R_L$' +
-                    ' = ${:.0f}$'.format(R_L/1e-6) +
-                    r' $\mu\mathrm{\Omega}$')
+            ax_ii.plot(
+                i_bias_bin[:sc_idx],
+                sc_fit[0] * i_bias_bin[:sc_idx] + sc_fit[1],
+                linestyle='--',
+                color=color_sc,
+                label=(
+                    r'$R_L$' +
+                    f' = ${R_L/1e-6:.0f}$' +
+                    r' $\mu\mathrm{\Omega}$'))
 
-            label_target = r'$R = {:.0f}$ '.format(R_op_target/1e-3) + \
-                r'$\mathrm{m}\Omega$'
-            label_rfrac = '{:.2f}-{:.2f}'.format(R_frac_min,
-                R_frac_max) + r'$R_N$'
+            label_target = (
+                r'$R = ' + f'{R_op_target/1e-3:.0f}' + r'$ ' +
+                r'$\mathrm{m}\Omega$')
+            label_rfrac = (f'{R_frac_min:.2f}-{R_frac_max:.2f}' +
+                           r'$R_N$')
 
             for i in range(len(ax_i)):
                 if ax_i[i] == ax_ri:
@@ -869,8 +891,9 @@ class SmurfIVMixin(SmurfBase):
             vb_min = np.min(v_bias)
             delta_v = float(vb_max - vb_min)/n_ticks
             axt.set_xticks(np.arange(ib_min, ib_max+delta, delta))
-            axt.set_xticklabels(['{:.2f}'.format(x) for x in
-                np.arange(vb_min, vb_max+delta_v, delta_v)])
+            axt.set_xticklabels(
+                [f'{x:.2f}' for x in
+                 np.arange(vb_min, vb_max+delta_v, delta_v)])
             axt.set_xlabel(r'Commanded $V_b$ [V]')
 
             ax_si.plot(i_bias_bin[:-1],si,color=color_meas)
@@ -899,7 +922,7 @@ class SmurfIVMixin(SmurfBase):
                 if plot_dir is None:
                     plot_dir = self.plot_dir
                 plot_filename = os.path.join(plot_dir, plot_name)
-                self.log('Saving IV plot to {}'.format(plot_filename))
+                self.log(f'Saving IV plot to {plot_filename}')
                 plt.savefig(plot_filename,bbox_inches='tight')
                 self.pub.register_file(plot_filename, 'iv', plot=True)
 
@@ -952,7 +975,7 @@ class SmurfIVMixin(SmurfBase):
             are on and exceed phase_excursion_min.
         """
 
-        self.log('Analyzing plc from file: {}'.format(fn_plc_raw_data))
+        self.log(f'Analyzing plc from file: {fn_plc_raw_data}')
 
         plc_raw_data = np.load(fn_plc_raw_data).item()
         bias_group = plc_raw_data['band']
@@ -970,13 +993,13 @@ class SmurfIVMixin(SmurfBase):
         for c, (b, ch) in enumerate(zip(band, chans)):
             if (channels is not None) and (ch not in channels):
                 continue
-            self.log('Analyzing band {} channel {}'.format(b,ch))
+            self.log(f'Analyzing band {b} channel {ch}')
             ch_idx = mask[b,ch]
             phase = phase_all[ch_idx]
 
             phase_excursion = max(phase) - min(phase)
             if phase_excursion < phase_excursion_min:
-                self.log('Skipping ch {}: phase excursion < min'.format(ch))
+                self.log(f'Skipping ch {ch}: phase excursion < min')
                 continue
             phase_excursion_list.append(phase_excursion)
 
@@ -994,8 +1017,8 @@ class SmurfIVMixin(SmurfBase):
                 ax.set_xlabel('Sample Num')
                 ax.set_ylabel('Phase [rad.]')
 
-                ax.set_title('Band {}, Group {}, Ch {:03}'.format(np.unique(band),
-                    bias_group, ch)) # this is not going to be very useful...
+                ax.set_title(f'Band {np.unique(band)}, ' +
+                             f'Group {bias_group}, Ch {ch:03}')
                 plt.tight_layout()
 
                 if save_plot:
@@ -1003,8 +1026,9 @@ class SmurfIVMixin(SmurfBase):
                     for bg in np.unique(bias_group):
                         bg_str = bg_str + str(bg)
 
-                    plot_name = basename + \
-                        'plc_stream_b{}_g{}_ch{:03}.png'.format(b, bg_str, ch)
+                    plot_name = (
+                        basename +
+                        f'plc_stream_b{b}_g{bg_str}_ch{ch:03}.png')
                     path = os.path.join(plot_dir, plot_name)
                     plt.savefig(path, bbox_inches='tight', dpi=300)
                     self.pub.register_file(path, 'plc_stream', plot=True)
@@ -1109,9 +1133,12 @@ class SmurfIVMixin(SmurfBase):
             ax_pr.grid()
 
             # Plot name
-            plot_name = basename_hot + '_' + basename_cold + f'_optEff_g{group}_ch{ch:03}.png'
+            plot_name = (
+                basename_hot + '_' + basename_cold +
+                f'_optEff_g{group}_ch{ch:03}.png')
             plot_filename = os.path.join(plot_dir, plot_name)
-            self.log('Saving optical-efficiency plot to {}'.format(plot_filename))
+            self.log(
+                f'Saving optical-efficiency plot to {plot_filename}')
             plt.savefig(plot_filename, bbox_inches='tight', dpi=300)
 
             # Publish
@@ -1125,9 +1152,10 @@ class SmurfIVMixin(SmurfBase):
         dPdT_median = np.median(dPdT_list)
         plt.title(f'Group {group}, median = {dPdT_median:.3f} pW/K '+
             f'({n_outliers} outliers not plotted)')
-        plot_name = basename_hot + '_' + basename_cold + '_dPdT_hist_g{}.png'.format(group)
+        plot_name = basename_hot + '_' + basename_cold + f'_dPdT_hist_g{group}.png'
         hist_filename = os.path.join(plot_dir,plot_name)
-        self.log('Saving optical-efficiency histogram to {}'.format(hist_filename))
+        self.log(
+            f'Saving optical-efficiency histogram to {hist_filename}')
         plt.savefig(hist_filename, bbox_inches='tight', dpi=300)
         self.pub.register_file(hist_filename, 'opt_efficiency', plot=True)
         plt.close()

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -806,7 +806,7 @@ class SmurfIVMixin(SmurfBase):
                 else:
                     channel_freq=self.channel_to_freq(band, channel)
                     title += f', {channel_freq:.2f} MHz'
-            title += (r', $R_\mathrm{sh}$ = ' + f'${R_sh*1.0E3:.2f}$ ' + 
+            title += (r', $R_\mathrm{sh}$ = ' + f'${R_sh*1.0E3:.2f}$ ' +
                       r'$\mathrm{m}\Omega$')
             plot_name = basename + '_' + plot_name
             title = basename + ' ' + title

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -256,8 +256,9 @@ class SmurfNoiseMixin(SmurfBase):
                         transform=ax.transAxes, fontsize=10)
                 ax.set_xlabel(r'Mean noise [$\mathrm{pA}/\sqrt{\mathrm{Hz}}$]')
 
-                plot_name = basename + \
-                            '{l}_{h}_noise_hist{plotname_append}.png'
+                plot_name = (
+                    basename +
+                    f'{l}_{h}_noise_hist{plotname_append}.png')
                 plt.savefig(os.path.join(self.plot_dir, plot_name),
                     bbox_inches='tight')
                 if show_plot:
@@ -274,7 +275,8 @@ class SmurfNoiseMixin(SmurfBase):
                 n_attempt = len(channels)
 
                 fig,ax = plt.subplots(1,3, figsize=(10,6))
-                fig.suptitle(f'{basename} noise parameters' +
+                fig.suptitle(
+                    f'{basename} noise parameters' +
                     f' ({n_fit} fit of {n_attempt} attempted)')
                 ax[0].hist(wl_list,
                     bins=np.logspace(np.floor(np.log10(np.min(wl_list))),
@@ -1302,7 +1304,7 @@ class SmurfNoiseMixin(SmurfBase):
                       plt.title(basename +
                                 f": Band {np.unique(band)}, Group " +
                                 f"{fig_title_string.strip(',')}, {n_analyzed}" +
-                                "channels")                      
+                                "channels"))
             plt.xticks(xtick_locs,xtick_labels)
             plt.xlabel('Commanded bias voltage [V]')
             plt.plot(xtick_locs,NEP_est_median_list, linestyle='--', marker='o',

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -165,9 +165,9 @@ class SmurfNoiseMixin(SmurfBase):
                     good_fit = True
                 if write_log:
                     self.log(f'{c+1}. b{b}ch{ch:03}:' +
-                         ' white-noise level = {:.2f}'.format(wl) +
-                         ' pA/rtHz, n = {:.2f}'.format(n) +
-                         ', f_knee = {:.2f} Hz'.format(f_knee))
+                         f' white-noise level = {wl:.2f}' +
+                         f' pA/rtHz, n = {n:.2f}' +
+                         f', f_knee = {f_knee:.2f} Hz')
             except Exception as e:
                 if write_log:
                     self.log(f'{c+1} b{b}ch{ch:03}: bad fit to noise model')
@@ -252,13 +252,12 @@ class SmurfNoiseMixin(SmurfBase):
             for i, (l, h) in enumerate(zip(low_freq, high_freq)):
                 fig, ax = plt.subplots(1, figsize=(10,6))
                 ax.hist(noise_floors[i,~np.isnan(noise_floors[i])], bins=bins)
-                ax.text(0.03, 0.95, '{:3.2f}'.format(l) + '-' +
-                    '{:3.2f} Hz'.format(h),
-                    transform=ax.transAxes, fontsize=10)
+                ax.text(0.03, 0.95, f'{l:3.2f}' + '-' + f'{h:3.2f} Hz',
+                        transform=ax.transAxes, fontsize=10)
                 ax.set_xlabel(r'Mean noise [$\mathrm{pA}/\sqrt{\mathrm{Hz}}$]')
 
                 plot_name = basename + \
-                    '{}_{}_noise_hist{}.png'.format(l, h, plotname_append)
+                            '{l}_{h}_noise_hist{plotname_append}.png'
                 plt.savefig(os.path.join(self.plot_dir, plot_name),
                     bbox_inches='tight')
                 if show_plot:
@@ -384,7 +383,7 @@ class SmurfNoiseMixin(SmurfBase):
         datafiles = np.array([])
         channel = np.array([])
         for i, t in enumerate(tones):
-            self.log('Measuring for tone power {}'.format(t))
+            self.log(f'Measuring for tone power {t}')
 
             # Tune the band with the new drive power
             self.tune_band_serial(band, drive=t,
@@ -594,12 +593,13 @@ class SmurfNoiseMixin(SmurfBase):
         self.make_dir(psd_dir)
 
         timestamp = self.get_timestamp()
-        fn_var_values = os.path.join(psd_dir, '{}_{}.txt'.format(timestamp,var))
+        fn_var_values = os.path.join(psd_dir,
+                                     f'{timestamp}_{var}.txt')
 
 
         np.savetxt(fn_var_values, var_range)
         # Is this an accurate tag?
-        self.pub.register_file(fn_var_values, 'noise_vs_{}'.format(var),
+        self.pub.register_file(fn_var_values, f'noise_vs_{var}',
                                format='txt')
 
         datafiles = np.array([], dtype=str)
@@ -608,7 +608,7 @@ class SmurfNoiseMixin(SmurfBase):
         actually_overbias = True
         for v in var_range:
             if var in biasaliases:
-                self.log('Bias {}'.format(v))
+                self.log(f'Bias {v}')
                 if type(kwargs['bias_group']) is int: # only received one group
                     self.overbias_tes(kwargs['bias_group'], tes_bias=v,
                                  high_current_mode=kwargs['high_current_mode'],
@@ -629,7 +629,7 @@ class SmurfNoiseMixin(SmurfBase):
             if var in amplitudealiases:
                 unit_override=''
                 xlabel_override='Tone amplitude [unit-less]'
-                self.log('Retuning at tone amplitude {}'.format(v))
+                self.log(f'Retuning at tone amplitude {v}')
                 self.set_amplitude_scale_array(band,
                     np.array(self.get_amplitude_scale_array(band)*v/
                         np.max(self.get_amplitude_scale_array(band)),dtype=int))
@@ -642,12 +642,12 @@ class SmurfNoiseMixin(SmurfBase):
             self.log('Taking data')
             datafile = self.take_stream_data(meas_time)
             datafiles = np.append(datafiles, datafile)
-            self.log('datafile {}'.format(datafile))
+            self.log(f'datafile {datafile}')
 
         self.log(f'Done with noise vs {var}')
 
         fn_datafiles = os.path.join(psd_dir,
-            '{}_datafiles.txt'.format(timestamp))
+                                    f'{timestamp}_datafiles.txt')
 
         np.savetxt(fn_datafiles,datafiles, fmt='%s')
         self.pub.register_file(fn_datafiles, 'datafiles', format='txt')
@@ -1245,11 +1245,12 @@ class SmurfNoiseMixin(SmurfBase):
             r' [$\mathrm{pA}/\sqrt{\mathrm{Hz}}$]')
         plt.ylim(10**bin_min, 10**bin_max)
         plt.title(basename +
-            ': Band {}, Group {}, {} channels'.format(np.unique(band),
-                fig_title_string.strip(','),n_analyzed))
+                  f": Band {np.unique(band)}, Group " +
+                  f"{fig_title_string.strip(',')}, {n_analyzed}" +
+                  "channels")
         xtick_labels = []
         for bs in bias:
-            xtick_labels.append('{}'.format(bs))
+            xtick_labels.append(f'{bs}')
         xtick_locs = np.arange(len(bias)-1,-1,-1) + 0.5
         plt.xticks(xtick_locs, xtick_labels)
         plt.xlabel('Commanded bias voltage [V]')
@@ -1297,10 +1298,11 @@ class SmurfNoiseMixin(SmurfBase):
             plt.yscale('log')
             plt.ylabel(f'NEP {ylabel_summary}' +
                 r' [$\mathrm{aW}/\sqrt{\mathrm{Hz}}$]')
-            plt.ylim(10**bin_NEP_min,10**bin_NEP_max)
             plt.title(basename +
-                ': Band {}, Group {}, {} channels'.format(np.unique(band),
-                    fig_title_string.strip(','), n_analyzed))
+                      plt.title(basename +
+                                f": Band {np.unique(band)}, Group " +
+                                f"{fig_title_string.strip(',')}, {n_analyzed}" +
+                                "channels")                      
             plt.xticks(xtick_locs,xtick_labels)
             plt.xlabel('Commanded bias voltage [V]')
             plt.plot(xtick_locs,NEP_est_median_list, linestyle='--', marker='o',
@@ -1435,7 +1437,7 @@ class SmurfNoiseMixin(SmurfBase):
         ret = {'all': filename}
 
         for i, ch in enumerate(channel):
-            self.log('ch {:03} - {} of {}'.format(ch, i+1, n_channel))
+            self.log(f'ch {ch:03} - {i+1} of {n_channel}')
             self.band_off(band)
             self.flux_ramp_on()
             self.set_amplitude_scale_channel(band, ch, drive)
@@ -1471,7 +1473,7 @@ class SmurfNoiseMixin(SmurfBase):
         wl_diff = np.zeros(len(keys))
 
         for i, k in enumerate(ret.keys()):
-            self.log('{} : {}'.format(k, ret[k]))
+            self.log(f'{k} : {ret[k]}')
             tc, dc, mc = self.read_stream_data(ret[k])
             dc *= self._pA_per_phi0/(2*np.pi)
             band, channel = np.where(mc != -1)  # there should be only one
@@ -1670,14 +1672,17 @@ class SmurfNoiseMixin(SmurfBase):
                 basename, _ = os.path.splitext(os.path.basename(d))
                 dirname = os.path.dirname(d)
 
-                self.log(os.path.join(psd_dir, basename +
-                    '_psd_ch{:03}.txt'.format(ch)))
+                self.log(
+                    os.path.join(psd_dir, basename +
+                                 f'_psd_ch{ch:03}.txt'))
 
                 # Catch when there is no file
                 try:
                     # Load the PSD data
-                    f, Pxx =  np.loadtxt(os.path.join(psd_dir, basename +
-                        '_psd_ch{:03}.txt'.format(ch)))
+                    f, Pxx =  np.loadtxt(
+                        os.path.join(
+                            psd_dir, basename +
+                            f'_psd_ch{ch:03}.txt'))
 
                     # smooth Pxx for plotting
                     if smooth_len >= 3:
@@ -1925,7 +1930,7 @@ class SmurfNoiseMixin(SmurfBase):
             y = i // n_col
             x = i % n_col
             ax[y,x].plot(vh[i])
-            ax[y,x].text(0.04, 0.91, '{}'.format(i), transform=ax[y,x].transAxes)
+            ax[y,x].text(0.04, 0.91, f'{i}', transform=ax[y,x].transAxes)
 
         plt.tight_layout()
 

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3670,7 +3670,7 @@ class SmurfTuneMixin(SmurfBase):
         """
         timestamp = self.get_timestamp()
         savedir = os.path.join(self.tune_dir, timestamp+"_tune")
-        self.log('Saving to : {}.npy'.format(savedir))
+        self.log(f'Saving to : {savedir}.npy')
         np.save(savedir, self.freq_resp)
         self.pub.register_file(savedir, 'tune', format='npy')
 
@@ -3698,7 +3698,7 @@ class SmurfTuneMixin(SmurfBase):
         """
         if filename is None and last_tune:
             filename = self.last_tune()
-            self.log('Defaulting to last tuning: {}'.format(filename))
+            self.log(f'Defaulting to last tuning: {filename}')
         elif filename is not None and last_tune:
             self.log('filename explicitly given. Overriding last_tune bool in load_tune.')
 
@@ -3708,7 +3708,7 @@ class SmurfTuneMixin(SmurfBase):
         if override:
             if band is None:
                 bands_in_file=list(fs.keys())
-                self.log('Loading tune data for all bands={}.'.format(str(bands_in_file)))
+                self.log(f'Loading tune data for all bands={bands_in_file}.')
                 self.freq_resp = fs
                 # Load all tune data for all bands in file.  only
                 # update tune_file if both band are loaded from the

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -85,17 +85,17 @@ class SmurfTuneMixin(SmurfBase):
         if load_tune:
             if last_tune:
                 tune_file = self.last_tune()
-                self.log('Last tune is : {}'.format(tune_file))
+                self.log(f'Last tune is : {tune_file}')
             elif tune_file is None:
                 tune_file = tune_cfg.get('default_tune')
-                self.log('Loading default tune file: {}'.format(tune_file))
+                self.log(f'Loading default tune file: {tune_file}')
             self.load_tune(tune_file)
 
         # Runs find_freq and setup_notches. This takes forever.
         else:
             cfg = self.config.get('init')
             for b in bands:
-                drive = cfg.get('band_{}'.format(b)).get('amplitude_scale')
+                drive = cfg.get(f'band_{b}').get('amplitude_scale')
                 self.find_freq(b,
                     drive_power=drive)
                 self.setup_notches(b, drive=drive,
@@ -104,7 +104,7 @@ class SmurfTuneMixin(SmurfBase):
         # Runs tune_band_serial to re-estimate eta params
         if retune:
             for b in bands:
-                self.log('Running tune band serial on band {}'.format(b))
+                self.log(f'Running tune band serial on band {b}')
                 self.tune_band_serial(b, from_old_tune=load_tune,
                     old_tune=tune_file, make_plot=make_plot,
                     show_plot=show_plot, save_plot=save_plot,
@@ -113,7 +113,7 @@ class SmurfTuneMixin(SmurfBase):
         # Starts tracking and runs check_lock to prune bad resonators
         if track_and_check:
             for b in bands:
-                self.log('Tracking and checking band {}'.format(b))
+                self.log(f'Tracking and checking band {b}')
                 self.track_and_check(b, fraction_full_scale=fraction_full_scale,
                     f_min=f_min, f_max=f_max, df_max=df_max, make_plot=make_plot,
                     save_plot=save_plot, show_plot=show_plot)
@@ -225,9 +225,10 @@ class SmurfTuneMixin(SmurfBase):
             }
 
         if save_data:
-            self.log('Saving resonances to {}'.format(self.output_dir))
-            path = os.path.join(self.output_dir,
-                                '{}_b{}_resonances'.format(timestamp, band))
+            self.log(f'Saving resonances to {self.output_dir}')
+            path = os.path.join(
+                self.output_dir,
+                f'{timestamp}_b{band}_resonances')
             np.save(path, resonances)
             self.pub.register_file(path, 'resonances', format='npyt')
 
@@ -243,7 +244,7 @@ class SmurfTuneMixin(SmurfBase):
 
         self.freq_resp[band]['resonances'] = resonances
         if drive is None:
-            drive = self.config.get('init').get('band_{}'.format(band)).get('amplitude_scale')
+            drive = self.config.get('init').get(f'band_{band}').get('amplitude_scale')
 
         # Add tone amplitude to tuning dictionary
         self.freq_resp[band]['drive'] = drive
@@ -376,8 +377,8 @@ class SmurfTuneMixin(SmurfBase):
                 self.freq_resp[band]['resonances'] = resonances
 
         if drive is None:
-            drive = \
-                self.config.get('init')['band_{}'.format(band)]['amplitude_scale']
+            drive = (
+                self.config.get('init')[f'band_{band}']['amplitude_scale'])
         self.freq_resp[band]['drive'] = drive
         self.freq_resp[band]['full_band_resp'] = {}
         if freq is not None:
@@ -482,7 +483,7 @@ class SmurfTuneMixin(SmurfBase):
             ax[0,0].set_xlim((0, 128))
             ax[0,0].set_xlabel('Subband')
             ax[0,0].set_ylabel('# Res')
-            ax[0,0].text(.02, .92, 'Total: {}'.format(len(sb)),
+            ax[0,0].text(.02, .92, f'Total: {len(sb)}',
                          fontsize=10, transform=ax[0,0].transAxes)
 
             # Eta stuff
@@ -508,13 +509,13 @@ class SmurfTuneMixin(SmurfBase):
             ax[1,1].set_xlabel('Freq [MHz]')
             ax[1,1].set_ylabel('Eta phase')
 
-            fig.suptitle('Band {} {}'.format(band, timestamp))
+            fig.suptitle(f'Band {band} {timestamp}')
             plt.subplots_adjust(left=.08, right=.95, top=.92, bottom=.08,
                                 wspace=.21, hspace=.21)
 
             if save_plot:
-                save_name = '{}_tune_summary{}.png'.format(timestamp,
-                    plotname_append)
+                save_name = (
+                    f'{timestamp}_tune_summary{plotname_append}.png')
                 path = os.path.join(self.plot_dir, save_name)
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'tune', plot=True)
@@ -557,9 +558,9 @@ class SmurfTuneMixin(SmurfBase):
                         if channel not in channels:
                             continue
                         else:
-                            self.log('Eta plot for channel {}'.format(channel))
+                            self.log(f'Eta plot for channel {channel}')
                     else:
-                        self.log('Eta plot {} of {}'.format(k+1, n_keys))
+                        self.log(f'Eta plot {k+1} of {n_keys}')
                         self.plot_eta_fit(r['freq_eta_scan'], r['resp_eta_scan'],
                             eta=r['eta'], eta_mag=r['eta_mag'],
                             eta_phase_deg=r['eta_phase'], band=band, res_num=k,
@@ -735,8 +736,9 @@ class SmurfTuneMixin(SmurfBase):
             ax[0].set_title(timestamp)
 
             if save_plot:
-                path = os.path.join(self.plot_dir,
-                    '{}_b{}_full_band_resp_raw.png'.format(timestamp, band))
+                path = os.path.join(
+                    self.plot_dir,
+                    f'{timestamp}_b{band}_full_band_resp_raw.png')
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'response', plot=True)
                 plt.close()
@@ -750,8 +752,10 @@ class SmurfTuneMixin(SmurfBase):
             ax.set_title(f'full_band_resp {timestamp}')
             plt.tight_layout()
             if save_plot:
-                plot_path = os.path.join(self.plot_dir,
-                    '{}_b{}_full_band_resp.png'.format(timestamp, band))
+                plot_path = (
+                    os.path.join(
+                        self.plot_dir,
+                        f'{timestamp}_b{band}_full_band_resp.png'))
 
                 plt.savefig(plot_path, bbox_inches='tight')
                 self.pub.register_file(plot_path, 'response', plot=True)
@@ -948,9 +952,9 @@ class SmurfTuneMixin(SmurfBase):
             if save_plot:
                 save_name = timestamp
                 if band is not None:
-                    save_name = save_name + '_b{}'.format(int(band))
+                    save_name = save_name + f'_b{band}'
                 if subband is not None:
-                    save_name = save_name + '_sb{}'.format(int(subband))
+                    save_name = save_name + f'_sb{subband}'
                 save_name = save_name + '_find_freq' + plotname_append + '.png'
                 path = os.path.join(self.plot_dir, save_name)
                 plt.savefig(path, bbox_inches='tight', dpi=300)
@@ -969,7 +973,7 @@ class SmurfTuneMixin(SmurfBase):
             width = (subband_freq[1] - subband_freq[0])
 
             for sb, sbf in zip(subbands, subband_freq):
-                self.log('Making plot for subband {}'.format(sb))
+                self.log(f'Making plot for subband {sb}')
                 idx = np.logical_and(plot_freq_mhz > sbf - plot_width/2.,
                     plot_freq_mhz < sbf + plot_width/2.)
                 if np.sum(idx) > 1:
@@ -1020,8 +1024,7 @@ class SmurfTuneMixin(SmurfBase):
                     ax[1].set_xlabel('Freq [MHz]')
                     ax[1].set_ylabel('Amp')
 
-                    ax[0].set_title('Band {} Subband {}'.format(band,
-                                                                sb, sbf))
+                    ax[0].set_title('Band {band} Subband {sb}')
 
                     if subband_plot_with_slow:
                         ff = np.arange(-3, 3.1, .05)
@@ -1038,7 +1041,7 @@ class SmurfTuneMixin(SmurfBase):
                         self.pub.register_file(path, 'find_freq', plot=True)
                         plt.close()
                 else:
-                    self.log('No data for subband {}'.format(sb))
+                    self.log(f'No data for subband {sb}')
 
         return freq[peak]
 
@@ -1184,7 +1187,7 @@ class SmurfTuneMixin(SmurfBase):
                     'Highly recommended that you input a non-default name')
                 save_name = 'find_peak.png'
             else:
-                self.log('Plotting saved to {}'.format(save_name))
+                self.log(f'Plotting saved to {save_name}')
 
             path = os.path.join(self.plot_dir, save_name)
             plt.savefig(path, bbox_inches='tight')
@@ -1300,7 +1303,7 @@ class SmurfTuneMixin(SmurfBase):
         if make_plot:
             if len(plot_chans) == 0:
                 self.log('Making plot for band' +
-                    ' {} res {:03}'.format(band, res_num))
+                    f' {band} res {res_num:03}')
                 self.plot_eta_fit(freq[left_plot:right_plot],
                     resp[left_plot:right_plot],
                     eta=eta, eta_mag=eta_mag, r2=r2,
@@ -1308,8 +1311,9 @@ class SmurfTuneMixin(SmurfBase):
                     res_num=res_num, sk_fit=sk_fit, f_slow=f_slow, resp_slow=resp_slow)
             else:
                 if res_num in plot_chans:
-                    self.log('Making plot for band ' +
-                        '{} res {:03}'.format(band, res_num))
+                    self.log(
+                        'Making plot for band ' +
+                        f'{band} res {res_num:03}')
                     self.plot_eta_fit(freq[left_plot:right_plot],
                         resp[left_plot:right_plot],
                         eta=eta, eta_mag=eta_mag, eta_phase_deg=eta_phase_deg,
@@ -1400,11 +1404,13 @@ class SmurfTuneMixin(SmurfBase):
         # phase plot, since we typically look at it when trying to
         # optimize them.
         bbox = dict(boxstyle="round", ec='w', fc='w', alpha=.65)
-        ax1.text(.03, .15,
-            'refPhaseDelay={}'.format(self.get_ref_phase_delay(band)),
+        ax1.text(
+            .03, .15,
+            f'refPhaseDelay={self.get_ref_phase_delay(band)}',
             transform=ax1.transAxes, fontsize=8, bbox=bbox)
-        ax1.text(.03, .05,
-            'refPhaseDelayFine={}'.format(self.get_ref_phase_delay_fine(band)),
+        ax1.text(
+            .03, .05,
+            f'refPhaseDelayFine={self.get_ref_phase_delay_fine(band)}',
             transform=ax1.transAxes, fontsize=8, bbox=bbox)
 
         # IQ circle
@@ -1416,30 +1422,31 @@ class SmurfTuneMixin(SmurfBase):
         ax2.set_ylabel('Q')
 
         if peak_freq is not None:
-            ax0.text(.03, .9, '{:5.2f} MHz'.format(peak_freq),
+            ax0.text(.03, .9, f'{peak_freq:5.2f} MHz',
                 transform=ax0.transAxes, fontsize=10,
                 bbox=bbox)
 
         lab = ''
         if eta is not None:
             if eta_mag is not None:
-                lab = r'$\eta/\eta_{mag}$' + \
-                    ': {:4.3f}+{:4.3f}'.format(np.real(eta/eta_mag),
-                    np.imag(eta/eta_mag)) + '\n'
+                lab = (
+                    r'$\eta/\eta_{mag}$' +
+                    f': {np.real(eta/eta_mag):4.3f}' +
+                    f'+{np.imag(eta/eta_mag):4.3f}\n')
             else:
-                lab = lab + r'$\eta$' + ': {}'.format(eta) + '\n'
+                lab = lab + r'$\eta$' + f': {eta}' + '\n'
         if eta_mag is not None:
-            lab = lab + r'$\eta_{mag}$' + ': {:1.3e}'.format(eta_mag) + '\n'
+            lab = lab + r'$\eta_{mag}$' + f': {eta_mag:1.3e}' + '\n'
         if eta_phase_deg is not None:
             lab = lab + r'$\eta_{ang}$' + \
-                ': {:3.2f}'.format(eta_phase_deg) + '\n'
+                f': {eta_phase_deg:3.2f}' + '\n'
         if r2 is not None:
-            lab = lab + r'$R^2$' + ' :{:4.3f}'.format(r2)
+            lab = lab + r'$R^2$' + f' :{r2:4.3f}'
         ax2.text(.03, .81, lab, transform=ax2.transAxes, fontsize=10,
             bbox=bbox)
 
         if channel is not None:
-            ax2.text(.85, .92, 'Ch {:03}'.format(channel),
+            ax2.text(.85, .92, f'Ch {channel:03}',
                 transform=ax2.transAxes, fontsize=10,
                 bbox=bbox)
 
@@ -1472,10 +1479,11 @@ class SmurfTuneMixin(SmurfBase):
 
         if save_plot:
             if res_num is not None and band is not None:
-                save_name = '{}_eta_b{}_res{:03}{}.png'.format(timestamp, band,
-                    res_num, plotname_append)
+                save_name = (
+                    f'{timestamp}_eta_b{band}_' +
+                    'res{res_num:03}{plotname_append}.png')
             else:
-                save_name = '{}_eta{}.png'.format(timestamp, plotname_append)
+                save_name = f'{timestamp}_eta{plotname_append}.png'
 
             path = os.path.join(self.plot_dir, save_name)
             plt.savefig(path, bbox_inches='tight')
@@ -1506,7 +1514,7 @@ class SmurfTuneMixin(SmurfBase):
         if self.check_freq_scale(f, centers[0]):
             pass
         else:
-            raise ValueError('{} and {}'.format(f, centers[0]))
+            raise ValueError(f'{f} and {centers[0]}')
 
         idx = np.argmin([abs(x - f) for x in centers])
         return idx
@@ -1547,12 +1555,11 @@ class SmurfTuneMixin(SmurfBase):
             The full path to the new master assignment file. Should be
             in self.tune_dir.
         """
-        if 'band_{}'.format(band) in self.channel_assignment_files.keys():
-            self.log('Old master assignment file:'+
-                     ' {}'.format(self.channel_assignment_files['band_{}'.format(band)]))
-        self.channel_assignment_files['band_{}'.format(band)] = filename
-        self.log('New master assignment file:'+
-                 ' {}'.format(self.channel_assignment_files['band_{}'.format(band)]))
+        if f'band_{band}' in self.channel_assignment_files.keys():
+            old_file=self.channel_assignment_files[f'band_{band}']
+            self.log(f'Old master assignment file: {old_file}')
+        self.channel_assignment_files[f'band_{band}'] = filename
+        self.log('New master assignment file: {filename}')
 
     @set_action()
     def get_master_assignment(self, band):
@@ -1655,8 +1662,9 @@ class SmurfTuneMixin(SmurfBase):
                         break
                 if not found_match:
                     n_unmatched += 1
-                    self.log('No match found for {:.2f} MHz'.format(f))
-            self.log(f'No channel assignment for {n_unmatched} of {n_freqs}'+
+                    self.log(f'No match found for {f:.2f} MHz')
+            self.log(
+                f'No channel assignment for {n_unmatched} of {n_freqs}'+
                 ' resonances.')
         else:
             d_freq = np.diff(freq)
@@ -1717,13 +1725,18 @@ class SmurfTuneMixin(SmurfBase):
         if bias_groups is None:
             bias_groups = -np.ones(len(freqs),dtype=int)
 
-        fn = os.path.join(self.tune_dir,
-                          f'{timestamp}_channel_assignment_b{band}.txt')
-        self.log('Writing new channel assignment to {}'.format(fn))
+        fn = os.path.join(
+            self.tune_dir,
+            f'{timestamp}_channel_assignment_b{band}.txt')
+        self.log(f'Writing new channel assignment to {fn}')
         f = open(fn,'w')
         for i in range(len(channels)):
-            f.write('%.4f,%i,%i,%i\n' % (freqs[i],subbands[i],channels[i],
-                bias_groups[i]))
+            f.write(
+                f'{freqs[i]:.4f},' +
+                f'{subbands[i]},'+
+                f'{channels[i]},'+
+                f'{bias_groups[i]}'+
+                '\n')
         f.close()
         self.pub.register_file(fn, 'master_assignment', format='txt')
 
@@ -1742,8 +1755,8 @@ class SmurfTuneMixin(SmurfBase):
             The tuning file to use for generating the
             master_assignment.
         """
-        self.log('Drawing band-{} tuning data from {}'.format(band,
-            tuning_filename))
+        self.log(
+            f'Drawing band-{band} tuning data from {tuning_filename}')
 
         # Load the tuning file
         d = np.load(tuning_filename).item()[band]['resonances']
@@ -1948,14 +1961,15 @@ class SmurfTuneMixin(SmurfBase):
         self.set_eta_mag_array(band, eta_mag, write_log=write_log,
             log_level=self.LOG_INFO)
 
-        self.log('Setting on {} channels on band {}'.format(counter, band),
+        self.log(
+            f'Setting on {counter} channels on band {band}',
             self.LOG_USER)
 
     @set_action()
     def fast_relock(self, band):
         """
         """
-        self.log('Fast relocking with: {}'.format(self.tune_file))
+        self.log(f'Fast relocking with: {self.tune_file}')
         self.set_tune_file_path(self.tune_file)
         self.set_load_tune_file(band, 1)
         self.log('Done fast relocking')
@@ -2303,7 +2317,7 @@ class SmurfTuneMixin(SmurfBase):
             for i, c in enumerate(chs):
                 color = cm(i/len(chs))
                 ax0.plot(np.arange(n_samp)/fs*scale,
-                         df[:,c], label='ch {}'.format(c),
+                         df[:,c], label=f'ch {c}',
                          color=color)
                 holder = np.zeros((n_fr-1, dt))
                 for i in np.arange(n_fr-1):
@@ -2319,14 +2333,15 @@ class SmurfTuneMixin(SmurfBase):
             ax0.legend(loc='upper left')
             ax1.set_xlabel('Time [ms]')
             ax2.set_xlabel('Freq [kHz]')
-            fig.suptitle('Band {} Subband {}'.format(band, sb))
+            fig.suptitle(f'Band {band} Subband {sb}')
 
             if save_plot:
                 save_name = timestamp
                 if not flux_ramp:
                     save_name = save_name + '_no_FR'
-                save_name = save_name+ \
-                    '_b{}_sb{:03}_flux_ramp_check.png'.format(band, sb)
+                save_name = (
+                    save_name +
+                    f'_b{band}_sb{sb:03}_flux_ramp_check.png')
                 path = os.path.join(self.plot_dir, save_name)
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'flux_ramp', plot=True)
@@ -2417,14 +2432,20 @@ class SmurfTuneMixin(SmurfBase):
 
         # Validate feedback_start_frac and feedback_end_frac
         if (feedback_start_frac < 0) or (feedback_start_frac >= 1):
-            raise ValueError("feedback_start_frac = {} not in [0,1)".format(feedback_start_frac))
+            raise ValueError(
+                f"feedback_start_frac = {feedback_start_frac} " +
+                "not in [0,1)")
         if (feedback_end_frac < 0):
-            raise ValueError("feedback_end_frac = {} not > 0".format(feedback_end_frac))
+            raise ValueError(
+                f"feedback_end_frac = {feedback_end_frac} not > 0")
         # If feedback_start_frac exceeds feedback_end_frac, then
         # there's no range of the flux ramp cycle over which we're
         # applying feedback.
         if (feedback_end_frac < feedback_start_frac):
-            raise ValueError("feedback_end_frac = {} is not less than feedback_start_frac = {}".format(feedback_end_frac, feedback_start_frac))
+            raise ValueError(
+                f"feedback_end_frac = {feedback_end_frac} " +
+                "is not less than " +
+                f"feedback_start_frac = {feedback_start_frac}")
         # Done validating feedbackStart and feedbackEnd
 
         ## End argument validation
@@ -2463,7 +2484,8 @@ class SmurfTuneMixin(SmurfBase):
                 lms_freq_hz = self.config.get('tune_band').get('lms_freq')[str(band)]
             self.lms_freq_hz[band] = lms_freq_hz
             if write_log:
-                self.log('Using lms_freq_estimator : {:.0f} Hz'.format(lms_freq_hz))
+                self.log('Using lms_freq_estimator : ' +
+                         f'{lms_freq_hz:.0f} Hz')
 
         if not flux_ramp:
             lms_enable1 = 0
@@ -2471,7 +2493,9 @@ class SmurfTuneMixin(SmurfBase):
             lms_enable3 = 0
 
         if write_log:
-            self.log("Using lmsFreqHz = {:.0f} Hz".format(lms_freq_hz), self.LOG_USER)
+            self.log("Using lmsFreqHz = " +
+                     f"{lms_freq_hz:.0f} Hz",
+                     self.LOG_USER)
 
         self.set_lms_gain(band, lms_gain, write_log=write_log)
         self.set_lms_enable1(band, lms_enable1, write_log=write_log)
@@ -2597,11 +2621,11 @@ class SmurfTuneMixin(SmurfBase):
                     ax[0].plot(f[:, ch]*1e3)
                     ax[0].set_ylabel('Tracked Freq [kHz]')
                     ax[0].text(.025, .93,
-                        'LMS Freq {:.0f} Hz'.format(lms_freq_hz), fontsize=10,
+                        f'LMS Freq {lms_freq_hz:.0f} Hz', fontsize=10,
                         transform=ax[0].transAxes, bbox=bbox, ha='left',
                         va='top')
 
-                    ax[0].text(.95, .93, 'Band {} Ch {:03}'.format(band, ch),
+                    ax[0].text(.95, .93, f'Band {band} Ch {ch:03}',
                         fontsize=10, transform=ax[0].transAxes, ha='right',
                         va='top', bbox=bbox)
 
@@ -2771,7 +2795,7 @@ class SmurfTuneMixin(SmurfBase):
         ret['data'] = {}
 
         for i, r in enumerate(rot_ang):
-            self.log('Rotating {:3.1f} deg'.format(r))
+            self.log(f'Rotating {r:3.1f} deg')
             eta_phase = np.zeros_like(eta_phase0)
             for c in np.arange(n_channels):
                 eta_phase[c] = tools.limit_phase_deg(eta_phase0[c] + r)
@@ -2823,10 +2847,10 @@ class SmurfTuneMixin(SmurfBase):
 
             color = cm(j/n_keys)
             ax.plot(np.arange(len(ds))/fs*scale, ds, color=color,
-                    label='{:3.1f}'.format(k))
+                    label=f'{k:3.1f}')
 
         ax.legend()
-        ax.set_title('Band {} Ch {:03}'.format(band, channel))
+        ax.set_title(f'Band {band} Ch {channel:03}')
         ax.set_xlabel('Time [ms]')
 
 
@@ -2902,11 +2926,11 @@ class SmurfTuneMixin(SmurfBase):
                 LTC1668RawDacData0=np.floor(0.5*(2**self._num_flux_ramp_dac_bits))
                 self.log("Before switching to fixed DC flux ramp output, " +
                          " explicitly setting flux ramp DAC to zero "+
-                         "(LTC1668RawDacData0={})".format(mode_control,LTC1668RawDacData0),
+                         f"(LTC1668RawDacData0={LTC1668RawDacData0})",
                          self.LOG_USER)
                 self.set_flux_ramp_dac(LTC1668RawDacData0)
 
-                self.log("Flux ramp ModeControl is {}".format(mode_control) +
+                self.log(f"Flux ramp ModeControl is {mode_control}" +
                          " - changing to 1 for fixed DC output.",
                          self.LOG_USER)
                 self.set_mode_control(1)
@@ -2918,8 +2942,9 @@ class SmurfTuneMixin(SmurfBase):
         if fractionFullScale<0:
             LTC1668RawDacData = 2**self._num_flux_ramp_dac_bits-LTC1668RawDacData-1
         if debug:
-            self.log("Setting flux ramp to {}".format(100 * fractionFullScale,
-                     int(LTC1668RawDacData)) + "% of full scale (LTC1668RawDacData={})",
+            self.log("Setting flux ramp to " +
+                     f"{100*fractionFullScale}% of full scale " +
+                     f"(LTC1668RawDacData={LTC1668RawDacData})",
                      self.LOG_USER)
         self.set_flux_ramp_dac(LTC1668RawDacData)
 
@@ -2979,23 +3004,30 @@ class SmurfTuneMixin(SmurfBase):
         diffDesiredFractionFullScale = np.abs(trialFractionFullScale -
             fraction_full_scale)
 
-        self.log("Percent full scale = {:0.3f}%".format(100 * fractionFullScale),
+        self.log(
+            f"Percent full scale = {100 * fractionFullScale:0.3f}%",
             self.LOG_USER)
 
         if diffDesiredFractionFullScale > df_range:
-            raise ValueError("Difference from desired fraction of full scale " +
-                "exceeded! {}".format(diffDesiredFractionFullScale) +
-                " vs acceptable {}".format(df_range))
-            self.log("Difference from desired fraction of full scale exceeded!" +
-                " P{} vs acceptable {}".format(diffDesiredFractionFullScale,
-                    df_range),
+            raise ValueError(
+                "Difference from desired fraction of full scale " +
+                f"exceeded! {diffDesiredFractionFullScale} " +
+                f"vs acceptable {df_range}.")
+            self.log(
+                "Difference from desired fraction of full scale " +
+                f"exceeded!  P{diffDesiredFractionFullScale} vs " +
+                f"acceptable {df_range}.",
                 self.LOG_USER)
 
         if rtmClock < 2e6:
-            raise ValueError("RTM clock rate = "+
-                "{} is too low (SPI clock runs at 1MHz)".format(rtmClock*1e-6))
-            self.log("RTM clock rate = "+
-                "{} is too low (SPI clock runs at 1MHz)".format(rtmClock * 1e-6),
+            raise ValueError(
+                "RTM clock rate = " +
+                f"{rtmClock*1e-6} is too low " +
+                "(SPI clock runs at 1MHz)")
+            self.log(
+                "RTM clock rate = " +
+                f"{rtmClock * 1e-6} is too low " +
+                "(SPI clock runs at 1MHz)",
                 self.LOG_USER)
             return
 
@@ -3101,7 +3133,7 @@ class SmurfTuneMixin(SmurfBase):
         setup_flux_ramp : bool, optional, default True
             Whether to setup the flux ramp at the end.
         """
-        self.log('Checking lock on band {}'.format(band))
+        self.log(f'Checking lock on band {band}')
 
         if reset_rate_khz is None:
             reset_rate_khz = self.reset_rate_khz
@@ -3115,7 +3147,7 @@ class SmurfTuneMixin(SmurfBase):
         channels = self.which_on(band)
         n_chan = len(channels)
 
-        self.log('Currently {} channels on'.format(n_chan))
+        self.log(f'Currently {n_chan} channels on')
 
         # Tracking setup returns information on all channels in a band
         f, df, sync = self.tracking_setup(band, make_plot=False,
@@ -3146,14 +3178,14 @@ class SmurfTuneMixin(SmurfBase):
 
         chan_after = self.which_on(band)
 
-        self.log('High cut channels {}'.format(high_cut))
-        self.log('Low cut channels {}'.format(low_cut))
-        self.log('df cut channels {}'.format(df_cut))
-        self.log('Good channels {}'.format(chan_after))
-        self.log('High cut count: {}'.format(len(high_cut)))
-        self.log('Low cut count: {}'.format(len(low_cut)))
-        self.log('df cut count: {}'.format(len(df_cut)))
-        self.log('Started with {}. Now {}'.format(n_chan, len(chan_after)))
+        self.log(f'High cut channels {high_cut}')
+        self.log(f'Low cut channels {low_cut}')
+        self.log(f'df cut channels {df_cut}')
+        self.log(f'Good channels {chan_after}')
+        self.log(f'High cut count: {high_cut}')
+        self.log(f'Low cut count: {low_cut}')
+        self.log(f'df cut count: {df_cut}')
+        self.log(f'Started with {n_chan}. Now {len(chan_after)}')
 
         # Store the data in freq_resp
         timestamp = self.get_timestamp(as_int=True)
@@ -3373,7 +3405,7 @@ class SmurfTuneMixin(SmurfBase):
 
         subband_nos, subband_centers = self.get_subband_centers(band)
 
-        self.log('Working on band {:d}'.format(band))
+        self.log(f'Working on band {band}')
         for sb in subband:
             self.log(f'Sweeping subband no: {sb}')
             f, r = self.fast_eta_scan(band, sb, scan_freq, n_read,
@@ -3585,13 +3617,15 @@ class SmurfTuneMixin(SmurfBase):
                      'Run find_freq first.', self.LOG_ERROR)
             return
         elif 'resonance' not in self.freq_resp[band]['find_freq'] and resonance is None:
-            self.log('No resonances stored in band {}'.format(band) +
+            self.log(
+                f'No resonances stored in band {band}' +
                 '. Run find_freq first.', self.LOG_ERROR)
             return
 
         if drive is None:
-            drive = self.config.get('init')['band_{}'.format(band)].get('amplitude_scale')
-            self.log('No drive given. Using value in config file: {}'.format(drive))
+            drive = self.config.get('init')[f'band_{band}'].get('amplitude_scale')
+            self.log(
+                f'No drive given. Using value in config file: {drive}')
 
         if delta_freq is None:
             delta_freq = self.config.get('tune_band').get('delta_freq')[str(band)]
@@ -3615,7 +3649,7 @@ class SmurfTuneMixin(SmurfBase):
 
         n_res = len(input_res)
         for i, f in enumerate(input_res):
-            self.log('freq {:5.4f} - {} of {}'.format(f, i+1, n_res))
+            self.log(f'freq {f:5.4f} - {i+1} of {n_res}')
             freq, resp, eta = self.eta_estimator(band, f, drive,
                                                  f_sweep_half=sweep_width,
                                                  df_sweep=df_sweep,
@@ -3719,7 +3753,7 @@ class SmurfTuneMixin(SmurfBase):
             else:
                 # Load only the tune data for the requested band(s).
                 band=np.ravel(np.array(band))
-                self.log('Only loading tune data for bands={}.'.format(str(band)))
+                self.log(f'Only loading tune data for bands={band}.')
                 for b in band:
                     self.freq_resp[b] = fs[b]
         else:
@@ -4128,7 +4162,7 @@ class SmurfTuneMixin(SmurfBase):
             status_dir = self.status_dir
             output_file = os.path.join(status_dir, filename)
 
-        self.log('Dumping status to file:{}'.format(output_file))
+        self.log(f'Dumping status to file:{output_file}')
         self.write_output(output_file)
 
         if return_screen:

--- a/python/pysmurf/client/util/listen.py
+++ b/python/pysmurf/client/util/listen.py
@@ -26,13 +26,13 @@ while True:
     d = json.loads(data)
     print(d)
     if last_seq is None:
-        print('New sequence: %i' % d['seq_no'])
+        print(f"New sequence: {d['seq_no']}")
     else:
         delta = d['seq_no'] - last_seq
         if delta != 1:
-            print('Sequence jump: %i + %i' % (last_seq, delta))
+            print(f'Sequence jump: {last_seq} + {delta}')
             types = []
     last_seq = d['seq_no']
     if not d['type'] in types:
-        print('New type: %s at %i' % (d['type'], d['seq_no']))
+        print(f"New type: {d['type']} at {d['seq_no']}")
         types.append(d['type'])

--- a/python/pysmurf/client/util/pub.py
+++ b/python/pysmurf/client/util/pub.py
@@ -114,8 +114,8 @@ class Publisher:
             self._backend = self._backend_udp
 
         else:
-            sys.stderr.write('%s: no backend for "%s", selecting null Publisher.\n' %
-                             (self.__class__, backend))
+            sys.stderr.write(f'{self.__class__}: no backend for ' +
+                             f'"{backend}", selecting null Publisher.\n')
             self._backend = self._backend_null
 
         self._action = None
@@ -147,8 +147,8 @@ class Publisher:
         payload = bytes(json_msg, 'utf_8')
         if len(payload) > UDP_MAX_BYTES:
             # Can't send this; write to stderr and notify consumer.
-            error = 'Backend error: dropped large UDP packet (%i bytes).' % len(payload)
-            sys.stderr.write('%s %s' % (self, error))
+            error = f'Backend error: dropped large UDP packet ({len(payload)} bytes).'
+            sys.stderr.write(f'{self} {error}')
             self.publish({'message': error}, 'backend_error')
             return
         self.udp_sock.sendto(payload, (self.udp_ip, self.udp_port))

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -90,12 +90,12 @@ class SmurfUtilMixin(SmurfBase):
         # set filename
         if filename is not None:
             data_filename = os.path.join(self.output_dir, filename+'.dat')
-            self.log('Writing to file : {}'.format(data_filename),
+            self.log(f'Writing to file : {data_filename}',
                 self.LOG_USER)
         else:
             timestamp = self.get_timestamp()
             data_filename = os.path.join(self.output_dir, timestamp+'.dat')
-            self.log('Writing to file : {}'.format(data_filename),
+            self.log(f'Writing to file : {data_filename}',
                 self.LOG_USER)
 
         dtype = 'debug'
@@ -222,9 +222,15 @@ class SmurfUtilMixin(SmurfBase):
         resp_cable=None
         if load_full_band_resp:
             self.log('Loading full band resp data')
-            fbr_freq_file=os.path.join(fbr_path,'%d_freq_full_band_resp.txt'%fbr_ctime)
-            fbr_real_resp_file=os.path.join(fbr_path,'%d_real_full_band_resp.txt'%fbr_ctime)
-            fbr_complex_resp_file=os.path.join(fbr_path,'%d_imag_full_band_resp.txt'%fbr_ctime)
+            fbr_freq_file=(
+                os.path.join(fbr_path,
+                             f'{fbr_ctime}_freq_full_band_resp.txt'))
+            fbr_real_resp_file=(
+                os.path.join(fbr_path,
+                             f'{fbr_ctime}_real_full_band_resp.txt'))
+            fbr_complex_resp_file=(
+                os.path.join(fbr_path,
+                             f'{fbr_ctime}_imag_full_band_resp.txt'))
 
             freq_cable = np.loadtxt(fbr_freq_file)
             real_resp_cable = np.loadtxt(fbr_real_resp_file)
@@ -259,8 +265,12 @@ class SmurfUtilMixin(SmurfBase):
         resp_dsp=None
         if load_find_freq:
             self.log('Loading DSP frequency sweep data')
-            ff_freq_file=os.path.join(ff_path,'%d_amp_sweep_freq.txt'%ff_ctime)
-            ff_resp_file=os.path.join(ff_path,'%d_amp_sweep_resp.txt'%ff_ctime)
+            ff_freq_file=(
+                os.path.join(ff_path,
+                             f'{ff_ctime}_amp_sweep_freq.txt'))
+            ff_resp_file=(
+                os.path.join(ff_path,
+                             f'{ff_ctime}_amp_sweep_resp.txt'))
 
             freq_dsp=np.loadtxt(ff_freq_file)
             resp_dsp=np.loadtxt(ff_resp_file,dtype='complex')
@@ -312,9 +322,9 @@ class SmurfUtilMixin(SmurfBase):
         processing_delay_us=dsp_delay_us-cable_delay_us
 
         print('-------------------------------------------------------')
-        print('Estimated refPhaseDelay={}'.format(refPhaseDelay))
-        print('Estimated refPhaseDelayFine={}'.format(refPhaseDelayFine))
-        print('Estimated processing_delay_us={}'.format(processing_delay_us))
+        print(f'Estimated refPhaseDelay={refPhaseDelay}')
+        print(f'Estimated refPhaseDelayFine={refPhaseDelayFine}')
+        print(f'Estimated processing_delay_us={processing_delay_us}')
         print('-------------------------------------------------------')
 
         #### done measuring dsp delay (cable+processing)
@@ -331,8 +341,12 @@ class SmurfUtilMixin(SmurfBase):
         resp_dsp_corr=None
         if load_find_freq_check:
             self.log('Loading delay-corrected DSP frequency sweep data')
-            ff_corr_freq_file=os.path.join(ff_corr_path,'%d_amp_sweep_freq.txt'%ff_corr_ctime)
-            ff_corr_resp_file=os.path.join(ff_corr_path,'%d_amp_sweep_resp.txt'%ff_corr_ctime)
+            ff_corr_freq_file=(
+                os.path.join(ff_corr_path,
+                             f'{ff_corr_ctime}_amp_sweep_freq.txt'))
+            ff_corr_resp_file=(
+                os.path.join(ff_corr_path,
+                             f'{ff_corr_ctime}_amp_sweep_resp.txt'))
 
             freq_dsp_corr=np.loadtxt(ff_corr_freq_file)
             resp_dsp_corr=np.loadtxt(ff_corr_resp_file,dtype='complex')
@@ -379,16 +393,16 @@ class SmurfUtilMixin(SmurfBase):
         f_dsp_corr_plot = (freq_dsp_corr_subset) / 1.0E6
         dsp_corr_phase = np.unwrap(np.angle(resp_dsp_corr_subset))
 
-        ax[0].set_title('AMC in Bay {}, Band {} Cable Delay'.format(bay,band))
+        ax[0].set_title(f'AMC in Bay {bay}, Band {band} Cable Delay')
         ax[0].plot(f_cable_plot,cable_phase,label='Cable (full_band_resp)',
             c='g', lw=3)
         ax[0].plot(f_cable_plot,cable_p(f_cable_plot*1.0E6),'m--',
             label='Cable delay fit',lw=3)
 
-        ax[1].set_title('AMC in Bay {}, Band {} DSP Delay'.format(bay,band))
+        ax[1].set_title(f'AMC in Bay {bay}, Band {band} DSP Delay')
         ax[1].plot(f_dsp_plot,dsp_phase,label='DSP (find_freq)',c='c',lw=3)
         ax[1].plot(f_dsp_plot,dsp_p(f_dsp_plot*1.0E6), c='orange', ls='--',
-            label='DSP delay fit', lw=3)
+                   label='DSP delay fit', lw=3)
 
         ax[0].set_ylabel("Phase [rad]")
         ax[0].set_xlabel('Frequency offset from band center [MHz]')
@@ -400,11 +414,11 @@ class SmurfUtilMixin(SmurfBase):
         ax[1].legend(loc='lower left',fontsize=8)
 
         bbox = dict(boxstyle="round", ec='w', fc='w', alpha=.65)
-        ax[0].text(.97, .90, 'cable delay={:.5f} us'.format(cable_delay_us),
+        ax[0].text(.97, .90, f'cable delay={cable_delay_us:.5f} us',
                    transform=ax[0].transAxes, fontsize=10,
                    bbox=bbox,horizontalalignment='right')
 
-        ax[1].text(.97, .90, 'dsp delay={:.5f} us'.format(dsp_delay_us),
+        ax[1].text(.97, .90, f'dsp delay={dsp_delay_us:.5f} us',
                    transform=ax[1].transAxes, fontsize=10,
                    bbox=bbox,horizontalalignment='right')
 
@@ -416,31 +430,31 @@ class SmurfUtilMixin(SmurfBase):
             label='DSP (find_freq)', c='c')
         ax[2].plot(f_dsp_corr_plot,dsp_corr_phase-np.median(dsp_corr_phase),
             label='DSP corrected (find_freq)', c='m')
-        ax[2].set_title('AMC in Bay {}, Band {} Residuals'.format(bay,band))
+        ax[2].set_title(f'AMC in Bay {bay}, Band {band} Residuals'.format(bay,band))
         ax[2].set_ylabel("Residual [rad]")
         ax[2].set_xlabel('Frequency offset from band center [MHz]')
         ax[2].set_ylim([-5,5])
 
-        ax[2].text(.97, .92, 'refPhaseDelay={}'.format(refPhaseDelay),
+        ax[2].text(.97, .92, f'refPhaseDelay={refPhaseDelay}',
                    transform=ax[2].transAxes, fontsize=8,
                    bbox=bbox,horizontalalignment='right')
-        ax[2].text(.97, .84, 'refPhaseDelayFine={}'.format(refPhaseDelayFine),
+        ax[2].text(.97, .84, f'refPhaseDelayFine={refPhaseDelayFine}',
                    transform=ax[2].transAxes, fontsize=8,
                    bbox=bbox,horizontalalignment='right')
         ax[2].text(.97, .76,
-            'processing delay={:.5f} us (fw={})'.format(processing_delay_us,fw_abbrev_sha),
-            transform=ax[2].transAxes, fontsize=8,
-            bbox=bbox,horizontalalignment='right')
-        ax[2].text(.97, .68, 'delay post-correction={:.3f} ns'.format(dsp_corr_delay_us*1000.),
+                   f'processing delay={processing_delay_us:.5f} us (fw={fw_abbrev_sha})',
                    transform=ax[2].transAxes, fontsize=8,
                    bbox=bbox,horizontalalignment='right')
+        ax[2].text(.97, .68, f'delay post-correction={dsp_corr_delay_us*1000.:.3f} ns',
+                   transform=ax[2].transAxes, fontsize=8,
+                bbox=bbox,horizontalalignment='right')
 
         ax[2].legend(loc='upper left',fontsize=8)
 
         plt.tight_layout()
 
         if save_plot:
-            save_name = '{}_b{}_delay.png'.format(timestamp,band)
+            save_name = f'{timestamp}_b{band}_delay.png'
 
             path = os.path.join(self.plot_dir, save_name)
             plt.savefig(path,bbox_inches='tight')
@@ -954,7 +968,7 @@ class SmurfUtilMixin(SmurfBase):
         if register_file:
             datafile = self.get_data_file_name().tostring().decode()
             if datafile:
-                self.log("Registering File {}".format(datafile))
+                self.log(f"Registering File {datafile}")
                 self.pub.register_file(datafile, 'data', format='dat')
 
         self.set_stream_enable(0, write_log=write_log, wait_after=.15)
@@ -1178,12 +1192,12 @@ class SmurfUtilMixin(SmurfBase):
         try:
             datafile = glob.glob(datafile+'*')[-1]
         except ValueError:
-            print('datafile=%s'%datafile)
+            print(f'datafile={datafile}')
 
-        self.log('Reading {}'.format(datafile))
+        self.log(f'Reading {datafile}')
 
         if channel is not None:
-            self.log('Only reading channel {}'.format(channel))
+            self.log(f'Only reading channel {channel}')
 
 
         keys = ['protocol_version','crate_id','slot_number','number_of_channels',
@@ -1210,7 +1224,7 @@ class SmurfUtilMixin(SmurfBase):
         # Indices for input channels
         channel_mask = np.zeros(n_chan, dtype=int)
         for i, c in enumerate(channel):
-            channel_mask[i] = keys_dict['data{}'.format(c)]
+            channel_mask[i] = keys_dict[f'data{c}']
 
         eval_n_samp = False
         if n_samp is not None:
@@ -1248,7 +1262,7 @@ class SmurfUtilMixin(SmurfBase):
 
                 # Store the data in a useful array and reset tmp arrays
                 if counter % n == n - 1 :
-                    self.log('{} elements loaded'.format(counter+1))
+                    self.log(f'{counter+1} elements loaded')
                     phase = np.hstack((phase, tmp_phase))
                     timestamp2 = np.append(timestamp2, tmp_timestamp2)
                     tmp_phase = np.zeros((n_chan, n))
@@ -1263,7 +1277,7 @@ class SmurfUtilMixin(SmurfBase):
         timestamp = filename.split('.')[0]
 
         mask = self.make_mask_lookup(os.path.join(rootpath,
-                                                  '{}_mask.txt'.format(timestamp)))
+                                                  f'{timestamp}_mask.txt'))
 
         return timestamp2, phase, mask
 
@@ -1570,7 +1584,7 @@ class SmurfUtilMixin(SmurfBase):
             ax1.set_ylim((-2**15, 2**15))
             ax2 = plt.subplot(212)
             ax2.plot(f_plot, 10*np.log10(p_adc))
-            ax2.set_ylabel('ADC{}'.format(band))
+            ax2.set_ylabel(f'ADC{band}')
             ax2.set_xlabel('Frequency [MHz]')
             ax2.set_title(f'{timestamp} Spectrum')
             plt.grid(which='both')
@@ -1582,14 +1596,16 @@ class SmurfUtilMixin(SmurfBase):
 
 
             if save_plot:
-                plot_fn = '{}/{}_adc{}.png'.format(self.plot_dir,timestamp,band)
+                plot_fn = f'{self.plot_dir}/{timestamp}_adc{band}.png'
                 plt.savefig(plot_fn)
                 self.pub.register_file(plot_fn, 'adc', plot=True)
-                self.log('ADC plot saved to %s' % (plot_fn))
+                self.log(f'ADC plot saved to {plot_fn}')
 
         if save_data:
-            outfn=os.path.join(self.output_dir,'{}_adc{}'.format(timestamp,band))
-            self.log('Saving raw adc data to {}'.format(outfn), self.LOG_USER)
+            outfn=os.path.join(self.output_dir,
+                               f'{timestamp}_adc{band}')
+            self.log(f'Saving raw adc data to {outfn}',
+                     self.LOG_USER)
 
             np.save(outfn, res)
             self.pub.register_file(outfn, 'adc', format='npy')
@@ -1672,7 +1688,7 @@ class SmurfUtilMixin(SmurfBase):
             ax1.set_ylim((-2**15, 2**15))
             ax2 = plt.subplot(212)
             ax2.plot(f_plot, 10*np.log10(p_dac))
-            ax2.set_ylabel('ADC{}'.format(band))
+            ax2.set_ylabel(f'ADC{band}')
             ax2.set_xlabel('Frequency [MHz]')
             ax2.set_title(f'{timestamp} Spectrum')
             plt.grid(which='both')
@@ -1683,14 +1699,14 @@ class SmurfUtilMixin(SmurfBase):
 
 
             if save_plot:
-                plot_fn = '{}/{}_dac{}.png'.format(self.plot_dir,timestamp,band)
+                plot_fn = f'{self.plot_dir}/{timestamp}_dac{band}.png'
                 plt.savefig(plot_fn)
                 self.pub.register_file(plot_fn, 'dac', plot=True)
-                self.log('DAC plot saved to %s' % (plot_fn))
+                self.log(f'DAC plot saved to {plot_fn}')
 
         if save_data:
-            outfn = os.path.join(self.output_dir,'{}_dac{}'.format(timestamp,band))
-            self.log('Saving raw dac data to {}'.format(outfn), self.LOG_USER)
+            outfn = os.path.join(self.output_dir,f'{timestamp}_dac{band}')
+            self.log(f'Saving raw dac data to {outfn}', self.LOG_USER)
 
             np.save(outfn, res)
             self.pub.register_file(outfn, 'dac', format='npy')
@@ -1764,7 +1780,7 @@ class SmurfUtilMixin(SmurfBase):
             self.set_waveform_end_addr(bay, daq_num, e, convert=True,
                 write_log=debug)
             if debug:
-                self.log('DAQ number {}: start {} - end {}'.format(daq_num, s, e))
+                self.log(f'DAQ number {daq_num}: start {s} - end {e}')
 
     @set_action()
     def config_cryo_channel(self, band, channel, frequencyMHz, amplitude,
@@ -1924,8 +1940,8 @@ class SmurfUtilMixin(SmurfBase):
         channel : int
             The channel to turn off.
         """
-        self.log('Turning off band {} channel {}'.format(band, channel),
-            self.LOG_USER)
+        self.log(f'Turning off band {band} channel {channel}',
+                 self.LOG_USER)
         self.set_amplitude_scale_channel(band, channel, 0, **kwargs)
         self.set_feedback_enable_channel(band, channel, 0, **kwargs)
 
@@ -2010,8 +2026,8 @@ class SmurfUtilMixin(SmurfBase):
                     which_jesd_down0 = ('Jesd Rx is down' if
                         jesd_tx_ok0 else 'Jesd Tx is down')
 
-                self.log('%s ... will attempt to recover.'%which_jesd_down0,
-                    self.LOG_ERROR)
+                self.log(f'{which_jesd_down0} ... will attempt to recover.',
+                         self.LOG_ERROR)
 
                 # attempt to recover ; if it fails it will assert
                 self.recover_jesd(recover_jesd_rx=(not jesd_rx_ok0),
@@ -2529,8 +2545,9 @@ class SmurfUtilMixin(SmurfBase):
         dac_volt_array = self.get_rtm_slow_dac_volt_array()
 
         if len(bias_group_volt_array) != n_bias_groups:
-            self.log("Received the wrong number of biases. Expected an array of " +
-                "n_bias_groups={} voltages".format(n_bias_groups), self.LOG_ERROR)
+            self.log("Received the wrong number of biases. Expected " +
+                     f"an array of n_bias_groups={n_bias_groups} voltages",
+                     self.LOG_ERROR)
         else:
             for bg in np.arange(n_bias_groups):
                 bias_order = self.bias_group_to_pair[:,0]
@@ -2680,18 +2697,22 @@ class SmurfUtilMixin(SmurfBase):
         # set it and tell the user
         if bias_hemt is not None:
             if bias_hemt_from_cfg:
-                self.log('Setting HEMT LNA Vg from config file to Vg={0:.{1}f}'.format(bias_hemt, 4),
+                self.log('Setting HEMT LNA Vg from config file to ' +
+                         f'Vg={bias_hemt:.3f}',
                          self.LOG_USER)
             else:
-                self.log('Setting HEMT LNA Vg to requested Vg={0:.{1}f}'.format(bias_hemt, 4),
+                self.log('Setting HEMT LNA Vg to requested ' +
+                         f'Vg={bias_hemt:.3f}',
                          self.LOG_USER)
 
             self.set_hemt_gate_voltage(bias_hemt, override=True, **kwargs)
 
         # otherwise do nothing and warn the user
         else:
-            self.log('No value specified for 50K LNA Vg and didn\'t find a ' +
-                'default in cfg (amplifier[\'hemt_Vg\']).', self.LOG_ERROR)
+            self.log("No value specified for 4K HEMT Vg and " +
+                     "didn't find a default in cfg " +
+                     "(amplifier['hemt_Vg']).",
+                     self.LOG_ERROR)
         ### done with 4K HEMT
         ########################################################################
 
@@ -2708,20 +2729,21 @@ class SmurfUtilMixin(SmurfBase):
         # set it and tell the user
         if bias_50k is not None:
             if bias_50k_from_cfg:
-                self.log('Setting 50K LNA Vg from config file ' +
-                    'to Vg={0:.{1}f}'.format(bias_50k, 4),
+                self.log('Setting 50K LNA Vg from config file to ' +
+                         f'Vg={bias_50k:.3f}',
                          self.LOG_USER)
             else:
                 self.log('Setting 50K LNA Vg to requested '+
-                    'Vg={0:.{1}f}'.format(bias_50k, 4),
+                         f'Vg={bias_50k:.3f}',
                          self.LOG_USER)
 
             self.set_50k_amp_gate_voltage(bias_50k, **kwargs)
 
         # otherwise do nothing and warn the user
         else:
-            self.log('No value specified for 50K LNA Vg and didn\'t find a ' +
-                'default in cfg (amplifier[\'LNA_Vg\']).',
+            self.log("No value specified for 50K LNA Vg and " +
+                     "didn't find a default in cfg " +
+                     "(amplifier['LNA_Vg']).",
                      self.LOG_ERROR)
         ### done with 50K LNA
         ########################################################################
@@ -2888,7 +2910,7 @@ class SmurfUtilMixin(SmurfBase):
 
             self.set_tes_bias_high_current(bias_group)
             self.log('Driving high current through TES. ' +
-                'Waiting {}'.format(overbias_wait), self.LOG_USER)
+                     f'Waiting {overbias_wait}', self.LOG_USER)
 
             time.sleep(overbias_wait)
 
@@ -2976,7 +2998,7 @@ class SmurfUtilMixin(SmurfBase):
         self.set_tes_bias_bipolar_array(voltage_bias_array)
 
         # Cool wait
-        self.log('Waiting {:3.2f} seconds to cool'.format(cool_wait),
+        self.log(f'Waiting {cool_wait:3.2f} seconds to cool',
                  self.LOG_USER)
         time.sleep(cool_wait)
         self.log('Done waiting.', self.LOG_USER)
@@ -3061,12 +3083,13 @@ class SmurfUtilMixin(SmurfBase):
         r = 16
 
         old_relay = self.get_cryo_card_relays()
-        old_relay = self.get_cryo_card_relays() # query twice to ensure update
-        self.log('Old relay {}'.format(bin(old_relay)))
+        # query twice to ensure update
+        old_relay = self.get_cryo_card_relays()
+        self.log(f'Old relay {bin(old_relay)}')
 
         new_relay = np.copy(old_relay)
         new_relay = (1 << r) | new_relay
-        self.log('New relay {}'.format(bin(new_relay)))
+        self.log(f'New relay {bin(new_relay)}')
         self.set_cryo_card_relays(new_relay, write_log=write_log)
         self.get_cryo_card_relays()
 
@@ -3090,7 +3113,7 @@ class SmurfUtilMixin(SmurfBase):
         if old_relay & 1 << r != 0:
             new_relay = new_relay & ~(1 << r)
 
-        self.log('New relay {}'.format(bin(new_relay)))
+        self.log(f'New relay {bin(new_relay)}')
         self.set_cryo_card_relays(new_relay)
         self.get_cryo_card_relays()
 
@@ -3359,7 +3382,7 @@ class SmurfUtilMixin(SmurfBase):
         elif smurf_chans is not None:
             keys = smurf_chans.keys()
             for k in keys:
-                self.log('Band {}'.format(k))
+                self.log(f'Band {k}')
                 n_chan = self.get_number_channels(k)
                 for ch in smurf_chans[k]:
 
@@ -3382,7 +3405,8 @@ class SmurfUtilMixin(SmurfBase):
             self.log('NOT DYNAMICALLY GENERATING THE MASK. STATIC. SET static_mask=0 '+
                      'IN CFG TO DYNAMICALLY GENERATE MASKS!!!')
         else:
-            self.log('Generating gcp mask file. {} channels added'.format(len(gcp_chans)))
+            self.log(f'Generating gcp mask file. {len(gcp_chans)} ' +
+                     'channels added')
 
             np.savetxt(self.smurf_to_mce_mask_file, gcp_chans, fmt='%i')
 
@@ -3701,7 +3725,7 @@ class SmurfUtilMixin(SmurfBase):
         mask = self.make_mask_lookup(mask_file)
 
         if mask[band, channel] == -1:
-            self.log('Band {} Ch {} not in mask file'.format(band, channel))
+            self.log(f'Band {band} Ch {channel} not in mask file')
             return None
 
         return self.mask_num_to_gcp_num(mask[band, channel])
@@ -3910,8 +3934,8 @@ class SmurfUtilMixin(SmurfBase):
         # Unless asked to be quiet, print where we're putting a fixed
         # tone.
         if not quiet:
-            self.log('Setting a fixed tone at {0:.2f} MHz'.format(freq_mhz) +
-                ' and amplitude {}'.format(drive), self.LOG_USER)
+            self.log(f'Setting a fixed tone at {freq_mhz:.2f} MHz' +
+                     f' and amplitude {drive}', self.LOG_USER)
 
     # SHOULD MAKE A GET FIXED TONE CHANNELS FUNCTION - WOULD MAKE IT
     # EASIER TO CHANGE THINGS FAST USING THE ARRAY GET/SETS
@@ -3958,7 +3982,8 @@ class SmurfUtilMixin(SmurfBase):
         if filename is None:
             filename=str(self.get_timestamp())+'_hwlog.dat'
         self.__hardware_log_file = os.path.join(self.output_dir, filename)
-        self.log('Starting hardware logging to file : {}'.format(self.__hardware_log_file),
+        self.log('Starting hardware logging to file : ' +
+                 f'{self.__hardware_log_file}',
                  self.LOG_USER)
         self.__hardware_logging_stop_event=threading.Event()
         self.__hardware_logging_pause_event=threading.Event()
@@ -4028,7 +4053,8 @@ class SmurfUtilMixin(SmurfBase):
 
         for bay in bays:
             for dac in [0,1]:
-                d['bay%d_dac%d_temp'%(bay,dac)]=lambda:self.get_dac_temp(bay,dac)
+                d[f'bay{bay}_dac{dac}_temp']=(
+                    lambda:self.get_dac_temp(bay,dac))
 
         #AT THE MOMENT, WAY TOO SLOW
         # keep track of how many tones are on in each band
@@ -4054,7 +4080,7 @@ class SmurfUtilMixin(SmurfBase):
         for key, value in d.items():
             columns.append(str(value()))
             names.append(key)
-            fmt+='{0[%d]:<20}'%counter
+            fmt+=f'{0[{counter}]:<20}'
             counter+=1
         fmt+='\n'
 

--- a/python/pysmurf/client/util/tools.py
+++ b/python/pysmurf/client/util/tools.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 #-----------------------------------------------------------------------------
+# Title      : pysmurf util tools
+#-----------------------------------------------------------------------------
+# File       : pysmurf/util/tools.py
+# Created    : 2018-08-29
+#-----------------------------------------------------------------------------
 # This file is part of the pysmurf software package. It is subject to
 # the license terms in the LICENSE.txt file found in the top-level directory
 # of this distribution and at:
@@ -12,15 +17,47 @@ import numpy as np
 from scipy.optimize import curve_fit
 
 def skewed_lorentzian(x, bkg, bkg_slp, skw, mintrans, res_f, Q):
-    """
-    Skewed Lorentzian
+    """ Skewed Lorentzian model.
+
+    Parameters
+    ----------
+    x : float
+        The x-data to build the skewed Lorentzian
+    bkg : float
+        The DC value of the skewed Lorentzian
+    bkg_slp : float
+        The slope of the skewed Lorentzian
+    skw : float
+        The skewness of the Lorentzian
+    mintrans : float
+        The minimum of the trans. This is associated with the skewness term.
+    res_f : float
+        The center frequency of the resonator (the center of the Lorentzian)
+    Q : float
+        The Q of the resonator
+
+    Returns
+    -------
+    float
+        The model of the Lorentzian
     """
     return bkg + bkg_slp*(x-res_f)-(mintrans+skw*(x-res_f))/\
         (1+4*Q**2*((x-res_f)/res_f)**2)
 
 def fit_skewed_lorentzian(f, mag):
-    """
-    Fits frequency and magnitude data with a skewed lorentzian
+    """ Fits frequency and magnitude data with a skewed lorentzian.
+
+    Args
+    ----
+    f : float array
+        The frequency array
+    mag : float array
+        The resonator response array
+
+    Returns
+    -------
+    fit_params : float array
+        The fit parameters
     """
 
     # define the initial values
@@ -31,63 +68,102 @@ def fit_skewed_lorentzian(f, mag):
     res_f = f[mag.argmin()]
     Q = 1e4
 
-    low_bounds = [bkg/2,-1e-3,-1,0,f[0],1e2]
-    up_bounds = [bkg*2,1e-3,1,30,f[-1],1e5]
+    low_bounds = [bkg/2, -1e-3, -1, 0, f[0], 1e2]
+    up_bounds = [bkg*2, 1e-3, 1, 30, f[-1], 1e5]
 
     try:
-        popt,pcov = curve_fit(skewed_lorentzian, f, mag,
-            p0=[bkg,bkg_slp,skw,mintrans,res_f,Q], method='lm')
-        if popt[5]<0:
+        popt, pcov = curve_fit(skewed_lorentzian, f, mag,
+            p0=[bkg, bkg_slp, skw,mintrans, res_f, Q], method='lm')
+        if popt[5] < 0:
             popt, pcov = curve_fit(skewed_lorentzian, f, mag,
-                p0=[bkg,bkg_slp,skw,mintrans,res_f,Q],
-                bounds=(low_bounds,up_bounds))
+                p0=[bkg, bkg_slp, skw, mintrans, res_f, Q],
+                bounds=(low_bounds, up_bounds))
     except RuntimeError:
-        popt=np.zeros((6,))
+        popt = np.zeros((6,))
     except ValueError:
-        popt=np.zeros((6,))
+        popt = np.zeros((6,))
 
     return popt
 
 
-def limit_phase_deg(phase,minphase=-180):
-    """
+def limit_phase_deg(phase, minphase=-180):
+    """ Limits the phase in degrees
+
     Brazenly stolen from
     https://stackoverflow.com/questions/2320986/easy-way-to-keeping-angles-between-179-and-180-degrees
-    """
-    newPhase=phase
-    while newPhase<=minphase:
-        newPhase+=360
-    while newPhase>minphase+360:
-        newPhase-=360
-    return newPhase
 
-def P_singleMode(f_center,bw,T):
+    Args
+    ----
+    phase : float
+        The input phase
+    minphase : float
+        The minimum phase
+
+    Returns
+    -------
+    phase_limited : float
+        The phase information with the limited phase
+    """
+    phase_limited = np.copy(phase)
+    while phase_limited <= minphase:
+        phase_limited += 360
+    while phase_limited > minphase + 360:
+        phase_limited -= 360
+    return phase_limited
+
+def P_singleMode(f_center, bw, T):
     '''
     Optical power in a single mode in a bandwidth bw centered on frequency
     f_center from an optical load of temperature T.  SI units.
+
+    Args
+    ----
+    f_center : float
+        The center frequency
+    bw : float
+        The bandwidth in SI units
+    T : float
+        The temperature
+
+    Returns
+    -------
+    float
+        The optical power
     '''
-    h=6.63e-34
-    kB=1.38e-23
-    df=bw/1000.
-    f_array = np.arange(f_center-bw/2.,f_center+bw/2.+df,df)
+    h = 6.63e-34
+    kB = 1.38e-23
+    df = bw/1000.
+    f_array = np.arange(f_center-bw/2., f_center+bw/2.+df, df)
     P = 0.
+
+    # Integrate over frequency bandwidth
     for i in range(len(f_array)):
-        f=f_array[i]
+        f = f_array[i]
         P += df*h*f/(np.exp(h*f/(kB*T))-1.)
     return P
 
-def dPdT_singleMode(f_center,bw,T):
+def dPdT_singleMode(f_center, bw, T):
     '''
     Change in optical power per change in temperature (dP/dT) in a single mode
     in a bandwidth bw centered on frequency f_center from an optical load of
     temperature T. SI units.
     '''
     dT = T/1e6
-    dP = P_singleMode(f_center,bw,T+dT) - P_singleMode(f_center,bw,T)
+    dP = P_singleMode(f_center, bw, T+dT) - P_singleMode(f_center, bw, T)
     return dP/dT
 
 def load_yaml(filename):
-    """
+    """ Load the yml yaml file
+
+    Args
+    ----
+    filename : str
+        Full path to the yaml file
+
+    Returns
+    -------
+    yaml_file_object
+        The yaml file
     """
     import yaml
 
@@ -97,17 +173,44 @@ def load_yaml(filename):
     return dat
 
 def yaml_parse(yml, cmd):
-    """
+    """ Gets the values out of the yaml file
+
+    Args
+    ----
+    yml : yaml_file
+        The input yaml file, loaded with load_yaml
+    cmd : str
+        The full epics path in the yaml file
+
+    Returns
+    -------
+    val
+        The value associated with the requested cmd
     """
     cmd = cmd.split(':')[1:]  # First is epics root. Throw out
 
     def get_val(yml, c):
+        """ Extracts the values.
+
+        This is a convenience function that calls itself recursively.
+
+        Args
+        ----
+        yml : yaml_file
+            The input yaml_file
+        c : str
+            The epics path
+
+        Returns
+        -------
+        val
+            The value associated with input param c
+        """
         if np.size(c) == 1 and c[0] in yml.keys():
             return yml[c[0]]
         elif np.size(c) > 1 and c[0] in yml.keys():
             return get_val(yml[c[0]], c[1:])
-        else:
-            return np.nan
+        return np.nan
 
     return get_val(yml, cmd)
 

--- a/python/pysmurf/client/watchdog/JesdWatchdog.py
+++ b/python/pysmurf/client/watchdog/JesdWatchdog.py
@@ -41,7 +41,8 @@ class JesdWatchdog(object):
 
     @staticmethod
     def jesdRXReset(prefix):
-        logging.error('[%s] ' % str(datetime.now()) + ' JesdRx went down, will attempt to recover...')
+        logging.error(f'[{datetime.now()}] ' +
+                      ' JesdRx went down, will attempt to recover...')
 
         # for recovery
         PwrUpSysRef = epics.get_pv(prefix + ':AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:LMK:PwrUpSysRef')
@@ -55,7 +56,8 @@ class JesdWatchdog(object):
 
     @staticmethod
     def jesdTXReset(prefix):
-        logging.error('[%s] ' % str(datetime.now()) + ' JesdTx went down, will attempt to recover...')
+        logging.error(f'[{datetime.now()}] ' +
+                      ' JesdTx went down, will attempt to recover...')
 
         # for recovery
         PwrUpSysRef = epics.get_pv(prefix + ':AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:LMK:PwrUpSysRef')

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -99,7 +99,7 @@ class PcieDev():
         """
         Open the RSSI connection on the specified lane, using the specified IP address.
         """
-        print("    Opening PCIe RSSI lane {}".format(lane))
+        print(f"    Opening PCIe RSSI lane {lane}")
         self._root.Core.UdpGrp.UdpConfig[lane].EnKeepAlive.set(1)
         self._root.Core.UdpGrp.UdpConfig[lane].KeepAliveConfig.set(0x2E90EDD0)  # 5 seconds
         self._root.Core.UdpGrp.RssiClient[lane].OpenConn.set(1)
@@ -116,7 +116,7 @@ class PcieDev():
         """
         Close the RSSI connection on the specified Ethernet lane.
         """
-        print("    Closing PCIe RSSI lane {}".format(lane))
+        print(f"    Closing PCIe RSSI lane {lane}")
         self._root.Core.UdpGrp.UdpConfig[lane].KeepAliveConfig.set(0)
         self._root.Core.UdpGrp.RssiClient[lane].OpenConn.set(0)
         self._root.Core.UdpGrp.RssiClient[lane].CloseConn.set(1)
@@ -131,26 +131,36 @@ class PcieDev():
         Print the register for the specified Ethernet lane.
         """
         print("      PCIe register status:")
-        print("      Core.UdpGrp.UdpConfig[{}].EnKeepAlive         = {}".format(lane,
-            self._root.Core.UdpGrp.UdpConfig[lane].EnKeepAlive.get()))
-        print("      Core.UdpGrp.UdpConfig[{}].KeepAliveConfig     = 0x{:02X}".format(lane,
-            self._root.Core.UdpGrp.UdpConfig[lane].KeepAliveConfig.get()))
-        print("      Core.UdpGrp.RssiClient[{}].OpenConn           = {}".format(lane,
-            self._root.Core.UdpGrp.RssiClient[lane].OpenConn.get()))
-        print("      Core.UdpGrp.RssiClient[{}].CloseConn          = {}".format(lane,
-            self._root.Core.UdpGrp.RssiClient[lane].CloseConn.get()))
-        print("      Core.UdpGrp.UdpEngine[{}].ClientRemotePort[0] = {}".format(lane,
-            self._root.Core.UdpGrp.UdpEngine[lane].ClientRemotePort[0].get()))
-        print("      Core.UdpGrp.UdpEngine[{}].ClientRemoteIp[0]   = {}".format(lane,
-            self._root.Core.UdpGrp.UdpEngine[lane].ClientRemoteIp[0].get()))
-        print("      Core.UdpGrp.UdpEngine[{}].ClientRemotePort[1] = {}".format(lane,
-            self._root.Core.UdpGrp.UdpEngine[lane].ClientRemotePort[1].get()))
-        print("      Core.UdpGrp.UdpEngine[{}].ClientRemoteIp[1]   = {}".format(lane,
-            self._root.Core.UdpGrp.UdpEngine[lane].ClientRemoteIp[1].get()))
-        print("      Core.EthPhyGrp.EthConfig[{}].LocalMac         = {}".format(lane,
-            self._root.Core.EthPhyGrp.EthConfig[lane].LocalMac.get()))
-        print("      Core.EthPhyGrp.EthConfig[{}].LocalIp          = {}".format(lane,
-            self._root.Core.EthPhyGrp.EthConfig[lane].LocalIp.get()))
+        print(
+            f"      Core.UdpGrp.UdpConfig[{lane}].EnKeepAlive         = " +
+            f"{self._root.Core.UdpGrp.UdpConfig[lane].EnKeepAlive.get()}")
+        print(
+            f"      Core.UdpGrp.UdpConfig[{lane}].KeepAliveConfig     = 0x" +
+            f"{self._root.Core.UdpGrp.UdpConfig[lane].KeepAliveConfig.get():02X}")
+        print(
+            f"      Core.UdpGrp.RssiClient[{lane}].OpenConn           = " +
+            f"{self._root.Core.UdpGrp.RssiClient[lane].OpenConn.get()}")
+        print(
+            f"      Core.UdpGrp.RssiClient[{lane}].CloseConn          = " +
+            f"{self._root.Core.UdpGrp.RssiClient[lane].CloseConn.get()}")
+        print(
+            f"      Core.UdpGrp.UdpEngine[{lane}].ClientRemotePort[0] = " +
+            f"{self._root.Core.UdpGrp.UdpEngine[lane].ClientRemotePort[0].get()}")
+        print(
+            f"      Core.UdpGrp.UdpEngine[{lane}].ClientRemoteIp[0]   = " +
+            f"{self._root.Core.UdpGrp.UdpEngine[lane].ClientRemoteIp[0].get()}")
+        print(
+            f"      Core.UdpGrp.UdpEngine[{lane}].ClientRemotePort[1] = " +
+            f"{self._root.Core.UdpGrp.UdpEngine[lane].ClientRemotePort[1].get()}")
+        print(
+            f"      Core.UdpGrp.UdpEngine[{lane}].ClientRemoteIp[1]   = " +
+            f"{self._root.Core.UdpGrp.UdpEngine[lane].ClientRemoteIp[1].get()}")
+        print(
+            f"      Core.EthPhyGrp.EthConfig[{lane}].LocalMac         = " +
+            f"{self._root.Core.EthPhyGrp.EthConfig[lane].LocalMac.get()}")
+        print(
+            f"      Core.EthPhyGrp.EthConfig[{lane}].LocalIp          = " +
+            f"{self._root.Core.EthPhyGrp.EthConfig[lane].LocalIp.get()}")
         print("")
 
     def print_version(self):
@@ -158,28 +168,28 @@ class PcieDev():
         Print the PCIe device firmware information.
         """
         print("  ==============================================================")
-        print("                   {}".format(self._root.description))
+        print(f"                   {self._root.description}")
         print("  ==============================================================")
-        print("    FW Version      : 0x{:08X}".format(
-            self._root.Core.AxiPcieCore.AxiVersion.FpgaVersion.get()))
-        print("    FW GitHash      : 0x{:040X}".format(
-            self._root.Core.AxiPcieCore.AxiVersion.GitHash.get()))
-        print("    FW image name   : {}".format(
-            self._root.Core.AxiPcieCore.AxiVersion.ImageName.get()))
-        print("    FW build env    : {}".format(
-            self._root.Core.AxiPcieCore.AxiVersion.BuildEnv.get()))
-        print("    FW build server : {}".format(
-            self._root.Core.AxiPcieCore.AxiVersion.BuildServer.get()))
-        print("    FW build date   : {}".format(
-            self._root.Core.AxiPcieCore.AxiVersion.BuildDate.get()))
-        print("    FW builder      : {}".format(
-            self._root.Core.AxiPcieCore.AxiVersion.Builder.get()))
-        print("    Up time         : {}".format(
-            self._root.Core.AxiPcieCore.AxiVersion.UpTime.get()))
-        print("    Xilinx DNA ID   : 0x{:032X}".format(
-            self._root.Core.AxiPcieCore.AxiVersion.DeviceDna.get()))
-        print("    Device ID       : {}".format(
-            self._root.Core.AxiPcieCore.AxiVersion.DeviceId.get()))
+        print("    FW Version      : 0x" +
+              f"{self._root.Core.AxiPcieCore.AxiVersion.FpgaVersion.get():08X}")
+        print("    FW GitHash      : 0x" +
+              f"{self._root.Core.AxiPcieCore.AxiVersion.GitHash.get():040X}")
+        print("    FW image name   : " +
+              f"{self._root.Core.AxiPcieCore.AxiVersion.ImageName.get()}")
+        print("    FW build env    : " +
+              f"{self._root.Core.AxiPcieCore.AxiVersion.BuildEnv.get()}")
+        print("    FW build server : " +
+              f"{self._root.Core.AxiPcieCore.AxiVersion.BuildServer.get()}")
+        print("    FW build date   : " +
+              f"{self._root.Core.AxiPcieCore.AxiVersion.BuildDate.get()}")
+        print("    FW builder      : " +
+              f"{self._root.Core.AxiPcieCore.AxiVersion.Builder.get()}")
+        print("    Up time         : " +
+              f"{self._root.Core.AxiPcieCore.AxiVersion.UpTime.get()}")
+        print("    Xilinx DNA ID   : 0x" +
+              f"{self._root.Core.AxiPcieCore.AxiVersion.DeviceDna.get():032X}")
+        print("    Device ID       : " +
+              f"{self._root.Core.AxiPcieCore.AxiVersion.DeviceId.get()}")
         print("  ==============================================================")
         print("")
 
@@ -247,10 +257,10 @@ class PcieCard():
             # Check if we are trying to use PCIe communication without the PCIe
             # cards present in the system
             if not self._pcie_rssi_present:
-                exit_message("  ERROR: PCIe device {} not present.".format(dev_rssi))
+                exit_message(f"  ERROR: PCIe device {dev_rssi} not present.")
 
             if not self._pcie_data_present:
-                exit_message("  ERROR: PCIe device {} not present.".format(dev_data))
+                exit_message(f"  ERROR: PCIe device {dev_data} not present.")
 
             # Verify the lane number is valid
             if lane is None:
@@ -271,8 +281,9 @@ class PcieCard():
                 # Verify that its DeviceID is correct
                 dev_data_id = pcie.get_id()
                 if dev_data_id != 1:
-                    exit_message("  ERROR: The DeviceId for the PCIe dev for DATA is {} instead "
-                        "of 1. Choose the correct device.".format(dev_data_id))
+                    exit_message(
+                        f"  ERROR: The DeviceId for the PCIe dev for DATA is {dev_data_id} instead "
+                        "of 1. Choose the correct device.")
 
                 # Print FW information
                 pcie.print_version()
@@ -283,8 +294,9 @@ class PcieCard():
                 # Verify that its DeviceID is correct
                 dev_rssi_id = pcie.get_id()
                 if dev_rssi_id != 0:
-                    exit_message("  ERROR: The DeviceId for the PCIe dev for RSSI is {} instead "
-                        "of 0. Choose the correct device.".format(dev_rssi_id))
+                    exit_message(
+                        f"  ERROR: The DeviceId for the PCIe dev for RSSI is {dev_rssi_id} instead "
+                        "of 0. Choose the correct device.")
 
                 # Print FW information
                 pcie.print_version()
@@ -295,14 +307,14 @@ class PcieCard():
                 local_mac_addr = pcie.get_local_mac(lane=self._lane)
                 if local_mac_addr == "00:00:00:00:00:00":
                     valid_local_mac_addr = False
-                    pcie.set_local_mac(lane=self._lane, mac="08:00:56:00:45:5{}".format(lane))
+                    pcie.set_local_mac(lane=self._lane, mac=f"08:00:56:00:45:5{lane}")
                     local_mac_addr = pcie.get_local_mac(lane=self._lane)
 
                 valid_local_ip_addr = True
                 local_ip_addr = pcie.get_local_ip(lane=self._lane)
                 if local_ip_addr == "0.0.0.0":
                     valid_local_ip_addr = False
-                    pcie.set_local_ip(lane=self._lane, ip="10.0.1.20{}".format(lane))
+                    pcie.set_local_ip(lane=self._lane, ip=f"10.0.1.20{lane}")
                     local_ip_addr = pcie.get_local_ip(lane=self._lane)
 
 
@@ -315,7 +327,8 @@ class PcieCard():
                     try:
                         socket.inet_pton(socket.AF_INET, ip_addr)
                     except socket.error:
-                        exit_message("ERROR: IP Address read from the PCIe card: {} is invalid.".format(ip_addr))
+                        exit_message(
+                            f"ERROR: IP Address read from the PCIe card: {ip_addr} is invalid.")
 
                 # Update the IP address.
                 # Note: when the PCIe card is not in use, the IP will be defined
@@ -336,10 +349,10 @@ class PcieCard():
                 "Yes" if valid_local_mac_addr else "No. A default address was loaded"))
             print("  - Valid IP address                       : {}".format(
                 "Yes" if valid_local_ip_addr else "No. A default address was loaded"))
-            print("  - Local MAC address:                     : {}".format(local_mac_addr))
-            print("  - Local IP address:                      : {}".format(local_ip_addr))
-            print("  - Using IP address                       : {}".format(self._ip_addr))
-            print("  - Using RSSI lane number                 : {}".format(self._lane))
+            print(f"  - Local MAC address:                     : {local_mac_addr}")
+            print(f"  - Local IP address:                      : {local_ip_addr}")
+            print(f"  - Using IP address                       : {self._ip_addr}")
+            print(f"  - Using RSSI lane number                 : {self._lane}")
             print("")
 
         # When the PCIe card is not present we don't do anything
@@ -379,11 +392,11 @@ class PcieCard():
         # Check if the PCIe is present
         if self._pcie_rssi_present:
             with self._pcie_rssi as pcie:
-                print("  * Looking for RSSI lanes pointing to {}...".format(self._ip_addr))
+                print(f"  * Looking for RSSI lanes pointing to {self._ip_addr}...")
                 # Look for links with the target IP address, and close their RSSI connection
                 for i in range(6):
                     if self._ip_addr == pcie.get_remote_ip(lane=i, client=0):
-                        print("    Lane {} points to it. Disabling it...".format(i))
+                        print(f"    Lane {i} points to it. Disabling it...")
                         pcie.close_lane(i)
                         print("")
                 print("  Done!")

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -335,9 +335,12 @@ class PcieCard():
                 # by the user.
                 self._ip_addr = ip_addr
 
-        # Yes no function for reporting status
+        # Yes no functions for reporting status
         def yes_or_no(b):
             return ("Yes" if b else "No")
+
+        def yes_or_no_addr(b):
+            return ("Yes" if b else "No. A default address was loaded")
 
         # Print system configuration and status
         print("  - PCIe for RSSI present in the system    : " +
@@ -349,10 +352,10 @@ class PcieCard():
 
         # Show IP address and lane when the PCIe is in use
         if self._use_pcie:
-            print("  - Valid MAC address                      : {}".format(
-                "Yes" if valid_local_mac_addr else "No. A default address was loaded"))
-            print("  - Valid IP address                       : {}".format(
-                "Yes" if valid_local_ip_addr else "No. A default address was loaded"))
+            print("  - Valid MAC address                      : " +
+                  f"{yes_or_no_addr(valid_local_mac_addr)}")
+            print("  - Valid IP address                       : " +
+                  f"{yes_or_no_addr(valid_local_ip_addr)}")
             print(f"  - Local MAC address:                     : {local_mac_addr}")
             print(f"  - Local IP address:                      : {local_ip_addr}")
             print(f"  - Using IP address                       : {self._ip_addr}")

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -338,7 +338,7 @@ class PcieCard():
         # Yes no function for reporting status
         def yes_or_no(b):
             return ("Yes" if b else "No")
-                
+
         # Print system configuration and status
         print("  - PCIe for RSSI present in the system    : " +
               f"{yes_or_no(self._pcie_rssi_present)}")

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -335,13 +335,17 @@ class PcieCard():
                 # by the user.
                 self._ip_addr = ip_addr
 
+        # Yes no function for reporting status
+        def yes_or_no(b):
+            return ("Yes" if b else "No")
+                
         # Print system configuration and status
-        print("  - PCIe for RSSI present in the system    : {}".format(
-            "Yes" if self._pcie_rssi_present else "No"))
-        print("  - PCIe for Data present in the system    : {}".format(
-            "Yes" if self._pcie_data_present else "No"))
-        print("  - PCIe based communicartion selected     : {}".format(
-            "Yes" if self._use_pcie else "No"))
+        print("  - PCIe for RSSI present in the system    : " +
+              f"{yes_or_no(self._pcie_rssi_present)}")
+        print("  - PCIe for Data present in the system    : " +
+              f"{yes_or_no(self._pcie_data_present)}")
+        print("  - PCIe based communication selected     : " +
+              f"{yes_or_no(self._use_pcie)}")
 
         # Show IP address and lane when the PCIe is in use
         if self._use_pcie:

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -139,7 +139,7 @@ class Common(pyrogue.Root):
         # Add epics interface
         self._epics = None
         if epics_prefix:
-            print("Starting EPICS server using prefix \"{}\"".format(epics_prefix))
+            print(f"Starting EPICS server using prefix \"{epics_prefix}\"")
             from pyrogue.protocols import epics
             self._epics = epics.EpicsCaServer(base=epics_prefix, root=self)
             self._pv_dump_file = pv_dump_file
@@ -147,13 +147,15 @@ class Common(pyrogue.Root):
             # PVs for stream data
             # This should be replaced with DataReceiver objects
             if stream_pv_size:
-                print("Enabling stream data on PVs (buffer size = {} points, data type = {})"
-                    .format(stream_pv_size,stream_pv_type))
+                print(
+                    "Enabling stream data on PVs " +
+                    f"(buffer size = {stream_pv_size} points, " +
+                    f"data type = {stream_pv_type})")
 
                 self._stream_fifos  = []
                 self._stream_slaves = []
                 for i in range(4):
-                    self._stream_slaves.append(self._epics.createSlave(name="AMCc:Stream{}".format(i),
+                    self._stream_slaves.append(self._epics.createSlave(name=f"AMCc:Stream{i}",
                                                                        maxSize=stream_pv_size,
                                                                        type=stream_pv_type))
 
@@ -198,14 +200,17 @@ class Common(pyrogue.Root):
             print("")
             print("FPGA image build information:")
             print("===================================")
-            print("BuildStamp              : {}"
-                .format(self.FpgaTopLevel.AmcCarrierCore.AxiVersion.BuildStamp.get()))
-            print("FPGA Version            : 0x{:x}"
-                .format(self.FpgaTopLevel.AmcCarrierCore.AxiVersion.FpgaVersion.get()))
-            print("Git hash                : 0x{:x}"
-                .format(self.FpgaTopLevel.AmcCarrierCore.AxiVersion.GitHash.get()))
+            print(
+                "BuildStamp              : " +
+                f"{self.FpgaTopLevel.AmcCarrierCore.AxiVersion.BuildStamp.get()}")
+            print(
+                "FPGA Version            : 0x" +
+                f"{self.FpgaTopLevel.AmcCarrierCore.AxiVersion.FpgaVersion.get():x}")
+            print(
+                "Git hash                : 0x" +
+                f"{self.FpgaTopLevel.AmcCarrierCore.AxiVersion.GitHash.get():x}")
         except AttributeError as attr_error:
-            print("Attibute error: {}".format(attr_error))
+            print(f"Attibute error: {attr_error}")
         print("")
 
         # Start epics
@@ -246,5 +251,5 @@ class Common(pyrogue.Root):
             print('No default configuration file was specified...')
             return
 
-        print('Setting defaults from file {}'.format(self._config_file))
+        print(f'Setting defaults from file {self._config_file}')
         self.LoadConfig(self._config_file)

--- a/python/pysmurf/core/utilities/_SmurfPublisher.py
+++ b/python/pysmurf/core/utilities/_SmurfPublisher.py
@@ -86,8 +86,10 @@ class SmurfPublisher(object):
             self._backend = self._backend_udp
 
         else:
-            sys.stderr.write('%s: no backend for "%s", selecting null Publisher.\n' %
-                             (self.__class__, backend))
+            sys.stderr.write(
+                f'{self.__class__}: no backend for "{backend}", ' +
+                'selecting null Publisher.\n')
+
             self._backend = self._backend_null
 
         # ###########################
@@ -124,8 +126,10 @@ class SmurfPublisher(object):
         payload = bytes(json_msg, 'utf_8')
         if len(payload) > UDP_MAX_BYTES:
             # Can't send this; write to stderr and notify consumer.
-            error = 'Backend error: dropped large UDP packet (%i bytes).' % len(payload)
-            sys.stderr.write('%s %s' % (self, error))
+            error = (
+                'Backend error: dropped large UDP packet ' +
+                f'({len(payload)} bytes).')
+            sys.stderr.write(f'{self} {error}')
             self.publish({'message': error}, 'backend_error')
             return
         self.udp_sock.sendto(payload, (self.udp_ip, self.udp_port))


### PR DESCRIPTION
## Issue
This PR resolves https://github.com/slaclab/pysmurf/issues/419 and partially addresses https://github.com/slaclab/pysmurf/issues/397.

## Description

The main purpose of this PR is to add all of the docstrings for the SmurfConfig class, but it includes some minor bug fixes, a lot of linting, and a lot of cleanup (mostly aesthetic).

- Adds complete docstrings for smurf_config submodule.
- Now using only fstring formatting for all of pysmurf client and core code.
- Adds flake8-sfs module with directive to enforce fstring string formatting.
- Resolves nearly every flake8-docstrings warnings for the smurf_config submodule.
- `SmurfConfig.read()` now returns the loaded configuration dictionary, resolving issue https://github.com/slaclab/pysmurf/issues/419.
- Changes sphinx references to be auto-numbered.
- Adds method role to flake8-rst-docstrings plugin.
- Adds skip instruction for pylint to client/base/schema.py 3rd party code.
- Resolves almost all trivial pylint errors for smurf_config submodule.
- Resolves some trivial pylint errors throughout client code.

## Does this PR break any interface?
- [ ] Yes
- [x] No