### PR TITLE
Update elastic buffer check, and add new variable `SystemConfigured`

### DIFF
--- a/python/pysmurf/core/devices/_SmurfApplication.py
+++ b/python/pysmurf/core/devices/_SmurfApplication.py
@@ -75,3 +75,9 @@ class SmurfApplication(pyrogue.Device):
             description='List of bays that are enabled',
             value=[2, 2],
             mode='RO'))
+
+        self.add(pyrogue.LocalVariable(
+            name='SystemConfigured',
+            description='The system was configured correctly',
+            mode='RO',
+            value=False))

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -289,7 +289,7 @@ class Common(pyrogue.Root):
         max_retries=10
         for k in range(max_retries):
             print(f'Check elastic buffers ({k})...')
-            retryAppTopInit = False
+            retry_app_top_init = False
             for i in self._enabled_bays:
                 # Workaround: Reading the individual registers does not work. So, we need to read
                 # the whole device, and then use the 'value()' method to get the register values.
@@ -311,11 +311,11 @@ class Common(pyrogue.Root):
                         print(f'  OK - JesdRx[{i}].ElBuffLatency[{j}] = {latency}')
                     else:
                         print(f'  Test failed. JesdRx[{i}].ElBuffLatency[{j}] = {latency}')
-                        retryAppTopInit = True
+                        retry_app_top_init = True
                         done = False
 
             # If the check failed, call 'AppTop.Init()' command again
-            if retryAppTopInit:
+            if retry_app_top_init:
                 print('  Executing AppTop.Init()...')
                 self.FpgaTopLevel.AppTop.Init()
             else:

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -294,18 +294,25 @@ class Common(pyrogue.Root):
                 # Workaround: Reading the individual registers does not work. So, we need to read
                 # the whole device, and then use the 'value()' method to get the register values.
                 self.FpgaTopLevel.AppTop.AppTopJesd[i].JesdRx.ReadDevice()
-                for j in range(5):
-                    el_buff_latency_1 = self.FpgaTopLevel.AppTop.AppTopJesd[i].JesdRx.ElBuffLatency[2*j].value()
-                    el_buff_latency_2 = self.FpgaTopLevel.AppTop.AppTopJesd[i].JesdRx.ElBuffLatency[2*j+1].value()
+                for j in range(10):
+                    # Check if the latency values are correct. The latency values should be:
+                    # - 13 or 14, for lanes = 0:1,4:9
+                    # - 255, for lanes 2:3
+                    latency = self.FpgaTopLevel.AppTop.AppTopJesd[i].JesdRx.ElBuffLatency[j].value()
+                    latency_ok = False
+                    if j in [2,3]:
+                        if latency == 255:
+                            latency_ok = True
+                    else:
+                        if latency in [13,14]:
+                            latency_ok = True
 
-                    # Check that the difference in latency between two adjacent buffers
-                    # is not greater than 2.
-                    if abs( el_buff_latency_1 - el_buff_latency_2 ) > 2:
-                        print(f'  Test failed. JesdRx[{i}].ElBuffLatency[{2*j}] = {el_buff_latency_1}, JesdRx[{i}].ElBuffLatency[{2*j+1}] = {el_buff_latency_2}')
+                    if latency_ok:
+                        print(f'  OK - JesdRx[{i}].ElBuffLatency[{j}] = {latency}')
+                    else:
+                        print(f'  Test failed. JesdRx[{i}].ElBuffLatency[{j}] = {latency}')
                         retryAppTopInit = True
                         done = False
-                    else:
-                        print(f'  OK - JesdRx[{i}].ElBuffLatency[{2*j}] = {el_buff_latency_1}, JesdRx[{i}].ElBuffLatency[{2*j+1}] = {el_buff_latency_2}')
 
             # If the check failed, call 'AppTop.Init()' command again
             if retryAppTopInit:

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -251,19 +251,18 @@ class Common(pyrogue.Root):
         print("Stopping root...")
         pyrogue.Root.stop(self)
 
-    # Function for setting a default configuration.
-    def _set_defaults_cmd(self):
-        # Check if a default configuration file has been defined
-        if self._config_file is None:
-            print('No default configuration file was specified...')
-            return
-
-        # Load defaults catching exceptions and checking the return value of "LoadConfig"
-        # and retrying if there were errors.
-        done = False
+    # Function to load the configuration file, catching exceptions and checking the
+    # return value of "LoadConfig", and trying if there were errors, up to
+    # "max_retries" times.
+    # This method return "True" if the configuration file was load correctly, and
+    # "returns False" otherwise.
+    def _load_config(self):
+        success = False
         max_retries=10
+
         for i in range(max_retries):
-            print(f'Setting defaults from file {self._config_file}')
+            print(f'Setting defaults from file {self._config_file} (try number {i})')
+
             try:
                 # Try to load the defaults file
                 ret = self.LoadConfig(self._config_file)
