### PR TITLE
Create new rogue variable `EnabledBays` with a list of enabled bays

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -4603,7 +4603,6 @@ class SmurfCommandMixin(SmurfBase):
         self._caput(self.channel_mapper + self._payload_size,
                     payload_size, **kwargs)
 
-    _enabled_bays = self.amcc + "EnabledBays"
     def get_enabled_bays(self, **kwargs):
         """
         Gets list of enabled bays.
@@ -4613,4 +4612,9 @@ class SmurfCommandMixin(SmurfBase):
         bays : list of int
             Which bays were enabled on pysmurf server startup.
         """
-        return self._caget(self._enabled_bays, **kwargs)
+        bays = []
+        _bays = self._caget(self.amcc + "EnabledBays", as_string=True, **kwargs)
+        for i in [0, 1]:
+            if str(i) in _bays:
+                bays.append(i)
+        return bays

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -264,6 +264,19 @@ class SmurfCommandMixin(SmurfBase):
                            self._smurf_startup_arguments,
                            as_string=True, **kwargs)
 
+    _enabled_bays = "EnabledBays"
+
+    def get_enabled_bays(self, **kwargs):
+        """
+        Gets list of enabled bays.
+
+        Returns
+        -------
+        bays : list of int
+            Which bays were enabled on pysmurf server startup.
+        """
+        return list(self._caget(self.smurf_application + self._enabled_bays, **kwargs))
+
     #### End SmurfApplication gets/sets
 
     _rogue_version = 'RogueVersion'
@@ -4671,19 +4684,3 @@ class SmurfCommandMixin(SmurfBase):
         """
         self._caput(self.channel_mapper + self._payload_size,
                     payload_size, **kwargs)
-
-    def get_enabled_bays(self, **kwargs):
-        """
-        Gets list of enabled bays.
-
-        Returns
-        -------
-        bays : list of int
-            Which bays were enabled on pysmurf server startup.
-        """
-        bays = []
-        _bays = self._caget(self.amcc + "EnabledBays", as_string=True, **kwargs)
-        for i in [0, 1]:
-            if str(i) in _bays:
-                bays.append(i)
-        return bays

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -4602,3 +4602,15 @@ class SmurfCommandMixin(SmurfBase):
         """
         self._caput(self.channel_mapper + self._payload_size,
                     payload_size, **kwargs)
+
+    _enabled_bays = self.amcc + "EnabledBays"
+    def get_enabled_bays(self, **kwargs):
+        """
+        Gets list of enabled bays.
+
+        Returns
+        -------
+        bays : list of int
+            Which bays were enabled on pysmurf server startup.
+        """
+        return self._caget(self._enabled_bays, **kwargs)

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2156,17 +2156,7 @@ class SmurfUtilMixin(SmurfBase):
         bays : list of int
             Which bays were enabled on pysmurf server startup.
         """
-        # What arguments were passed to the pysmurf server on startup?
-        smurf_startup_args=self.get_smurf_startup_args()
-
-        # Bays are enabled unless --disable-bay{bay} is provided to
-        # the pysmurf server on startup.
-        bays=[]
-        for bay in [0,1]:
-            if f'--disable-bay{bay}' not in smurf_startup_args:
-                bays.append(bay)
-
-        return bays
+        return self.get_enabled_bays()
 
     def which_bands(self):
         """Which bands the carrier firmware was built for.

--- a/python/pysmurf/core/devices/_SmurfApplication.py
+++ b/python/pysmurf/core/devices/_SmurfApplication.py
@@ -26,7 +26,11 @@ class SmurfApplication(pyrogue.Device):
     """
     SMuRF Application Block
     """
-    def __init__(self, **kwargs):
+    def __init__(self,
+                 disable_bay0 = False,
+                 disable_bay1 = False,
+                 **kwargs):
+
         pyrogue.Device.__init__(self, name="SmurfApplication", description='SMuRF Application Container', **kwargs)
 
         self.add(pyrogue.LocalVariable(
@@ -59,3 +63,9 @@ class SmurfApplication(pyrogue.Device):
             mode='RW',
             value=0, # Initial value determine variable type, (int, float, list, etc)
         ))
+
+        self.add(pyrogue.LocalVariable(
+            name='EnabledBays',
+            description='List of bays that are enabled',
+            value=[i for i,e in enumerate([disable_bay0, disable_bay1]) if not e],
+            mode='RO'))

--- a/python/pysmurf/core/devices/_SmurfApplication.py
+++ b/python/pysmurf/core/devices/_SmurfApplication.py
@@ -26,10 +26,7 @@ class SmurfApplication(pyrogue.Device):
     """
     SMuRF Application Block
     """
-    def __init__(self,
-                 disable_bay0 = False,
-                 disable_bay1 = False,
-                 **kwargs):
+    def __init__(self, **kwargs):
 
         pyrogue.Device.__init__(self, name="SmurfApplication", description='SMuRF Application Container', **kwargs)
 
@@ -64,8 +61,16 @@ class SmurfApplication(pyrogue.Device):
             value=0, # Initial value determine variable type, (int, float, list, etc)
         ))
 
