### PR TITLE
Update smurf-rogue base image to version R2.8.1

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.8.0
+FROM tidair/smurf-rogue:R2.8.1
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src


### PR DESCRIPTION
This updates rogue to version v4.11.2

## Issue
This PR resolves [ESCRYODET-640](https://jira.slac.stanford.edu/browse/ESCRYODET-640).

## Description

This PR updates rogue to version v4.11.2. This version fixes a memory leak bug which was reported in [ESCRYODET-640](https://jira.slac.stanford.edu/browse/ESCRYODET-640).

## Does this PR break any interface?
- [ ] Yes
- [X] No