@@ -272,16 +271,28 @@ class Common(pyrogue.Root):
                 if not ret:
                     print(f'  Setting defaults try number {i} failed. "LoadConfig" returned "False"')
                 else:
-                    done = True
+                    success = True
                     break
             except pyrogue.DeviceError as err:
                 print(f'  Setting defaults try number {i} failed with: {err}')
 
         # Check if we could load the defaults before 'max_retries' retires.
-        if done:
+        if success:
             print('Defaults were set correctly!')
+            return True
         else:
             print(f'ERROR: Failed to set defaults after {max_retries} retries!')
+            return False
+
+    # Function for setting a default configuration.
+    def _set_defaults_cmd(self):
+        # Check if a default configuration file has been defined
+        if self._config_file is None:
+            print('No default configuration file was specified...')
+            return
+
+        # Try to load the configuration file
+        if not _load_config():
             return
 
         # After loading defaults successfully, check the status of the elastic buffers

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -343,6 +343,11 @@ class Common(pyrogue.Root):
     # It returns "True" if the configuration was set correctly, or
     # "False" otherwise
     def _set_defaults_cmd(self):
+
+        # Set the "SystemConfigured" flag to "False". It will set to "True"
+        # at the end of this method, if the setup success.
+        self.SmurfApplication.SystemConfigured.set(False)
+
         # Check if a default configuration file has been defined
         if self._config_file is None:
             print('No default configuration file was specified...')
@@ -358,5 +363,7 @@ class Common(pyrogue.Root):
             print('Aborting...')
             return False
 
-        # The configuration was set successfully
+        # The configuration was set successfully.
+        # Set the "SystemConfigured" flag to "True".
+        self.SmurfApplication.SystemConfigured.set(True)
         return True

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -290,16 +290,19 @@ class Common(pyrogue.Root):
         for k in range(max_retries):
             print(f'Check elastic buffers ({k})...')
             retry_app_top_init = False
+
             for i in self._enabled_bays:
                 # Workaround: Reading the individual registers does not work. So, we need to read
                 # the whole device, and then use the 'value()' method to get the register values.
                 self.FpgaTopLevel.AppTop.AppTopJesd[i].JesdRx.ReadDevice()
+
                 for j in range(10):
                     # Check if the latency values are correct. The latency values should be:
                     # - 13 or 14, for lanes = 0:1,4:9
                     # - 255, for lanes 2:3
                     latency = self.FpgaTopLevel.AppTop.AppTopJesd[i].JesdRx.ElBuffLatency[j].value()
                     latency_ok = False
+
                     if j in [2,3]:
                         if latency == 255:
                             latency_ok = True

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -340,18 +340,23 @@ class Common(pyrogue.Root):
             return False
 
     # Function for setting a default configuration.
+    # It returns "True" if the configuration was set correctly, or
+    # "False" otherwise
     def _set_defaults_cmd(self):
         # Check if a default configuration file has been defined
         if self._config_file is None:
             print('No default configuration file was specified...')
-            return
+            return False
 
         # Try to load the configuration file
         if not self._load_config():
             print('Aborting...')
-            return
+            return False
 
         # After loading defaults successfully, check the status of the elastic buffers
         if not self._check_elastic_buffers():
             print('Aborting...')
-            return
+            return False
+
+        # The configuration was set successfully
+        return True

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -325,7 +325,7 @@ class Common(pyrogue.Root):
             # If the check failed, try to reload the configuration again
             if retry_load_config:
                 print('  Trying to reload the configuration again...')
-                if not _load_config():
+                if not self._load_config():
                     break
             else:
                 success = True
@@ -347,11 +347,11 @@ class Common(pyrogue.Root):
             return
 
         # Try to load the configuration file
-        if not _load_config():
+        if not self._load_config():
             print('Aborting...')
             return
 
         # After loading defaults successfully, check the status of the elastic buffers
-        if not _check_elastic_buffers():
+        if not self._check_elastic_buffers():
             print('Aborting...')
             return


### PR DESCRIPTION
## Issue
This PR includes new features which help resolving [ESCRYODET-671](https://jira.slac.stanford.edu/browse/ESCRYODET-671).

## Description

This PR changes the wait we were testing the elastic buffers. We now check that the register for lanes 2,3 must be equal to 255, and all the other lanes must be either 13 or 14. Also, one when the check fails, instead of trying to execute `AppTop.Init()`, we instead try to reload the default configuration. 

Additionally, I added I new variable `SystemConfigured` under the `SmurfApplication` device. This variable will indicate if the configuration method `_set_defaults_cmd` was able to successfully load the configuration.

## Does this PR break any interface?
- [ ] Yes
- [X] No

### Which interface changed?
I added I new variable `SystemConfigured` under the `SmurfApplication` device. This change doesn't brake any interfaces, instead adds a new variable to the tree. This variable indicates the configuration was successfully load when calling the `setDefaults` command.