### PR TITLE
pysmurf cfg file can be specified in smurf_startup.cfg, no longer requiring an init script.

### DIFF
--- a/cfg_files/stanford/fp30_smurf_startup.cfg
+++ b/cfg_files/stanford/fp30_smurf_startup.cfg
@@ -37,7 +37,7 @@ using_timing_master=false
 disable_streaming=false
 # If write_config=true, writes the rogue configuration file to
 # /data/smurf_data/${ctime}_slot${slot_number}.yml
-write_config=true
+write_config=false
 # Whether or not to start atca_monitor docker.  Assumes atca_monitor
 # docker can be started by /home/cryo/docker/atca_monitor/run.sh
 # script.
@@ -58,12 +58,14 @@ pysmurf=/home/cryo/docker/pysmurf/v4.0.0
 
 # slot_cfgs first column is slot number (1-7)
 #           2nd column is rogue docker directory
-#(optional) 3rd column is pysmurf cfg.  If specified
-#     	    for any slot, must be explicitly specified
-#           for all slots.
+#(optional) 3rd column is pysmurf cfg.  If specified for any slot,
+#     	    must be explicitly specified for all slots.  If the
+#     	    pysmurf cfg file is in the pysmurf directory, can specify
+#     	    it relative to it ;
+#     	    e.g. cfg_files/stanford/experiment_fp30_cc02-03_lbOnlyBay0.cfg
 unset slot_cfgs
 read -r -d '' slot_cfgs << EOM
-5    /home/cryo/docker/smurf/current	/data/pysmurf_cfg/experiment_fp30_cc02-03_lbOnlyBay0.cfg
+5    /home/cryo/docker/smurf/current	cfg_files/stanford/experiment_fp30_cc02-03_lbOnlyBay0.cfg
 EOM
 
 # can either specify a global pysmurf init script

--- a/cfg_files/stanford/fp30_smurf_startup.cfg
+++ b/cfg_files/stanford/fp30_smurf_startup.cfg
@@ -1,27 +1,78 @@
-shelfmanager=shm-smrf-sp01
-
-set_crate_fans_to_full=true
-# COMTEL max fan level is 100, ASIS is 15, ELMA is 15
-## We're using an ELMA crate on campus right now.
-max_fan_level=10
-
-attach_at_end=true
-screenshot_signal_analyzer=false
-configure_pysmurf=true
-reboot=true
-using_timing_master=false
-run_half_band_test=false
-write_config=false
-start_atca_monitor=true
-# still not completely parallel.  Also doesn't work.
-parallel_setup=false
 cpwd=$PWD
 
-pysmurf=/home/cryo/docker/pysmurf/R4-rc1
-
+# name of shelf manager (SMuRF server default is shm-smrf-sp01).
+shelfmanager=shm-smrf-sp01
 crate_id=2
-slots_in_configure_order=(5)
 
