### PR TITLE
Fixes readthedocs badge and docstring convention note in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ pip3 install .
 
 ## Documentation
 Documentation is built using Sphinx, and follows the [NumPy Style
-Docstrings][1]. To build the documentation first install the pysmurf
-package, then run:
+Docstrings][1] convention. To build the documentation first install
+the pysmurf package, then run:
 
 ```
 cd docs/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pysmurf
 
-[![Build Status](https://travis-ci.com/slaclab/pysmurf.svg?branch=master)](https://travis-ci.com/slaclab/pysmurf) [![Documentation Status](https://readthedocs.org/projects/pysmurf/badge/?version=latest)](https://pysmurf.readthedocs.io/en/latest/?badge=latest)
+[![Build Status](https://travis-ci.com/slaclab/pysmurf.svg?branch=master)](https://travis-ci.com/slaclab/pysmurf) [![Documentation Status](https://readthedocs.org/projects/pysmurf/badge/?version=master)](https://pysmurf.readthedocs.io/en/master/?badge=master)
 
 The python control software for SMuRF. Includes scripts to do low level
 commands as well as higher level analysis.
@@ -16,9 +16,9 @@ pip3 install .
 ```
 
 ## Documentation
-Documentation is built using Sphinx, and follows the
-[Google Style Docstrings][1]. To build the documentation first install the
-pysmurf package, then run:
+Documentation is built using Sphinx, and follows the [NumPy Style
+Docstrings][1]. To build the documentation first install the pysmurf
+package, then run:
 
 ```
 cd docs/
@@ -30,4 +30,4 @@ documentation by opening `_build/html/index.html` in the browser of your choice.
 
 The documentation is also updated to readthedocs here: https://pysmurf.readthedocs.io/en/master/
 
-[1]: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
+[1]: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -1175,7 +1175,7 @@ class SmurfNoiseMixin(SmurfBase):
                 plt.show()
 
             if save_plot:
-                plot_name = f'noise_vs_bias_' + \
+                plot_name = 'noise_vs_bias_' + \
                     f'g{file_name_string}b{b}ch{ch:03}.png'
                 if data_timestamp is not None:
                     plot_name = f'{data_timestamp}_' + plot_name

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3259,8 +3259,8 @@ class SmurfTuneMixin(SmurfBase):
 
         if drive_power is None:
             drive_power = self.config.get('init')[f'band_{band}'].get('amplitude_scale')
-            self.log(f'No drive_power given. Using value in config ' +
-                f'file: {drive_power}')
+            self.log('No drive_power given. Using value in config ' +
+                     f'file: {drive_power}')
 
         self.log('Sweeping across frequencies')
         f, resp = self.full_band_ampl_sweep(band, subband, drive_power, n_read)

--- a/python/pysmurf/core/emulators/_DataFromFile.py
+++ b/python/pysmurf/core/emulators/_DataFromFile.py
@@ -104,7 +104,6 @@ class DataMaster(rogue.interfaces.stream.Master):
         except IOError:
             print("Error trying to open {file_name}")
 
-
     # Method for generating a frame
     def sendData(self, data):
         """

--- a/python/pysmurf/core/emulators/_DataFromFile.py
+++ b/python/pysmurf/core/emulators/_DataFromFile.py
@@ -107,7 +107,6 @@ class DataMaster(rogue.interfaces.stream.Master):
 
     # Method for generating a frame
     def sendData(self, data):
-
         """
         Send a Rogue Frame. The frame contains the SMuRF header and the
         input data point in the first channel. The frame will contain only


### PR DESCRIPTION
## Issue
This is a trivial correction to the README.md file relating to docstrings.

## Description

Changes readthedocs badge in README.md file to master instead of latest (which we're not using right now).  Corrects README.md to say we use PyNumpy docstring conventions, not google docstrings conventions.

## Does this PR break any interface?
- [ ] Yes
- [x] No