### PR TITLE
Update smurf_iv.py

### DIFF
--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -32,7 +32,8 @@ class SmurfIVMixin(SmurfBase):
                     show_plot=False, overbias_wait=2., cool_wait=30,
                     make_plot=True, save_plot=True, plotname_append='',
                     channels=None, band=None, high_current_mode=True,
-                    overbias_voltage=8., grid_on=True, phase_excursion_min=3.):
+                    overbias_voltage=8., grid_on=True, phase_excursion_min=3.,
+                    bias_line_resistance=None):
         """Takes a slow IV
 
         Steps the TES bias down slowly. Starts at bias_high to
@@ -158,7 +159,7 @@ class SmurfIVMixin(SmurfBase):
             show_plot=show_plot, save_plot=save_plot,
             plotname_append=plotname_append, R_sh=R_sh, grid_on=grid_on,
             phase_excursion_min=phase_excursion_min, channel=channels,
-            band=band)
+            band=band, bias_line_resistance=bias_line_resistance)
 
         return path
 


### PR DESCRIPTION
Adding bias_line_resistance argument to slow_iv_all command.

## Issue
This PR resolves inability to set bias line resistance. 

## Description

Minor change to pass bias_line_resistance argument from slow_iv_all to analyze_slow_iv_all

## Does this PR break any interface?
- [ ] Yes
- [x ] No

### Which interface changed?
Change to arguments in slow_iv_all and analyze_slow_iv_all

### What was the interface before the change
Did not have bias_line_resistance argument available

### What will be the new interface after the change
Allows setting the bias line resistance depending on wiring of the testing setup and local physical measurements