-pysmurf_init_script=scratch/shawn/scripts/init_stanford.py
+# COMTEL max fan level is 100, ASIS is 15, ELMA is 15 # We're using an
+#ELMA crate on campus right now.
+max_fan_level=10
+# Badly named ; actually only sets the max fan level to the value
+# specified above by max_fan_level.
+set_crate_fans_to_full=true
+
+# If double_setup=true, runs pysmurf setup twice.  Only supported in
+# serial setup mode.  Added to help resolve the "double tap"
+# configuration issue we see on some systems, where we find we have to
+# run setup twice consecutively in order to get the JESD to properly
+# configure.
+double_setup=false
+# If attach_at_end=true, attaches to the smurf tmux session after done
+# configuring all slots in the same terminal that the user first ran
+# shawnhammer from.
+attach_at_end=true
+# Whether or not to run pysmurf.setup after instantiating a pysmurf
+# object.
+configure_pysmurf=true
+# If reboot=true, deactivates and re-activates the carriers in each
+# slot.
+reboot=true
+# If using_timing_master=true, checks if timing master docker is up
+# (looks for a docker named "tpg_ioc".  If none found, exits without
+# proceeding to configure.  Also displays tpg_ioc docker logs in a
+# split of the tmux smurf:utils panel.
+using_timing_master=false
+# If disable_streaming=true, runs pysmurf set_stream_enable(0) after
+# setup.  Only supported in serial setup mode.
+disable_streaming=false
+# If write_config=true, writes the rogue configuration file to
+# /data/smurf_data/${ctime}_slot${slot_number}.yml
+write_config=true
+# Whether or not to start atca_monitor docker.  Assumes atca_monitor
+# docker can be started by /home/cryo/docker/atca_monitor/run.sh
+# script.
+start_atca_monitor=true
+# If parallel_setup=true, will run setup on all slots simultaneously.
+# Otherwise, setup will be run on each slot serially.
+parallel_setup=false
+
+# Directory on server file system of pysmurf docker directory.  Will
+# use the run.sh script in this directory to instantiate pysmurf
+# dockers.
+pysmurf=/home/cryo/docker/pysmurf/v4.0.0
+
+# only used if slot_cfgs is not provided.  Assumes
+# rogue directory is /home/cryo/docker/smurf/current
+# for every slot.
+#slots_in_configure_order=(5)
+
+# slot_cfgs first column is slot number (1-7)
+#           2nd column is rogue docker directory
+#(optional) 3rd column is pysmurf cfg.  If specified
+#     	    for any slot, must be explicitly specified
+#           for all slots.
+unset slot_cfgs
+read -r -d '' slot_cfgs << EOM
+5    /home/cryo/docker/smurf/current	/data/pysmurf_cfg/experiment_fp30_cc02-03_lbOnlyBay0.cfg
+EOM
+
+# can either specify a global pysmurf init script
+# for every slot, or specify the pysmurf cfg
+# to use for each slot in the 3rd column of
+# slot_cfgs above.  If pysmurf cfg is already
+# provided in 3rd column of slot_cfgs, it will
+# override the global pysmurf_init_script
+# variable.
+#pysmurf_init_script=scratch/shawn/scripts/init_stanford.py
 
 tmux_session_name=smurf

