### PR TITLE
Backwards compatibility fix for which_bays

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2154,7 +2154,25 @@ class SmurfUtilMixin(SmurfBase):
         bays : list of int
             Which bays were enabled on pysmurf server startup.
         """
-        return self.get_enabled_bays()
+        try:
+            return self._cached_enabled_bays
+        except AttributeError:
+            # New method of getting enabled bays:
+            enabled_bays = self.get_enabled_bays()
+
+            if enabled_bays is None:  # Then new rogue var doesn't exist
+                # Old method of getting enabled bays
+                smurf_startup_args = self.get_smurf_startup_args()
+
+                # Bays are enabled unless --disable-bay{bay} is provided to
+                # the pysmurf server on startup.
+                enabled_bays = []
+                for bay in [0, 1]:
+                    if f'--disable-bay{bay}' not in smurf_startup_args:
+                        enabled_bays.append(bay)
+
+            self._cached_enabled_bays = enabled_bays
+            return enabled_bays
 
     def which_bands(self):
         """Which bands the carrier firmware was built for.


### PR DESCRIPTION
## Issue
This PR resolves #439.

## Description
Adds backwards compatibility to the which_bays function

## Does this PR break any interface?
- [ ] Yes
- [X] No