+        # This variable will hold a list of the enabled bays. We set here the initial
+        # value as a list of 2 elements, which will be its maximum size (as we have at
+        # most 2 enabled bays). Its EPICS PV will be created with the initial size of
+        # this list. This will generated an EPICS PV of size 2 in all cases, as currently
+        # a bug in rogue does not allow to read list of size 1; also on the client side,
+        # epics.caget will always return an numpy array even when only 1 bay is enabled.
+        # We fill the list will invalid values; the list will be updated after the rogue
+        # root is started (to wait for the PV to be created) with the correct values.
         self.add(pyrogue.LocalVariable(
             name='EnabledBays',
             description='List of bays that are enabled',
-            value=[i for i,e in enumerate([disable_bay0, disable_bay1]) if not e],
+            value=[2, 2],
             mode='RO'))

--- a/python/pysmurf/core/roots/CmbEth.py
+++ b/python/pysmurf/core/roots/CmbEth.py
@@ -96,4 +96,6 @@ class CmbEth(Common):
                         configure      = configure,
                         VariableGroups = VariableGroups,
                         server_port    = server_port,
+                        disable_bay0   = disable_bay0,
+                        disable_bay1   = disable_bay1,
                         **kwargs)

--- a/python/pysmurf/core/roots/CmbPcie.py
+++ b/python/pysmurf/core/roots/CmbPcie.py
@@ -91,4 +91,6 @@ class CmbPcie(Common):
                         configure      = configure,
                         VariableGroups = VariableGroups,
                         server_port    = server_port,
+                        disable_bay0   = disable_bay0,
+                        disable_bay1   = disable_bay1,
                         **kwargs)

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -52,9 +52,7 @@ class Common(pyrogue.Root):
         # self._fpga = Top level FPGA
 
         # Add PySmurf Application Block
-        self.add(pysmurf.core.devices.SmurfApplication(
-            disable_bay0=disable_bay0,
-            disable_bay1=disable_bay1))
+        self.add(pysmurf.core.devices.SmurfApplication())
 
         # Add FPGA
         self.add(self._fpga)
@@ -192,6 +190,8 @@ class Common(pyrogue.Root):
                                                                   autoPrefix='config',
                                                                   autoCompress=False))
 
+        # List of enabled bays
+        self._enabled_bays = [i for i,e in enumerate([disable_bay0, disable_bay1]) if not e]
 
     def start(self):
         pyrogue.Root.start(self)
@@ -231,6 +231,9 @@ class Common(pyrogue.Root):
         # Load default configuration, if requested
         if self._configure:
             self.setDefaults.call()
+
+        # Update the 'EnabledBays' variable with the correct list of enabled bays.
+        self.SmurfApplication.EnabledBays.set(self._enabled_bays)
 
         # Workaround: Set the Mask value to '[0]' by default when the server starts.
         # This is needed because the pysmurf-client by default stat data streaming

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -38,6 +38,8 @@ class Common(pyrogue.Root):
                  configure      = False,
                  VariableGroups = None,
                  server_port    = 0,
+                 disable_bay0   = False,
+                 disable_bay1   = False,
                  **kwargs):
 
         pyrogue.Root.__init__(self, name="AMCc", initRead=True, pollEn=polling_en,
@@ -128,6 +130,17 @@ class Common(pyrogue.Root):
             name='setDefaults',
             description='Set default configuration',
             function=self._set_defaults_cmd))
+
+        bays = []
+        if not disable_bay0:
+            bays.append(0)
+        if not disable_bay1:
+            bays.append(1)
+        self.add(pyrogue.LocalVariable(
+            name='EnabledBays',
+            description='List of bays that are enabled',
+            value=bays,
+            mode='RO'))
 
         # Flag that indicates if the default configuration should be loaded
         # once the root is started.

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -139,7 +139,7 @@ class Common(pyrogue.Root):
         self.add(pyrogue.LocalVariable(
             name='EnabledBays',
             description='List of bays that are enabled',
-            value=bays,
+            value=str(bays),
             mode='RO'))
 
         # Flag that indicates if the default configuration should be loaded

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -52,7 +52,9 @@ class Common(pyrogue.Root):
         # self._fpga = Top level FPGA
 
         # Add PySmurf Application Block
-        self.add(pysmurf.core.devices.SmurfApplication())
+        self.add(pysmurf.core.devices.SmurfApplication(
+            disable_bay0=disable_bay0,
+            disable_bay1=disable_bay1))
 
         # Add FPGA
         self.add(self._fpga)
@@ -130,17 +132,6 @@ class Common(pyrogue.Root):
             name='setDefaults',
             description='Set default configuration',
             function=self._set_defaults_cmd))
-
-        bays = []
-        if not disable_bay0:
-            bays.append(0)
-        if not disable_bay1:
-            bays.append(1)
-        self.add(pyrogue.LocalVariable(
-            name='EnabledBays',
-            description='List of bays that are enabled',
-            value=str(bays),
-            mode='RO'))
 
         # Flag that indicates if the default configuration should be loaded
         # once the root is started.


### PR DESCRIPTION
## Issue
This PR resolves #427.

## Description
This adds a rogue variable `EnabledBays` to the Common root, which is a list of bays that are enabled, and switches `S.which_bays()` to check this variable instead of checking for `--disable-bayX` in the command line args. I've tested at UCSD.

## Does this PR break any interface?
- [ ] Yes
- [X] No
