### PR TITLE
Add checks and fixes to help solve configuration issues

### DIFF
--- a/docker/server/scripts/server_common.sh
+++ b/docker/server/scripts/server_common.sh
@@ -83,7 +83,7 @@ rebootFPGA()
         exit
     fi
 
-    sleep 1
+    sleep 5
 
     ipmitool -I lan -H ${shelfmanager} -t ${ipmb} -b 0 -A NONE raw 0x2C 0x0A 0 0 1 0 &> /dev/null
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -410,7 +410,7 @@ class SmurfCommandMixin(SmurfBase):
         """
         Sets the default epics variables
         """
-        self._caput(self.epics_root + ':AMCc:setDefaults', 1, wait_after=20,
+        self._caput(self.epics_root + ':AMCc:setDefaults', 1, wait_after=30,
             **kwargs)
         self.log('Defaults are set.', self.LOG_INFO)
 
@@ -418,10 +418,10 @@ class SmurfCommandMixin(SmurfBase):
     def set_read_all(self, **kwargs):
         """
         ReadAll sends a command to read all register to the pyrogue server
-        Registers must upated in order to PVs to update.
-        This call is necesary to read register with pollIntervale=0.
+        Registers must updated in order to PVs to update.
+        This call is necessary to read register with pollIntervale=0.
         """
-        self._caput(self.epics_root + ':AMCc:ReadAll', 1, wait_after=5,
+        self._caput(self.epics_root + ':AMCc:ReadAll', 1, wait_after=20,
             **kwargs)
         self.log('ReadAll sent', self.LOG_INFO)
 

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -290,7 +290,7 @@ class Common(pyrogue.Root):
         for k in range(max_retries):
             print(f'Check elastic buffers ({k})...')
             retryAppTopInit = False
-            for i in range(2):
+            for i in self._enabled_bays:
                 # Workaround: Reading the individual registers does not work. So, we need to read
                 # the whole device, and then use the 'value()' method to get the register values.
                 self.FpgaTopLevel.AppTop.AppTopJesd[i].JesdRx.ReadDevice()

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -43,7 +43,7 @@ class Common(pyrogue.Root):
                  **kwargs):
 
         pyrogue.Root.__init__(self, name="AMCc", initRead=True, pollEn=polling_en,
-            streamIncGroups='stream', serverPort=server_port, **kwargs)
+            timeout=5.0, streamIncGroups='stream', serverPort=server_port, **kwargs)
 
         #########################################################################################
         # The following interfaces are expected to be defined at this point by a sub-class

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -258,15 +258,22 @@ class Common(pyrogue.Root):
             print('No default configuration file was specified...')
             return
 
-        # Load defaults catching exceptions, and retying if any.
+        # Load defaults catching exceptions and checking the return value of "LoadConfig"
+        # and retrying if there were errors.
         done = False
         max_retries=10
         for i in range(max_retries):
             print(f'Setting defaults from file {self._config_file}')
             try:
-                self.LoadConfig(self._config_file)
-                done = True
-                break
+                # Try to load the defaults file
+                ret = self.LoadConfig(self._config_file)
+
+                # Check the return value from 'LoadConfig'.
+                if not ret:
+                    print(f'  Setting defaults try number {i} failed. "LoadConfig" returned "False"')
+                else:
+                    done = True
+                    break
             except pyrogue.DeviceError as err:
                 print(f'  Setting defaults try number {i} failed with: {err}')
 

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -319,4 +319,3 @@ class Common(pyrogue.Root):
             print('Elastic buffer check passed!')
         else:
             print(f'ERROR: Elastic buffer check failed {max_retries} times')
-

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -258,5 +258,58 @@ class Common(pyrogue.Root):
             print('No default configuration file was specified...')
             return
 
-        print(f'Setting defaults from file {self._config_file}')
-        self.LoadConfig(self._config_file)
+        # Load defaults catching exceptions, and retying if any.
+        done = False
+        max_retries=10
+        for i in range(max_retries):
+            print(f'Setting defaults from file {self._config_file}')
+            try:
+                self.LoadConfig(self._config_file)
+                done = True
+                break
+            except pyrogue.DeviceError as err:
+                print(f'  Setting defaults try number {i} failed with: {err}')
+
+        # Check if we could load the defaults before 'max_retries' retires.
+        if done:
+            print('Defaults were set correctly!')
+        else:
+            print(f'ERROR: Failed to set defaults after {max_retries} retries!')
+            return
+
+        # After loading defaults successfully, check the status of the elastic buffers
+        done = True
+        max_retries=10
+        for k in range(max_retries):
+            print(f'Check elastic buffers ({k})...')
+            retryAppTopInit = False
+            for i in range(2):
+                # Workaround: Reading the individual registers does not work. So, we need to read
+                # the whole device, and then use the 'value()' method to get the register values.
+                self.FpgaTopLevel.AppTop.AppTopJesd[i].JesdRx.ReadDevice()
+                for j in range(5):
+                    el_buff_latency_1 = self.FpgaTopLevel.AppTop.AppTopJesd[i].JesdRx.ElBuffLatency[2*j].value()
+                    el_buff_latency_2 = self.FpgaTopLevel.AppTop.AppTopJesd[i].JesdRx.ElBuffLatency[2*j+1].value()
+
+                    # Check that the difference in latency between two adjacent buffers
+                    # is not greater than 2.
+                    if abs( el_buff_latency_1 - el_buff_latency_2 ) > 2:
+                        print(f'  Test failed. JesdRx[{i}].ElBuffLatency[{2*j}] = {el_buff_latency_1}, JesdRx[{i}].ElBuffLatency[{2*j+1}] = {el_buff_latency_2}')
+                        retryAppTopInit = True
+                        done = False
+                    else:
+                        print(f'  OK - JesdRx[{i}].ElBuffLatency[{2*j}] = {el_buff_latency_1}, JesdRx[{i}].ElBuffLatency[{2*j+1}] = {el_buff_latency_2}')
+
+            # If the check failed, call 'AppTop.Init()' command again
+            if retryAppTopInit:
+                print('  Executing AppTop.Init()...')
+                self.FpgaTopLevel.AppTop.Init()
+            else:
+                break
+
+        # Check if the test passed before 'max_retries' retries
+        if done:
+            print('Elastic buffer check passed!')
+        else:
+            print(f'ERROR: Elastic buffer check failed {max_retries} times')
+


### PR DESCRIPTION
## Issue
This PR resolves [ESCRYODET-667](https://jira.slac.stanford.edu/browse/ESCRYODET-667).

## Description

This PR includes some fixes and new features to help solve the configuration issue described in [ESCRYODET-667](https://jira.slac.stanford.edu/browse/ESCRYODET-667):
- Add extra checking while loading defaults: check the final status of the elastic buffer latency. Also, verify the return value and catch any exception from the `LoadConfig` command.
- Increase the rogue timeout from 1s to 5s.
- Increase the `wait_after` period for the set defaults and read all pysmurf client commands. With the previous periods, the commands were returning before the server finished the operations.
- Increase the timeout between deactivate and activate IPMI commands  during the `rebootFPGA` function.

## Does this PR break any interface?
- [ ] Yes
- [X] No