### PR TITLE
Fixes wrong hardcoded clock rate in get_flux_ramp_freq, adds docstrings to get_flux_ramp_freq and set_flux_ramp_freq.

### DIFF
--- a/cfg_files/stanford/fp30_smurf_startup.cfg
+++ b/cfg_files/stanford/fp30_smurf_startup.cfg
@@ -41,7 +41,7 @@ write_config=false
 # Whether or not to start atca_monitor docker.  Assumes atca_monitor
 # docker can be started by /home/cryo/docker/atca_monitor/run.sh
 # script.
-start_atca_monitor=true
+start_atca_monitor=false
 # If parallel_setup=true, will run setup on all slots simultaneously.
 # Otherwise, setup will be run on each slot serially.
 parallel_setup=false
@@ -78,3 +78,5 @@ EOM
 #pysmurf_init_script=scratch/shawn/scripts/init_stanford.py
 
 tmux_session_name=smurf
+
+#script_to_run=scratch/shawn/deterministic_latency.py

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -192,7 +192,7 @@ class SmurfCommandMixin(SmurfBase):
         Args
         ----
         \**kwargs
-            Arbitrary keyword arguments.  Passed to directly to the
+            Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
 
         Returns
@@ -215,7 +215,7 @@ class SmurfCommandMixin(SmurfBase):
         Args
         ----
         \**kwargs
-            Arbitrary keyword arguments.  Passed to directly to the
+            Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
 
         Returns
@@ -235,7 +235,7 @@ class SmurfCommandMixin(SmurfBase):
         Args
         ----
         \**kwargs
-            Arbitrary keyword arguments.  Passed to directly to the
+            Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
 
         Returns
@@ -255,7 +255,7 @@ class SmurfCommandMixin(SmurfBase):
         Args
         ----
         \**kwargs
-            Arbitrary keyword arguments.  Passed to directly to the
+            Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
 
         Returns
@@ -294,7 +294,7 @@ class SmurfCommandMixin(SmurfBase):
         Args
         ----
         \**kwargs
-            Arbitrary keyword arguments.  Passed to directly to the
+            Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
 
         Returns
@@ -718,7 +718,7 @@ class SmurfCommandMixin(SmurfBase):
         bay : int
             Which AMC bay (0 or 1).
         \**kwargs
-            Arbitrary keyword arguments.  Passed to directly to the
+            Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
 
         Returns
@@ -2274,7 +2274,7 @@ class SmurfCommandMixin(SmurfBase):
         Args
         ----
         \**kwargs
-            Arbitrary keyword arguments.  Passed to directly to the
+            Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
 
         Returns
@@ -2293,7 +2293,7 @@ class SmurfCommandMixin(SmurfBase):
         Args
         ----
         \**kwargs
-            Arbitrary keyword arguments.  Passed to directly to the
+            Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
 
         Returns
@@ -2314,7 +2314,7 @@ class SmurfCommandMixin(SmurfBase):
         Args
         ----
         \**kwargs
-            Arbitrary keyword arguments.  Passed to directly to the
+            Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
 
         Returns
@@ -2534,7 +2534,7 @@ class SmurfCommandMixin(SmurfBase):
         Args
         ----
         \**kwargs
-            Arbitrary keyword arguments.  Passed to directly to the
+            Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
 
         Returns
