### PR TITLE
Use new registers which give the state of the configuration process during setup

### DIFF
--- a/cfg_files/rflab/rflab_smurf_startup.cfg
+++ b/cfg_files/rflab/rflab_smurf_startup.cfg
@@ -3,7 +3,7 @@ shelfmanager=shm-smrf-sp01
 set_crate_fans_to_full=true
 # COMTEL max fan level is 100, ASIS is 15, ELMA is 15
 ## COMTEL in RF lab
-max_fan_level=100
+max_fan_level=50
 
 # more often used
 attach_at_end=true
@@ -18,7 +18,7 @@ parallel_setup=false
 # requires tmux-logging plugin
 enable_tmux_logging=false
 screenshot_signal_analyzer=false
-run_full_band_response=true
+run_full_band_response=false
 run_half_band_test=false
 write_config=false
 save_state=true
@@ -32,7 +32,7 @@ crate_id=3
 
 unset slot_cfgs
 read -r -d '' slot_cfgs << EOM
-3    /home/cryo/docker/smurf/dev_fw/slotN/v4.0.0	cfg_files/rflab/experiment_rflab_thermal_testing_201907.cfg
+3    /home/cryo/docker/smurf/dev_sw/slotN/v4.0.0	cfg_files/rflab/experiment_rflab_thermal_testing_201907.cfg
 EOM
 
 #pysmurf_init_script=scratch/shawn/scripts/init_rflab.py

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -315,7 +315,7 @@ class SmurfControl(SmurfCommandMixin,
 
     def setup(self, write_log=True, payload_size=2048, **kwargs):
         r"""Configures SMuRF system.
-        
+
         TODO: NEED TO BE MORE DETAILED, CLEARER.
 
         Sets up the SMuRF system by first loading hardware register
@@ -323,7 +323,7 @@ class SmurfControl(SmurfCommandMixin,
         values with defaults from the pysmurf configuration file.
 
         Setup steps (in order of execution):
-        
+
         - Disables hardware logging if it’s active (to avoid register
           access collisions).
         - Sets FPGA OT limit (if one is specified in pysmurf cfg).
@@ -367,9 +367,9 @@ class SmurfControl(SmurfCommandMixin,
            Returns `True` if system setup succeeded, otherwise
            `False`.
 
-        See Also                                                                
+        See Also
         --------
-        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_defaults_pv` : 
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_defaults_pv` :
               Loads the hardware defaults.
 
         """

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -377,7 +377,7 @@ class SmurfControl(SmurfCommandMixin,
         # don't support checking if setDefaults succeeded.
         if set_defaults_success is None:
             set_defaults_success = True
-        
+
         # Log an error if setDefaults failed.
         if not set_defaults_success:
             self.log(
@@ -582,11 +582,11 @@ class SmurfControl(SmurfCommandMixin,
 
                     # Configure RTM to trigger off of the timing system
                     self.set_ramp_start_mode(1, write_log=write_log)
-                    
+
             self.log('Done with setup.', self.LOG_USER)
         else:
             self.log('Setup failed!', self.LOG_ERROR)
-            
+
         # If active, re-enable hardware logging after setup.
         if self._hardware_logging_thread is not None:
             self.log('Resuming hardware logging.', self.LOG_USER)

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -314,9 +314,42 @@ class SmurfControl(SmurfCommandMixin,
         self.config.update('outputs', {})
 
     def setup(self, write_log=True, payload_size=2048, **kwargs):
-        """Sets the PVs to the default values in the experiment.cfg.
+        r"""Configures SMuRF system.
+        
+        TODO: NEED TO BE MORE DETAILED, CLEARER.
 
-        NEED LONGER DESCRIPTION OF SETUP MEMBER FUNCTION HERE.
+        Sets up the SMuRF system by first loading hardware register
+        defaults followed by overriding the hardware default register
+        values with defaults from the pysmurf configuration file.
+
+        Setup steps (in order of execution):
+        
+        - Disables hardware logging if it’s active (to avoid register
+          access collisions).
+        - Sets FPGA OT limit (if one is specified in pysmurf cfg).
+        - Resets the RF DACs on AMCs in use.
+        - Sets hardware defaults using
+          :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_defaults_pv`.
+        - Overrides hardware defaults register values for subset of
+          registers controlled by the pysmurf configuration file.
+        - Resets the RTM CPLD.
+        - Turns off flux ramp, but configures based on values for
+          reset rate and fraction full scale provided in pysmurf
+          configuration file.
+        - Enables data streaming.
+        - Sets mask and payload size to a single channel.
+        - Sets RF amplifier biases (without enabling drain voltages).
+        - Configures timing based on pysmurf configuration file settings.
+        - Resumes hardware logging if it was active at beginning.
+
+        If system configuration fails, returns `False`, otherwise
+        returns `True`.  Failure modes (which will return `False`) are
+        as follows:
+
+        - :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_defaults_pv`
+          fails (only supported for pysmurf core code versions
+          >=4.1.0).  If failure is detected, doesn't attempt to
+          execute the subsequent setup steps.
 
         Args
         ----
@@ -324,12 +357,21 @@ class SmurfControl(SmurfCommandMixin,
             Whether to write to the log file.
         payload_size : int, optional, default 2048
             The starting size of the payload.
+        \**kwargs
+            Arbitrary keyword arguments.  Passed to many, but not all,
+            of the `_caput` calls.
 
         Returns
         -------
         success : bool
            Returns `True` if system setup succeeded, otherwise
            `False`.
+
+        See Also                                                                
+        --------
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_defaults_pv` : 
+              Loads the hardware defaults.
+
         """
         success=True
         self.log('Setting up...', (self.LOG_USER))

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -302,7 +302,13 @@ class SmurfControl(SmurfCommandMixin,
             self.freq_resp[band]['lock_status'] = {}
 
         if setup:
-            self.setup(payload_size=payload_size, **kwargs)
+            success = self.setup(payload_size=payload_size, **kwargs)
+            # Log an error if system setup failed.
+            if not success:
+                self.log(
+                    'ERROR : System setup failed!  Proceed at your own'
+                    ' risk!',
+                    self.LOG_ERROR)
 
         # initialize outputs cfg
         self.config.update('outputs', {})
@@ -315,11 +321,17 @@ class SmurfControl(SmurfCommandMixin,
         Args
         ----
         write_log : bool, optional, default True
-              Whether to write to the log file.
+            Whether to write to the log file.
         payload_size : int, optional, default 2048
-              The starting size of the payload.
+            The starting size of the payload.
 
+        Returns
+        -------
+        success : bool
+           Returns `True` if system setup succeeded, otherwise
+           `False`.
         """
+        success=True
         self.log('Setting up...', (self.LOG_USER))
 
         # If active, disable hardware logging while doing setup.
@@ -328,7 +340,8 @@ class SmurfControl(SmurfCommandMixin,
                      (self.LOG_USER))
             self.pause_hardware_logging()
 
-        # Thermal OT protection
+        # Thermal OT protection - should this be moved after
+        # setDefaults?
         ultrascale_temperature_limit_degC = (
             self._ultrascale_temperature_limit_degC)
         if ultrascale_temperature_limit_degC is not None:
@@ -353,204 +366,234 @@ class SmurfControl(SmurfCommandMixin,
                     self.set_dac_reset(
                         bay, dac, val, write_log=write_log)
 
+        # setDefaults
         self.set_read_all(write_log=write_log)
-        self.set_defaults_pv(write_log=write_log)
+        set_defaults_success = self.set_defaults_pv(write_log=write_log)
 
-        # The per band configs. May want to make available per-band
-        # values.
-        for band in bands:
-            self.set_iq_swap_in(band, self._iq_swap_in[band],
-                                write_log=write_log, **kwargs)
-            self.set_iq_swap_out(band, self._iq_swap_out[band],
-                                 write_log=write_log, **kwargs)
-
-            self.set_ref_phase_delay(
-                band,
-                self._ref_phase_delay[band],
-                write_log=write_log, **kwargs)
-            self.set_ref_phase_delay_fine(
-                band,
-                self._ref_phase_delay_fine[band],
-                write_log=write_log, **kwargs)
-
-            # in DSPv3, lmsDelay should be 4*refPhaseDelay (says
-            # Mitch).  If none provided in cfg, enforce that
-            # constraint.  If provided in cfg, override with provided
-            # value.
-            if self._lms_delay[band] is None:
-                self.set_lms_delay(
-                    band, int(4*self._ref_phase_delay[band]),
-                    write_log=write_log, **kwargs)
-            else:
-                self.set_lms_delay(
-                    band, self._lms_delay[band],
-                    write_log=write_log, **kwargs)
-
-            self.set_lms_gain(
-                band, self._lms_gain[band],
-                write_log=write_log, **kwargs)
-
-            self.set_trigger_reset_delay(
-                band, self._trigger_reset_delay[band],
-                write_log=write_log, **kwargs)
-
-            self.set_feedback_enable(
-                band, self._feedback_enable[band],
-                write_log=write_log, **kwargs)
-            self.set_feedback_gain(
-                band, self._feedback_gain[band],
-                write_log=write_log, **kwargs)
-            self.set_feedback_limit_khz(
-                band, self._feedback_limit_khz[band],
-                write_log=write_log, **kwargs)
-            self.set_feedback_polarity(
-                band, self._feedback_polarity[band],
-                write_log=write_log, **kwargs)
-
-            for dmx in np.array(self._data_out_mux[band]):
-                self.set_data_out_mux(
-                    int(self.band_to_bay(band)), int(dmx),
-                    "UserData", write_log=write_log, **kwargs)
-
-            self.set_dsp_enable(
-                band, self._dsp_enable,
-                write_log=write_log, **kwargs)
-
-            # Tuning defaults
-            self.set_gradient_descent_gain(
-                band, self._gradient_descent_gain[band],
-                write_log=write_log, **kwargs)
-            self.set_gradient_descent_averages(
-                band, self._gradient_descent_averages[band],
-                write_log=write_log, **kwargs)
-            self.set_gradient_descent_converge_hz(
-                band, self._gradient_descent_converge_hz[band],
-                write_log=write_log, **kwargs)
-            self.set_gradient_descent_step_hz(
-                band, self._gradient_descent_step_hz[band],
-                write_log=write_log, **kwargs)
-            self.set_gradient_descent_momentum(
-                band, self._gradient_descent_momentum[band],
-                write_log=write_log, **kwargs)
-            self.set_gradient_descent_beta(
-                band, self._gradient_descent_beta[band],
-                write_log=write_log, **kwargs)
-            self.set_eta_scan_averages(
-                band, self._eta_scan_averages[band],
-                write_log=write_log, **kwargs)
-            self.set_eta_scan_del_f(
-                band, self._eta_scan_del_f[band],
-                write_log=write_log, **kwargs)
-
-        # Set UC and DC attenuators
-        for band in bands:
-            self.set_att_uc(
-                band, self._att_uc[band],
-                write_log=write_log)
-            self.set_att_dc(
-                band, self._att_dc[band],
-                write_log=write_log)
-
-        # Things that have to be done for both AMC bays, regardless of whether or not an AMC
-        # is plugged in there.
-        for bay in [0, 1]:
-            self.set_trigger_hw_arm(bay, 0, write_log=write_log)
-
-        self.set_trigger_width(0, 10, write_log=write_log)  # mystery bit that makes triggering work
-        self.set_trigger_enable(0, 1, write_log=write_log)
-        ## only sets enable, but is initialized to True already by
-        ## default, and crashing for unknown reasons in rogue 4.
-        self.set_evr_channel_reg_enable(0, True, write_log=write_log)
-        self.set_evr_trigger_channel_reg_dest_sel(0,
-                                                  0x20000,
-                                                  write_log=write_log)
-
-        self.set_enable_ramp_trigger(1, write_log=write_log)
-
-        # 0x1 selects fast flux ramp, 0x0 selects slow flux ramp.  The
-        # slow flux ramp only existed on the first rev of RTM boards,
-        # C0, and wasn't ever really used.
-        self.set_select_ramp(0x1, write_log=write_log)
-
-        self.set_cpld_reset(0, write_log=write_log)
-        self.cpld_toggle(write_log=write_log)
-
-        # Make sure flux ramp starts off
-        self.flux_ramp_off(write_log=write_log)
-        self.flux_ramp_setup(self._reset_rate_khz,
-                             self._fraction_full_scale,
-                             write_log=write_log)
-
-        # Turn on stream enable for all bands
-        self.set_stream_enable(1, write_log=write_log)
-
-        # Set payload size and mask to a single channel
-        self.set_payload_size(payload_size)
-        self.set_channel_mask([0])
-
-        self.set_amplifier_bias(write_log=write_log)
-        self.get_amplifier_bias()
-
-        # also read the temperature of the CC
-        self.log(f"Cryocard temperature = {self.C.read_temperature()}")
-
-        # if no timing section present, assumes your defaults.yml
-        # has set you up...good luck.
-        if self._timing_reference is not None:
-            timing_reference = self._timing_reference
-
-            # check if supported
-            timing_options = ['ext_ref', 'backplane']
-            assert (timing_reference in timing_options), (
-                'timing_reference in cfg file ' +
-                f'(={timing_reference}) not in ' +
-                f'timing_options={timing_options}')
-
+        # Checking if setDefaults succeeded is only supported for
+        # pysmurf core code versions >=4.1.0.  If it's not supported,
+        # self.set_defaults_pv will return None.  Overriding None with
+        # True to skip this check for older versions of pysmurf that
+        # don't support checking if setDefaults succeeded.
+        if set_defaults_success is None:
+            set_defaults_success = True
+        
+        # Log an error if setDefaults failed.
+        if not set_defaults_success:
             self.log(
-                'Configuring the system to take timing ' +
-                f'from {timing_reference}')
+                'ERROR : System configuration/setDefaults failed!  Do'
+                ' not proceed!  Reboot or ask someone for help.  You'
+                ' are strongly encouraged to report this as an issue'
+                ' on the pysmurf github repo at'
+                ' https://github.com/slaclab/pysmurf/issues (please'
+                ' provide a state dump using the pysmurf'
+                ' set_read_all/save_state functions).',
+                self.LOG_ERROR)
+            success = False
 
-            if timing_reference == 'ext_ref':
-                for bay in self.bays:
-                    self.log(f'Select external reference for bay {bay}')
-                    self.sel_ext_ref(bay)
+        # Only proceed with the rest of setup if setDefaults
+        # succeeded, otherwise we risk giving users false hope.
+        if success:
+            # The per band configs. May want to make available per-band
+            # values.
+            for band in bands:
+                self.set_iq_swap_in(band, self._iq_swap_in[band],
+                                    write_log=write_log, **kwargs)
+                self.set_iq_swap_out(band, self._iq_swap_out[band],
+                                     write_log=write_log, **kwargs)
 
-                # make sure RTM knows there's no timing system
-                self.set_ramp_start_mode(0, write_log=write_log)
+                self.set_ref_phase_delay(
+                    band,
+                    self._ref_phase_delay[band],
+                    write_log=write_log, **kwargs)
+                self.set_ref_phase_delay_fine(
+                    band,
+                    self._ref_phase_delay_fine[band],
+                    write_log=write_log, **kwargs)
 
-            # https://confluence.slac.stanford.edu/display/SMuRF/Timing+Carrier#TimingCarrier-Howtoconfiguretodistributeoverbackplanefromslot2
-            if timing_reference == 'backplane':
-                # Set SMuRF carrier crossbar to use the backplane
-                # distributed timing.
-                # OutputConfig[1] = 0x2 configures the SMuRF carrier's
-                # FPGA to take the timing signals from the backplane
-                # (TO_FPGA = FROM_BACKPLANE)
-                self.log('Setting crossbar OutputConfig[1]=0x2 (TO_FPGA=FROM_BACKPLANE)')
-                self.set_crossbar_output_config(1, 2)
+                # in DSPv3, lmsDelay should be 4*refPhaseDelay (says
+                # Mitch).  If none provided in cfg, enforce that
+                # constraint.  If provided in cfg, override with provided
+                # value.
+                if self._lms_delay[band] is None:
+                    self.set_lms_delay(
+                        band, int(4*self._ref_phase_delay[band]),
+                        write_log=write_log, **kwargs)
+                else:
+                    self.set_lms_delay(
+                        band, self._lms_delay[band],
+                        write_log=write_log, **kwargs)
 
-                self.log('Waiting 1 sec for timing up-link...')
-                time.sleep(1)
+                self.set_lms_gain(
+                    band, self._lms_gain[band],
+                    write_log=write_log, **kwargs)
 
-                # Check if link is up - just printing status to
-                # screen, not currently taking any action if it's not.
-                timing_rx_link_up = self.get_timing_link_up()
-                self.log(f'Timing RxLinkUp = {timing_rx_link_up}', self.LOG_USER if
-                         timing_rx_link_up else self.LOG_ERROR)
+                self.set_trigger_reset_delay(
+                    band, self._trigger_reset_delay[band],
+                    write_log=write_log, **kwargs)
 
-                # Set LMK to use timing system as reference
-                for bay in self.bays:
-                    self.log(f'Configuring bay {bay} LMK to lock to the timing system')
-                    self.set_lmk_reg(bay, 0x147, 0xA)
+                self.set_feedback_enable(
+                    band, self._feedback_enable[band],
+                    write_log=write_log, **kwargs)
+                self.set_feedback_gain(
+                    band, self._feedback_gain[band],
+                    write_log=write_log, **kwargs)
+                self.set_feedback_limit_khz(
+                    band, self._feedback_limit_khz[band],
+                    write_log=write_log, **kwargs)
+                self.set_feedback_polarity(
+                    band, self._feedback_polarity[band],
+                    write_log=write_log, **kwargs)
 
-                # Configure RTM to trigger off of the timing system
-                self.set_ramp_start_mode(1, write_log=write_log)
+                for dmx in np.array(self._data_out_mux[band]):
+                    self.set_data_out_mux(
+                        int(self.band_to_bay(band)), int(dmx),
+                        "UserData", write_log=write_log, **kwargs)
 
-        self.log('Done with setup')
+                self.set_dsp_enable(
+                    band, self._dsp_enable,
+                    write_log=write_log, **kwargs)
 
+                # Tuning defaults
+                self.set_gradient_descent_gain(
+                    band, self._gradient_descent_gain[band],
+                    write_log=write_log, **kwargs)
+                self.set_gradient_descent_averages(
+                    band, self._gradient_descent_averages[band],
+                    write_log=write_log, **kwargs)
+                self.set_gradient_descent_converge_hz(
+                    band, self._gradient_descent_converge_hz[band],
+                    write_log=write_log, **kwargs)
+                self.set_gradient_descent_step_hz(
+                    band, self._gradient_descent_step_hz[band],
+                    write_log=write_log, **kwargs)
+                self.set_gradient_descent_momentum(
+                    band, self._gradient_descent_momentum[band],
+                    write_log=write_log, **kwargs)
+                self.set_gradient_descent_beta(
+                    band, self._gradient_descent_beta[band],
+                    write_log=write_log, **kwargs)
+                self.set_eta_scan_averages(
+                    band, self._eta_scan_averages[band],
+                    write_log=write_log, **kwargs)
+                self.set_eta_scan_del_f(
+                    band, self._eta_scan_del_f[band],
+                    write_log=write_log, **kwargs)
+
+            # Set UC and DC attenuators
+            for band in bands:
+                self.set_att_uc(
+                    band, self._att_uc[band],
+                    write_log=write_log)
+                self.set_att_dc(
+                    band, self._att_dc[band],
+                    write_log=write_log)
+
+            # Things that have to be done for both AMC bays, regardless of whether or not an AMC
+            # is plugged in there.
+            for bay in [0, 1]:
+                self.set_trigger_hw_arm(bay, 0, write_log=write_log)
+
+            self.set_trigger_width(0, 10, write_log=write_log)  # mystery bit that makes triggering work
+            self.set_trigger_enable(0, 1, write_log=write_log)
+            ## only sets enable, but is initialized to True already by
+            ## default, and crashing for unknown reasons in rogue 4.
+            self.set_evr_channel_reg_enable(0, True, write_log=write_log)
+            self.set_evr_trigger_channel_reg_dest_sel(0,
+                                                      0x20000,
+                                                      write_log=write_log)
+
+            self.set_enable_ramp_trigger(1, write_log=write_log)
+
+            # 0x1 selects fast flux ramp, 0x0 selects slow flux ramp.  The
+            # slow flux ramp only existed on the first rev of RTM boards,
+            # C0, and wasn't ever really used.
+            self.set_select_ramp(0x1, write_log=write_log)
+
+            self.set_cpld_reset(0, write_log=write_log)
+            self.cpld_toggle(write_log=write_log)
+
+            # Make sure flux ramp starts off
+            self.flux_ramp_off(write_log=write_log)
+            self.flux_ramp_setup(self._reset_rate_khz,
+                                 self._fraction_full_scale,
+                                 write_log=write_log)
+
+            # Turn on stream enable for all bands
+            self.set_stream_enable(1, write_log=write_log)
+
+            # Set payload size and mask to a single channel
+            self.set_payload_size(payload_size)
+            self.set_channel_mask([0])
+
+            self.set_amplifier_bias(write_log=write_log)
+            self.get_amplifier_bias()
+
+            # also read the temperature of the CC
+            self.log(f"Cryocard temperature = {self.C.read_temperature()}")
+
+            # if no timing section present, assumes your defaults.yml
+            # has set you up...good luck.
+            if self._timing_reference is not None:
+                timing_reference = self._timing_reference
+
+                # check if supported
+                timing_options = ['ext_ref', 'backplane']
+                assert (timing_reference in timing_options), (
+                    'timing_reference in cfg file ' +
+                    f'(={timing_reference}) not in ' +
+                    f'timing_options={timing_options}')
+
+                self.log(
+                    'Configuring the system to take timing ' +
+                    f'from {timing_reference}')
+
+                if timing_reference == 'ext_ref':
+                    for bay in self.bays:
+                        self.log(f'Select external reference for bay {bay}')
+                        self.sel_ext_ref(bay)
+
+                    # make sure RTM knows there's no timing system
+                    self.set_ramp_start_mode(0, write_log=write_log)
+
+                # https://confluence.slac.stanford.edu/display/SMuRF/Timing+Carrier#TimingCarrier-Howtoconfiguretodistributeoverbackplanefromslot2
+                if timing_reference == 'backplane':
+                    # Set SMuRF carrier crossbar to use the backplane
+                    # distributed timing.
+                    # OutputConfig[1] = 0x2 configures the SMuRF carrier's
+                    # FPGA to take the timing signals from the backplane
+                    # (TO_FPGA = FROM_BACKPLANE)
+                    self.log('Setting crossbar OutputConfig[1]=0x2 (TO_FPGA=FROM_BACKPLANE)')
+                    self.set_crossbar_output_config(1, 2)
+
+                    self.log('Waiting 1 sec for timing up-link...')
+                    time.sleep(1)
+
+                    # Check if link is up - just printing status to
+                    # screen, not currently taking any action if it's not.
+                    timing_rx_link_up = self.get_timing_link_up()
+                    self.log(f'Timing RxLinkUp = {timing_rx_link_up}', self.LOG_USER if
+                             timing_rx_link_up else self.LOG_ERROR)
+
+                    # Set LMK to use timing system as reference
+                    for bay in self.bays:
+                        self.log(f'Configuring bay {bay} LMK to lock to the timing system')
+                        self.set_lmk_reg(bay, 0x147, 0xA)
+
+                    # Configure RTM to trigger off of the timing system
+                    self.set_ramp_start_mode(1, write_log=write_log)
+                    
+            self.log('Done with setup.', self.LOG_USER)
+        else:
+            self.log('Setup failed!', self.LOG_ERROR)
+            
         # If active, re-enable hardware logging after setup.
         if self._hardware_logging_thread is not None:
-            self.log('Resuming hardware logging.', (self.LOG_USER))
+            self.log('Resuming hardware logging.', self.LOG_USER)
             self.resume_hardware_logging()
+
+        # Assume if we made it here that configuration was successful.
+        return success
 
     def make_dir(self, directory):
         """Create directory on file system at the specified path.

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -514,8 +514,8 @@ class SmurfCommandMixin(SmurfBase):
             and :func:`get_system_configured`).  Only used for pysmurf
             core code versions >= 4.1.0.
         \**kwargs
-            Arbitrary keyword arguments.  Passed directly to the
-            `_caget` call.
+            Arbitrary keyword arguments.  Passed directly to 
+            all `_caget` calls.
 
         Returns
         -------
@@ -535,7 +535,7 @@ class SmurfCommandMixin(SmurfBase):
         """
         # strip any commit info off the end of the pysmurf version
         # string
-        pysmurf_version = self.get_pysmurf_version().split('+')[0]
+        pysmurf_version = self.get_pysmurf_version(**kwargs).split('+')[0]
 
         # Extra registers allow confirmation of successful
         # configuration for pysmurf versions >=4.1.0.
@@ -565,7 +565,8 @@ class SmurfCommandMixin(SmurfBase):
                 # We successfully exit the loop when we are able to
                 # read the "ConfiguringInProgress" flag and it is set
                 # to "False".  Otherwise we keep trying.
-                if not self.get_configuring_in_progress(timeout=caget_timeout_sec):
+                if not self.get_configuring_in_progress(
+                        timeout=caget_timeout_sec, **kwargs):
                     success=True
                     break
 
@@ -593,7 +594,8 @@ class SmurfCommandMixin(SmurfBase):
             # configuration fails but this SystemConfigured poll
             # returns the True from a previous setDefaults.
             time.sleep(30)
-            success = self.get_system_configured(timeout=caget_timeout_sec)
+            success = self.get_system_configured(
+                timeout=caget_timeout_sec, **kwargs)
 
             # Measure how long the process take
             end_time = time.time()

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -266,7 +266,7 @@ class SmurfCommandMixin(SmurfBase):
         return self._caget(self.smurf_application +
                            self._smurf_startup_arguments_reg,
                            as_string=True, **kwargs)
-
+    
     _enabled_bays_reg = "EnabledBays"
 
     def get_enabled_bays(self, **kwargs):
@@ -287,6 +287,72 @@ class SmurfCommandMixin(SmurfBase):
         except Exception:
             return enabled_bays
 
+    _configuring_in_progress_reg = 'ConfiguringInProgress'
+
+    def get_configuring_in_progress(self, **kwargs):
+        r"""Whether or not configuration process in progress.
+        
+        Set to `True` when the rogue `setDefaults` command is called
+        (usually by a call to :func:`set_defaults_pv`), and then set
+        to `False` when the rogue `setDefaults` method exits.
+        
+        Args
+        ----
+        \**kwargs
+            Arbitrary keyword arguments.  Passed directly to the
+            `_caget` call.
+
+        Returns
+        -------
+        bool
+           Boolean flag indicating whether or not the configuration
+           process is in progress.  Returns `True` if the
+           configuration process is in progress, otherwise returns
+           `False`.
+
+        See Also
+        --------
+        :func:`set_defaults_pv` : Loads the default configuration.
+        :func:`get_system_configured` : Returns final state of
+                configuration process.
+        """
+        return self._caget(self.smurf_application +
+                           self._configuring_in_progress_reg,
+                           **kwargs)
+
+    _system_configured_reg = 'SystemConfigured'
+
+    def get_system_configured(self, **kwargs):
+        r"""Returns final state of the configuration process.
+
+        If the configuration was loaded without errors by the rogue
+        `setDefaults` command (usually by a call to
+        :func:`set_defaults_pv`) and all tests pass, this flag is set
+        to `True` when the rogue `setDefaults` method exits.
+        
+        Args
+        ----
+        \**kwargs
+            Arbitrary keyword arguments.  Passed directly to the
+            `_caget` call.
+
+        Returns
+        -------
+        bool
+           Boolean flag indicating the final state of the
+           configuration process.  If the configuration was loaded
+           without errors and all tests passed, then this flag is set
+           to `True`.  Otherwise it is set to `False`.
+
+        See Also
+        --------
+        :func:`set_defaults_pv` : Loads the default configuration.
+        :func:`get_configuring_in_progress` : Whether or not
+                configuration process in progress.
+        """
+        return self._caget(self.smurf_application +
+                           self._system_configured_reg,
+                           **kwargs)            
 
     #### End SmurfApplication gets/sets
 
@@ -409,9 +475,24 @@ class SmurfCommandMixin(SmurfBase):
         return n_processed_channels
 
     def set_defaults_pv(self, **kwargs):
-        """
-        Sets the default epics variables
-        """
+        r"""Loads the default configuration.
+
+        Calls the rogue `setDefaults` command, which loads the default
+        software and hardware configuration.
+        
+        Args
+        ----
+        \**kwargs
+            Arbitrary keyword arguments.  Passed directly to the
+            `_caget` call.
+
+        See Also
+        --------
+        :func:`get_configuring_in_progress` : Whether or not
+                configuration process in progress.
+        :func:`get_system_configured` : Returns final state of
+                configuration process.
+        """        
         self._caput(self.epics_root + ':AMCc:setDefaults', 1, wait_after=30,
             **kwargs)
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -501,9 +501,13 @@ class SmurfCommandMixin(SmurfBase):
             If not None, the number of seconds to wait after
             triggering the rogue `setDefaults` command.
         max_timeout_sec : float, optional, default 400.0
-            ???.
+            Seconds to wait for system to configure before giving up.
+            Only used for pysmurf core code versions >= 4.1.0.
         caget_timeout_sec : float, optional, default 10.0
-            ???.
+            Seconds to wait for each poll of the configuration process
+            status registers (see :func:`get_configuring_in_progress`
+            and :func:`get_system_configured`).  Only used for pysmurf
+            core code versions >= 4.1.0.
         \**kwargs
             Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
@@ -558,7 +562,7 @@ class SmurfCommandMixin(SmurfBase):
                 # We successfully exit the loop when we are able to
                 # read the "ConfiguringInProgress" flag and it is set
                 # to "False".  Otherwise we keep trying.
-                if not self.get_configuring_in_progress():
+                if not self.get_configuring_in_progress(timeout=caget_timeout_sec):
                     success=True
                     break
 
@@ -586,10 +590,10 @@ class SmurfCommandMixin(SmurfBase):
             # configuration fails but this SystemConfigured poll
             # returns the True from a previous setDefaults.
             time.sleep(30)
-            success = self.get_system_configured()
+            success = self.get_system_configured(timeout=caget_timeout_sec)
 
             # Measure how long the process take
-            end_time = time.time()            
+            end_time = time.time()
 
             self.log(
                 'System configuration finished after'

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -324,9 +324,10 @@ class SmurfCommandMixin(SmurfBase):
                 configuration process.
 
         """
-        return self._caget(self.smurf_application +
-                           self._configuring_in_progress_reg,
-                           **kwargs)
+        return bool(
+            self._caget(self.smurf_application +
+                        self._configuring_in_progress_reg, **kwargs)
+        )
 
     _system_configured_reg = 'SystemConfigured'
 
@@ -360,9 +361,10 @@ class SmurfCommandMixin(SmurfBase):
                 configuration process in progress.
 
         """
-        return self._caget(self.smurf_application +
-                           self._system_configured_reg,
-                           **kwargs)
+        return bool(
+            self._caget(self.smurf_application +
+                        self._system_configured_reg, **kwargs)
+        )
 
     #### End SmurfApplication gets/sets
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -495,6 +495,11 @@ class SmurfCommandMixin(SmurfBase):
         Calls the rogue `setDefaults` command, which loads the default
         software and hardware configuration.
 
+        If using pysmurf core code versions >=4.1.0 (as reported by
+        :func:`get_pysmurf_version`), returns `True` if the
+        `setDefaults` command was successfully executed on the rogue
+        side, or failed.  Returns `None` for older versions.
+
         Args
         ----
         wait_after_sec : float or None, optional, default 30.0
@@ -531,8 +536,6 @@ class SmurfCommandMixin(SmurfBase):
         # strip any commit info off the end of the pysmurf version
         # string
         pysmurf_version = self.get_pysmurf_version().split('+')[0]
-        # temporary override for testing
-        pysmurf_version = '4.1.0'
 
         # Extra registers allow confirmation of successful
         # configuration for pysmurf versions >=4.1.0.

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -514,7 +514,7 @@ class SmurfCommandMixin(SmurfBase):
             and :func:`get_system_configured`).  Only used for pysmurf
             core code versions >= 4.1.0.
         \**kwargs
-            Arbitrary keyword arguments.  Passed directly to 
+            Arbitrary keyword arguments.  Passed directly to
             all `_caget` calls.
 
         Returns

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -266,17 +266,23 @@ class SmurfCommandMixin(SmurfBase):
         return self._caget(self.smurf_application +
                            self._smurf_startup_arguments_reg,
                            as_string=True, **kwargs)
-    
+
     _enabled_bays_reg = "EnabledBays"
 
     def get_enabled_bays(self, **kwargs):
-        """
-        Gets list of enabled bays.
+        r"""Returns list of enabled AMC bays.
+
+        Args
+        ----
+        \**kwargs
+            Arbitrary keyword arguments.  Passed directly to the
+            `_caget` call.
 
         Returns
         -------
         bays : list of int
             Which bays were enabled on pysmurf server startup.
+
         """
         enabled_bays = self._caget(
             self.smurf_application +
@@ -291,11 +297,11 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_configuring_in_progress(self, **kwargs):
         r"""Whether or not configuration process in progress.
-        
+
         Set to `True` when the rogue `setDefaults` command is called
         (usually by a call to :func:`set_defaults_pv`), and then set
         to `False` when the rogue `setDefaults` method exits.
-        
+
         Args
         ----
         \**kwargs
@@ -313,8 +319,10 @@ class SmurfCommandMixin(SmurfBase):
         See Also
         --------
         :func:`set_defaults_pv` : Loads the default configuration.
+
         :func:`get_system_configured` : Returns final state of
                 configuration process.
+
         """
         return self._caget(self.smurf_application +
                            self._configuring_in_progress_reg,
@@ -329,7 +337,7 @@ class SmurfCommandMixin(SmurfBase):
         `setDefaults` command (usually by a call to
         :func:`set_defaults_pv`) and all tests pass, this flag is set
         to `True` when the rogue `setDefaults` method exits.
-        
+
         Args
         ----
         \**kwargs
@@ -347,12 +355,14 @@ class SmurfCommandMixin(SmurfBase):
         See Also
         --------
         :func:`set_defaults_pv` : Loads the default configuration.
+
         :func:`get_configuring_in_progress` : Whether or not
                 configuration process in progress.
+
         """
         return self._caget(self.smurf_application +
                            self._system_configured_reg,
-                           **kwargs)            
+                           **kwargs)
 
     #### End SmurfApplication gets/sets
 
@@ -479,7 +489,7 @@ class SmurfCommandMixin(SmurfBase):
 
         Calls the rogue `setDefaults` command, which loads the default
         software and hardware configuration.
-        
+
         Args
         ----
         \**kwargs
@@ -492,8 +502,10 @@ class SmurfCommandMixin(SmurfBase):
                 configuration process in progress.
         :func:`get_system_configured` : Returns final state of
                 configuration process.
-        """        
-        self._caput(self.epics_root + ':AMCc:setDefaults', 1, wait_after=30,
+
+        """
+        self._caput(
+            self.epics_root + ':AMCc:setDefaults', 1, wait_after=30,
             **kwargs)
 
     def set_read_all(self, **kwargs):

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -585,15 +585,6 @@ class SmurfCommandMixin(SmurfBase):
             # The final status of the configuration sequence is
             # available in the "SystemConfigured" flag.
             # So, let's read it and use it as out return value.
-            #
-            # Found that there's approximately a 5 sec lag between
-            # when ConfiguringInProgress flag clears and when
-            # SystemConfigured.  For now, wait 30 sec and pray.
-            # SystemConfigured is also not cleared by triggering
-            # setDefaults, so may run into trouble if a 2nd
-            # configuration fails but this SystemConfigured poll
-            # returns the True from a previous setDefaults.
-            time.sleep(30)
             success = self.get_system_configured(
                 timeout=caget_timeout_sec, **kwargs)
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -534,20 +534,20 @@ class SmurfCommandMixin(SmurfBase):
             start_time = time.time()
 
             # Start by calling the 'setDefaults' command. Set the 'wait' flag
-            # to wait for the command to finish, although the server usually 
+            # to wait for the command to finish, although the server usually
             # gets unresponsive during setup and the connection is lost.
             self._caput(
                 self.epics_root + ':AMCc:setDefaults', 1,
-                wait_done=True, **kwargs)            
-            
+                wait_done=True, **kwargs)
+
             # Now let's wait until the process is finished. We define a maximum
-            # time we will wait, 400 seconds in this case, divided in smaller 
+            # time we will wait, 400 seconds in this case, divided in smaller
             # tries of 10 second each
             max_timeout = 400
             caget_timeout = 10
             num_retries = int(max_timeout/caget_timeout)
             success = False
-            for i in range(num_retries):
+            for _ in range(num_retries):
                 # Try to read the status of the
                 # "ConfiguringInProgress" flag.
                 #
@@ -583,7 +583,7 @@ class SmurfCommandMixin(SmurfBase):
                 f' {int(end_time - start_time)} seconds.'
                 f' The final state was {success}',
                 self.LOG_INFO)
-            
+
             return success
 
         else:

--- a/scratch/shawn/rf_deterministic_latency.py
+++ b/scratch/shawn/rf_deterministic_latency.py
@@ -1,0 +1,102 @@
+# Runlike this exec(open("scratch/shawn/full_band_response.py").read())
+# to use the pysmurf S object you've already initialized
+import time
+import numpy as np
+import sys
+import os
+import matplotlib.pylab as plt
+plt.ion()
+
+bands=[2] #S.config.get('init').get('bands')
+
+niter=1
+n_scan=5
+fit_freq_min=-150e6
+fit_freq_max=150e6
+
+results_dict={}
+
+timestamp=S.get_timestamp()
+
+results_dict['timestamp']=timestamp
+results_dict['n_scan']=n_scan
+results_dict['fit_freq_min']=fit_freq_min
+results_dict['fit_freq_max']=fit_freq_max
+
+for idx in range(niter):
+    results_dict[band]={}    
+    for band in bands:
+        results_dict[band][idx]={}            
+        print(' ')
+        print(' ')
+        print(f'Band {band}')
+        print(' ')
+        print(' ')
+        
+        freq, resp = S.full_band_resp(band=band,
+                                      n_scan=n_scan,
+                                      timestamp=timestamp)
+        
+        results_dict[band][idx]['freq']=freq
+        results_dict[band][idx]['resp']=resp
+        
+        rf_phase = (
+            np.unwrap(np.arctan2(np.imag(resp),np.real(resp))))
+        
+        # fit line to central frequency interval
+        fit_idx = np.where( (freq > fit_freq_min) & (freq < fit_freq_max) )
+        fit_z = np.polyfit( freq[fit_idx]/1.e6, rf_phase[fit_idx], 1)
+        results_dict[band][idx]['fit'] = np.poly1d(fit_z)
+        
+nrows=1
+if len(bands)>4:
+    nrows=2
+fig, ax = plt.subplots(nrows=nrows, ncols=4, figsize=(14,7), sharex=True)
+
+fig.suptitle(f'RF deterministic latency {timestamp}')
+for band in bands:
+    this_ax=None
+    this_title=f'band {band}'
+    if len(bands)>4:
+        this_ax=ax[int(band/4)][band%4]
+    else:
+        this_ax=ax[band%4]
+    this_ax.set_title(this_title)
+
+    print('here')
+    for idx in range(niter):        
+        f_plot=results_dict[band][idx]['freq']
+        resp_plot=results_dict[band][idx]['resp']
+        rf_phase_plot = (
+            np.unwrap(np.arctan2(np.imag(resp_plot),np.real(resp_plot))))        
+
+        #this_ax.plot(f_plot/1.e6, rf_phase_plot)
+        #this_ax.plot(f_plot/1.e6,results_dict[band][0]['fit'](f_plot/1.e6),'r--')
+
+        this_ax.plot(f_plot/1.e6,(
+            rf_phase_plot - results_dict[band][0]['fit'](f_plot/1.e6)),
+            'r--')               
+        #this_ax.plot(f_plot/1.e6, rf_phase_plot)
+        #plt.xlim(fit_freq_min/1.e6,fit_freq_max/1.e6)
+
+sys.exit(1)
+
+save_name=f'{timestamp}_rfdetlat.npy'
+save_path=os.path.join(S.output_dir, save_name)
+print(f'Saving data to {save_path}')
+
+## Save data to disk for lookup
+np.save(save_path, results_dict)
+
+plt.tight_layout()
+
+print(f'Saving plot to {os.path.join(S.plot_dir, save_name)}')
+plt.savefig(os.path.join(S.plot_dir, save_name.replace('.npy','png')),
+            bbox_inches='tight')
+
+## log plot file
+logf=open('/data/smurf_data/smurf_loop.log','a+')
+logf.write(f'{save_path}'+'\n')
+logf.close()
+
+print('Done running deterministic_latency.py.')

--- a/scratch/shawn/scripts/shawnhammer.sh
+++ b/scratch/shawn/scripts/shawnhammer.sh
@@ -298,7 +298,7 @@ if [ "$parallel_setup" = true ] ; then
 		echo "-> Waiting for carrier setup on slot ${slot} ..."		
 	    	if is_slot_pysmurf_setup_complete ${slot}; then
 	    	    slot_status[$slot_idx]=7;
-	    	fi		
+	    	fi
 	    fi	    	    
 
 	    # check if complete


### PR DESCRIPTION
## Issue
This PR resolves issue https://github.com/slaclab/pysmurf/issues/462.

## Description

This PR mostly expands the `smurf_command.set_defaults_pv` routine to check if loading the hardware defaults succeeded using the new `ConfiguringInProgress` and `SystemConfigured` registers described in https://github.com/slaclab/pysmurf/issues/462.  These new registers are not provided in the current stable pysmurf release (v4.0.0) so to use them right now, you have to run with a dev_sw rogue docker with the below version of pysmurf.  Here's an attempt at a comprehensive list of changes made:

* Added new `get_configuring_in_progress` and `get_system_configured` routines to `smurf_command` to poll the new `ConfiguringInProgress` and `SystemConfigured` registers.
* Adjusts the RF lab configuration files to use the newer dev_sw version I tested this code on.
* Elevated the wait after the `setDefaults` calls in `set_defaults_pv` to a new `set_defaults_pv` routine keyword `wait_after_sec`.
* Added configuration success check suggested in issue https://github.com/slaclab/pysmurf/issues/462.  The check is only done if the pysmurf core code version is >=4.1.0.
* shawnhammer now checks if `setup` fails.
* `setup` and `set_defaults_pv` now return a boolean success flag which is False if they fail, True if they succeed.  `set_defaults_pv` returns None for pysmurf core code versions <=4.1.0.
* Two new keywords `max_timeout_sec` and `caget_timeout_sec` added to the `set_defaults_pv` routine to allow user to control how long the routine waits for the system to configure/respond to register polls.  
* Adds Shawn's rf_deterministic_latency.py test script.
* Expands docstrings for the `setup` and `set_defaults_pv` routines.  The `setup` routine still needs more work.  I've created a new pysmurf issue for that here - https://github.com/slaclab/pysmurf/issues/475.

Tested with these software versions:

smurf_cfg : v1.3.0
carrier fw : ae09de6
Rogue zip : v0.1.10
pysmurf(master) : fcf349ac
Rogue/pyrogue version : v4.10.6

## Does this PR break any interface?
- [ ] Yes
- [x] No