--- a/python/pysmurf/client/command/smurf_cmd.py
+++ b/python/pysmurf/client/command/smurf_cmd.py
@@ -85,11 +85,9 @@ def make_runfile(output_dir, row_len=60, num_rows=60, data_rate=60,
     S.log(f"Writing to {full_path}")
     sys.stdout.writelines(line_holder)
 
-def start_acq(S, num_rows, num_rows_reported, data_rate,
-        row_len):
+def start_acq(S, num_rows, num_rows_reported, data_rate, row_len):
     """
     """
-    bands = S.config.get('init').get('bands')
     S.log('Setting PVs for streaming header')
     S.set_num_rows(num_rows, write_log=True)
     S.set_num_rows_reported(num_rows_reported, write_log=True)
@@ -98,8 +96,7 @@ def start_acq(S, num_rows, num_rows_reported, data_rate,
 
     S.log('Starting streaming data')
     S.set_smurf_to_gcp_stream(True, write_log=True)
-    for b in bands:
-        S.set_stream_enable(1, write_log=True)
+    S.set_stream_enable(1, write_log=True)
 
 def stop_acq(S):
     """

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -383,7 +383,7 @@ class SmurfIVMixin(SmurfBase):
         p_trans_list = []
         si_target_list = []
         v_tes_target_list = []
-        for c, (b, ch) in enumerate(zip(bands,chans)):
+        for _, (b, ch) in enumerate(zip(bands,chans)):
             if (channel is not None) and (ch not in channel):
                 self.log(f'Not in desired channel list: skipping band {b} ch {ch}')
                 continue
@@ -990,7 +990,7 @@ class SmurfIVMixin(SmurfBase):
 
         phase_excursion_list = []
 
-        for c, (b, ch) in enumerate(zip(band, chans)):
+        for _, (b, ch) in enumerate(zip(band, chans)):
             if (channels is not None) and (ch not in channels):
                 continue
             self.log(f'Analyzing band {b} channel {ch}')

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -384,7 +384,7 @@ class SmurfNoiseMixin(SmurfBase):
         # Take data
         datafiles = np.array([])
         channel = np.array([])
-        for i, t in enumerate(tones):
+        for _, t in enumerate(tones):
             self.log(f'Measuring for tone power {t}')
 
             # Tune the band with the new drive power
@@ -881,7 +881,7 @@ class SmurfNoiseMixin(SmurfBase):
 
         timestream_dict = {}
         # Analyze data and save
-        for i, (bs, d) in enumerate(zip(bias, datafile)):
+        for _, (bs, d) in enumerate(zip(bias, datafile)):
             timestream_dict[bs] = {}
             for b in np.unique(band):
                 timestream_dict[bs][b] = {}
@@ -1618,7 +1618,7 @@ class SmurfNoiseMixin(SmurfBase):
         mask = np.loadtxt(self.smurf_to_mce_mask_file)
 
         # Analyze data and save
-        for i, (b, d) in enumerate(zip(tone, datafile)):
+        for _, (_, d) in enumerate(zip(tone, datafile)):
             timestamp, phase, mask = self.read_stream_data(d)
             phase *= self._pA_per_phi0/(2.*np.pi) # phase converted to pA
 

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2794,7 +2794,7 @@ class SmurfTuneMixin(SmurfBase):
         ret['rot_ang'] = rot_ang
         ret['data'] = {}
 
-        for i, r in enumerate(rot_ang):
+        for _, r in enumerate(rot_ang):
             self.log(f'Rotating {r:3.1f} deg')
             eta_phase = np.zeros_like(eta_phase0)
             for c in np.arange(n_channels):

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -1061,7 +1061,7 @@ class SmurfUtilMixin(SmurfBase):
 
                     #initialize data structure
                     phase=list()
-                    for i,_ in enumerate(channel):
+                    for _,_ in enumerate(channel):
                         phase.append(list())
                     for i,_ in enumerate(channel):
                         phase[i].append(data[i])
@@ -3537,7 +3537,7 @@ class SmurfUtilMixin(SmurfBase):
 
             else:
                 # Sets TES bias high then low
-                for i in np.arange(n_step):
+                for _ in np.arange(n_step):
                     self.set_tes_bias_bipolar_array(start_bias + step_array,
                                                     wait_done=False)
                     time.sleep(wait_time)

--- a/scratch/shawn/scripts/shawnhammer.sh
+++ b/scratch/shawn/scripts/shawnhammer.sh
@@ -88,6 +88,8 @@ else
     slots=( $(awk '{print $1}' <<< "$slot_cfgs") )
     # second column is the pyrogue directories, in slot configure order    
     pyrogues=( $(awk '{print $2}' <<< "$slot_cfgs") )
+    # third (optional) column is the pysmurf experiment.cfg
+    pysmurf_cfgs=( $(awk '{print $3}' <<< "$slot_cfgs") )
 fi
 
 source shawnhammerfunctions
@@ -224,7 +226,8 @@ if [ "$parallel_setup" = true ] ; then
     while [[ "${setup_complete}" = false ]] ; do
 	for ((slot_idx=0; slot_idx<${#slots[@]}; ++slot_idx)); do
 	    slot=${slots[slot_idx]}
-	    pyrogue=${pyrogues[slot_idx]} 	
+	    pyrogue=${pyrogues[slot_idx]}
+	    pysmurf_cfg=${pysmurf_cfgs[slot_idx]}
 
 	    if [ "${slot_status[${slot_idx}]}" = "0" ]; then
 		# make sure ethernet is up on carrier
@@ -259,7 +262,7 @@ if [ "$parallel_setup" = true ] ; then
 	    # pysmurf object
 	    if [ "${slot_status[${slot_idx}]}" = "4" ]; then
 	    	echo "-> Starting pysmurf on ${slot}."		
-	    	start_slot_pysmurf ${slot}
+	    	start_slot_pysmurf ${slot} ${pysmurf_cfg}
 	    	slot_status[$slot_idx]=5;
 		if [ "${configure_pysmurf}" = false ]; then
 		    # skip setup
@@ -300,14 +303,15 @@ else
     ##  older serial method
     for ((i=0; i<${#slots[@]}; ++i)); do
 	slot=${slots[i]}
-	pyrogue=${pyrogues[i]} 
+	pyrogue=${pyrogues[i]}
+	pysmurf_cfg=${pysmurf_cfgs[i]} 	
 
 	# make sure ethernet is up on carrier
 	echo "-> Waiting for ethernet on carrier in slot ${slot} to come up ..."
 	cd $cpwd
 	ping_carrier 10.0.${crate_id}.$((${slot}+100))
 	
-	start_slot_tmux_serial ${slot} ${pyrogue}
+	start_slot_tmux_serial ${slot} ${pyrogue} ${pysmurf_cfg}
 	
 	pysmurf_docker_slot=`docker ps -a -n 1 -q`
 	

--- a/scratch/shawn/scripts/shawnhammer.sh
+++ b/scratch/shawn/scripts/shawnhammer.sh
@@ -342,6 +342,8 @@ if [ "$attach_at_end" = true ] ; then
     tmux attach -t ${tmux_session_name}
 fi
 
+# Rarely used for some lofi debugging at Stanford.
+#
 # terminal running script that screenshots can't overlap with the
 # remote desktop window, for some stupid reason.
 if [ "$screenshot_signal_analyzer" = true ] ; then

--- a/scratch/shawn/scripts/shawnhammerfunctions.sh
+++ b/scratch/shawn/scripts/shawnhammerfunctions.sh
@@ -95,10 +95,12 @@ pysmurf_init() {
 	tmux send-keys -t ${tmux_session_name}:${slot_number} "import matplotlib.pylab as plt" C-m
 	tmux send-keys -t ${tmux_session_name}:${slot_number} "import numpy as np" C-m
 	tmux send-keys -t ${tmux_session_name}:${slot_number} "import sys" C-m
+	tmux send-keys -t ${tmux_session_name}:${slot_number} "import os" C-m	
 
 	# define some local variables that some shawnhammer functions will use later
 	tmux send-keys -t ${tmux_session_name}:${slot_number} 'epics_prefix="'smurf_server_s${slot_number}'"' C-m
-	tmux send-keys -t ${tmux_session_name}:${slot_number} 'config_file="'${pysmurf_cfg}'"' C-m
+	# abs path in case user specified the relative path
+	tmux send-keys -t ${tmux_session_name}:${slot_number} 'config_file=os.path.abspath("'${pysmurf_cfg}'")' C-m
 
 	# instantiate pysmurf
 	tmux send-keys -t ${tmux_session_name}:${slot_number} 'S = pysmurf.client.SmurfControl(epics_root=epics_prefix,cfg_file=config_file,setup=False,make_logfile=False,shelf_manager="'${shelfmanager}'")' C-m

--- a/scratch/shawn/tune_1000x_nist.py
+++ b/scratch/shawn/tune_1000x_nist.py
@@ -1,1 +1,0 @@
-/home/cryo/docker/pysmurf/nist-cmb/pysmurf/scratch/shawn/tune_1000x_nist.py


### PR DESCRIPTION
## Issue
This PR resolves issue https://github.com/slaclab/pysmurf/issues/407.

## Description
A third optional column in the slot_cfgs table in smurf_startup.cfg can be used instead of a pysmurf init script.  If the pysmurf experiment.cfg is specified for one slot, it must be specified for all slots.  If it's not specified, shawnhammer will look for an init script specified by the `pysmurf_init_script` variable in smurf_startup.cfg (so this change is backwards compatible with using a pysmurf init script).  If both the column of pysmurf experiment.cfg files and the `pysmurf_init_script` variable is defined, the `pysmurf_init_script` variable will be ignored.

pysmurf object instantiation is now done with a new function called `pysmurf_init` in shawnhammerfunction.sh, which replicates what was previously done by the init scripts, namely;
- Loads the python `pysmurf.client`, `matplotlib.pylab` (as `plt`), `numpy` (as `np`) and `sys` modules.
- Instantiates a pysmurf `SmurfControl` object without running setup.
- Defines the `epics_prefix` and `config_file` variables in the pysmurf ipython session.

This PR also fixes a bug in shawnhammer where the pysmurf object was being pointlessly re-instantiated when it ran `SmurfControl.setup()` ; this is now just done with the already instantiated pysmurf object.

Some additional minor changes to shawnhammer:
- `write_config` flag now writes the yml to /data/smurf_data/, instead of /home/cryo/shawn/, and waits until the yml file has been written and is nonzero instead of waiting an arbitrary 45 seconds.
- Eliminates seemingly unnecessary `bands` local variable and for loop in `smurf_cmd.start_acq`.
- Replaces all unused for loop indices with underscores, resolving a common [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) error.
- Comments added for all parameters in stanford smurf_startup.cfg script to clarify what they mean.

## Does this PR break any interface?
- [ ] Yes
- [x] No