@@ -3415,7 +3415,7 @@ class SmurfCommandMixin(SmurfBase):
         r"""Sets flux ramp reset rate in kHz.
 
         Sets the flux ramp reset rate.  In units of kHz.  Wrapper
-        function for set_ramp_max_cnt. Takes input in Hz.
+        function for :func:`set_ramp_max_cnt`.
 
         The flux ramp reset rate is specified by setting the trigger
         repetition rate (the `RampMaxCnt` register in
@@ -3427,10 +3427,11 @@ class SmurfCommandMixin(SmurfBase):
         val : float
             The frequency to set the flux ramp reset rate to in kHz.
         \**kwargs
-            Arbitrary keyword arguments.  Passed to directly to the
+            Arbitrary keyword arguments.  Passed directly to the
             `_caput` call.
 
-        .. warning::
+        .. note::
+
            Because `RampMaxCnt` is specified in 307.2 MHz ticks, the
            flux ramp rate must be an integer divisor of 307.2 MHz.
            For example, for this reason it is not possible to set the
@@ -3442,7 +3443,8 @@ class SmurfCommandMixin(SmurfBase):
            reports the flux ramp reset rate that will actually be
            programmed.
 
-        .. warning::
+        .. note::
+
            If `RampMaxCnt` is set too low, then it will invert and
            produce a train of pulses 1x or 2x 307.2 MHz ticks wide,
            but it will be mostly high.
@@ -3481,7 +3483,7 @@ class SmurfCommandMixin(SmurfBase):
         Args
         ----
         \**kwargs
-            Arbitrary keyword arguments.  Passed to directly to the
+            Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
 
         Returns

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -3410,7 +3410,7 @@ class SmurfCommandMixin(SmurfBase):
         """
         return self._caget(self.rtm_cryo_det_root + self._ramp_max_cnt,
             **kwargs)
-    
+
     def set_flux_ramp_freq(self, val, **kwargs):
         r"""Sets flux ramp reset rate in kHz.
 
@@ -3497,7 +3497,7 @@ class SmurfCommandMixin(SmurfBase):
         if self.offline: # FIX ME - this is a stupid hard code
             return 4.0
         else:
-            ramp_max_cnt_rate_khz = self._ramp_max_cnt_clock_hz/1.e3            
+            ramp_max_cnt_rate_khz = self._ramp_max_cnt_clock_hz/1.e3
             return ramp_max_cnt_rate_khz/(
                 self.get_ramp_max_cnt(**kwargs)+1)
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -3430,8 +3430,8 @@ class SmurfCommandMixin(SmurfBase):
             Arbitrary keyword arguments.  Passed directly to the
             `_caput` call.
 
-        .. note::
-
+        Note
+        ----
            Because `RampMaxCnt` is specified in 307.2 MHz ticks, the
            flux ramp rate must be an integer divisor of 307.2 MHz.
            For example, for this reason it is not possible to set the
@@ -3443,8 +3443,8 @@ class SmurfCommandMixin(SmurfBase):
            reports the flux ramp reset rate that will actually be
            programmed.
 
-        .. note::
-
+        Warning
+        -------
            If `RampMaxCnt` is set too low, then it will invert and
            produce a train of pulses 1x or 2x 307.2 MHz ticks wide,
            but it will be mostly high.

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -3438,7 +3438,7 @@ class SmurfCommandMixin(SmurfBase):
            flux ramp rate to exactly 7 kHz.
            :func:`set_flux_ramp_freq` rounds the `RampMaxCnt` computed
            for the desired flux ramp reset rate to the nearest integer
-           using the built-in :py:func:`round` routine, and if the
+           using the built-in `round` routine, and if the
            computed `RampMaxCnt` differs from the rounded value,
            reports the flux ramp reset rate that will actually be
            programmed.


### PR DESCRIPTION
## Issue
This PR resolves issue https://github.com/slaclab/pysmurf/issues/449.

## Description

Adds docstrings to the smurf_command submodule `get_flux_ramp_freq` and `get_flux_ramp_freq` functions.  Fixes incorrect hardcoded clock rate assumed for `RampMaxCnt` in `get_flux_ramp_freq` (was 3.0725E5, but should be 3.072E5).  Added new `_ramp_max_cnt_clock_hz` attribute to the `SmurfCommandMixin` class that 
`get_flux_ramp_freq` and `set_flux_ramp_freq` both get the clock rate from.  This is still a hardcode, but at least now they'll both be forced to compute the flux ramp reset rate from the same base clock rate.  We could compute on the fly from the digitizer frequency, but then it's not possible to easily check if the flux ramp rate is an integer divisor of the clock rate due to precision error.

Fixed incorrect units in docstring ; these functions take and return the flux ramp reset rate in kHz, not Hz.  Added check to `set_flux_ramp_freq` ; now warns user if requested flux ramp is not an integer divisor of 307.2MHz, and if it's not, reports what the actual programmed flux ramp rate will be (only rates which integer divide 307.2MHz are possible).  

## Does this PR break any interface?
- [ ] Yes
- [x] No