### PR TITLE
IV functions renamed, now using tone_power and nsamp instead of varying names.

### DIFF
--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -419,7 +419,7 @@ class SmurfConfigPropertiesMixin:
 
         See Also
         --------
-        :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.analyze_slow_iv`,
+        :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.analyze_iv`,
         :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_all_vs_noise_solo`,
         :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_vs_bias`,
         :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_vs_tone`,
@@ -1124,7 +1124,7 @@ class SmurfConfigPropertiesMixin:
 
         See Also
         --------
-        :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.analyze_slow_iv`,
+        :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.analyze_iv`,
         :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.NET_CMB`,
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.bias_bump`
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.identify_bias_groups`
@@ -1161,7 +1161,7 @@ class SmurfConfigPropertiesMixin:
 
         See Also
         --------
-        :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.analyze_slow_iv`,
+        :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.analyze_iv`,
         :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.partial_load_curve_all`,
         :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.run_iv`,
         :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.NET_CMB`,
@@ -1213,7 +1213,7 @@ class SmurfConfigPropertiesMixin:
 
         See Also
         --------
-        :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.analyze_slow_iv`,
+        :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.analyze_iv`,
         :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.partial_load_curve_all`,
         :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.NET_CMB`,
         :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.get_iv_data`,

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -996,7 +996,7 @@ class SmurfConfigPropertiesMixin:
 
         See Also
         --------
-        :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.slow_iv_all`,
+        :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.run_iv`,
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.overbias_tes_all`
         """
         return self._all_groups
@@ -1163,7 +1163,7 @@ class SmurfConfigPropertiesMixin:
         --------
         :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.analyze_slow_iv`,
         :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.partial_load_curve_all`,
-        :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.slow_iv_all`,
+        :func:`~pysmurf.client.debug.smurf_iv.SmurfIVMixin.run_iv`,
         :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.NET_CMB`,
         :func:`~pysmurf.client.debug.smurf_noise.SmurfNoiseMixin.analyze_noise_vs_bias`,
         :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.bias_bump`

--- a/python/pysmurf/client/command/smurf_cmd.py
+++ b/python/pysmurf/client/command/smurf_cmd.py
@@ -326,14 +326,14 @@ if __name__ == "__main__":
 
         if args.bias_group < 0: # all
             S.log('running slow IV on all bias groups')
-            S.slow_iv_all(bias_groups=S.all_groups, wait_time=args.iv_wait_time,
+            S.run_iv(bias_groups=S.all_groups, wait_time=args.iv_wait_time,
                 bias_high=iv_bias_high, bias_low = iv_bias_low,
                 high_current_wait=args.iv_high_current_wait,
                 high_current_mode=S.high_current_mode_bool,
                 bias_step=iv_bias_step, make_plot=False)
         else: # individual bias group
             S.log(f'running slow IV on bias group {args.bias_group}')
-            S.slow_iv_all(bias_groups=np.array([args.bias_group]),
+            S.run_iv(bias_groups=np.array([args.bias_group]),
                 wait_time=args.iv_wait_time, bias_high=iv_bias_high,
                 bias_low=iv_bias_low,
                 high_current_wait=args.iv_high_current_wait,

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -1399,7 +1399,7 @@ class SmurfCommandMixin(SmurfBase):
             self._cryo_root(band) + self._amplitude_scale_array_reg,
             **kwargs)
 
-    def set_amplitude_scale_array_currentchans(self, band, drive,
+    def set_amplitude_scale_array_currentchans(self, band, tone_power,
                                                **kwargs):
         """
         Set only the currently on channels to a new drive power. Essentially
@@ -1410,14 +1410,14 @@ class SmurfCommandMixin(SmurfBase):
         ----
         band : int
             The band to change.
-        drive : int
+        tone_power : int
             Tone power to change to.
         """
 
         old_amp = self.get_amplitude_scale_array(band, **kwargs)
         n_channels=self.get_number_channels(band)
         new_amp = np.zeros((n_channels,),dtype=int)
-        new_amp[np.where(old_amp!=0)] = drive
+        new_amp[np.where(old_amp!=0)] = tone_power
         self.set_amplitude_scale_array(self, new_amp, **kwargs)
 
     _feedback_enable_array_reg = 'feedbackEnableArray'

--- a/python/pysmurf/client/command/test_sphinx.py
+++ b/python/pysmurf/client/command/test_sphinx.py
@@ -1209,7 +1209,7 @@ class SmurfCommandMixin(SmurfBase):
             self._cryo_root(band) + self._amplitude_scale_array_reg,
             **kwargs)
 
-    def set_amplitude_scale_array_currentchans(self, band, drive,
+    def set_amplitude_scale_array_currentchans(self, band, tone_power,
                                                **kwargs):
         """
         Set only the currently on channels to a new drive power. Essentially
@@ -1220,14 +1220,14 @@ class SmurfCommandMixin(SmurfBase):
         ----
         band : int
             The band to change.
-        drive : int
+        tone_power : int
             Tone power to change to.
         """
 
         old_amp = self.get_amplitude_scale_array(band, **kwargs)
         n_channels=self.get_number_channels(band)
         new_amp = np.zeros((n_channels,),dtype=int)
-        new_amp[np.where(old_amp!=0)] = drive
+        new_amp[np.where(old_amp!=0)] = tone_power
         self.set_amplitude_scale_array(self, new_amp, **kwargs)
 
     _feedback_enable_array_reg = 'feedbackEnableArray'

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -154,7 +154,7 @@ class SmurfIVMixin(SmurfBase):
         self.pub.register_file(path, 'iv_raw', format='npy')
 
         R_sh=self._R_sh
-        self.analyze_slow_iv_from_file(fn_iv_raw_data, make_plot=make_plot,
+        self.analyze_iv_from_file(fn_iv_raw_data, make_plot=make_plot,
             show_plot=show_plot, save_plot=save_plot,
             plotname_append=plotname_append, R_sh=R_sh, grid_on=grid_on,
             phase_excursion_min=phase_excursion_min, channel=channels,
@@ -291,7 +291,7 @@ class SmurfIVMixin(SmurfBase):
         return path
 
     @set_action()
-    def analyze_slow_iv_from_file(self, fn_iv_raw_data, make_plot=True,
+    def analyze_iv_from_file(self, fn_iv_raw_data, make_plot=True,
                                   show_plot=False, save_plot=True,
                                   plotname_append='', R_sh=None,
                                   phase_excursion_min=3., grid_on=False,
@@ -442,7 +442,7 @@ class SmurfIVMixin(SmurfBase):
                 if not show_plot:
                     plt.close()
 
-            iv_dict = self.analyze_slow_iv(v_bias, phase,
+            iv_dict = self.analyze_iv(v_bias, phase,
                 basename=basename, band=b, channel=ch, make_plot=make_plot,
                 show_plot=show_plot, save_plot=save_plot, plot_dir=plot_dir,
                 R_sh=R_sh, high_current_mode=high_current_mode,
@@ -574,13 +574,13 @@ class SmurfIVMixin(SmurfBase):
                 plt.close()
 
     @set_action()
-    def analyze_slow_iv(self, v_bias, resp, make_plot=True, show_plot=False,
+    def analyze_iv(self, v_bias, resp, make_plot=True, show_plot=False,
             save_plot=True, basename=None, band=None, channel=None, R_sh=None,
             plot_dir=None, high_current_mode=False, bias_group=None,
             grid_on=False, R_op_target=0.007, pA_per_phi0=None,
             bias_line_resistance=None, plotname_append='', **kwargs):
         """
-        Analyzes the IV curve taken with slow_iv()
+        Analyzes the IV curve taken with run_iv()
 
         Args
         ----
@@ -955,7 +955,7 @@ class SmurfIVMixin(SmurfBase):
             phase_excursion_min=1., channels=None):
         """
         Function to analyze a partial load curve from its raw
-        file. Basically the same as the slow_iv analysis but without
+        file. Basically the same as the run_iv analysis but without
         fitting the superconducting branch.
 
         Args

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -28,11 +28,12 @@ class SmurfIVMixin(SmurfBase):
 
     @set_action()
     def run_iv(self, bias_groups=None, wait_time=.1, bias=None,
-                    bias_high=1.5, bias_low=0, bias_step=.005,
-                    show_plot=False, overbias_wait=2., cool_wait=30,
-                    make_plot=True, save_plot=True, plotname_append='',
-                    channels=None, band=None, high_current_mode=True,
-                    overbias_voltage=8., grid_on=True, phase_excursion_min=3.):
+               bias_high=1.5, bias_low=0, bias_step=.005,
+               show_plot=False, overbias_wait=2., cool_wait=30,
+               make_plot=True, save_plot=True, plotname_append='',
+               channels=None, band=None, high_current_mode=True,
+               overbias_voltage=8., grid_on=True,
+               phase_excursion_min=3.):
         """Takes a slow IV
 
         Steps the TES bias down slowly. Starts at bias_high to
@@ -292,12 +293,13 @@ class SmurfIVMixin(SmurfBase):
 
     @set_action()
     def analyze_iv_from_file(self, fn_iv_raw_data, make_plot=True,
-                                  show_plot=False, save_plot=True,
-                                  plotname_append='', R_sh=None,
-                                  phase_excursion_min=3., grid_on=False,
-                                  R_op_target=0.007, pA_per_phi0=None,
-                                  channel=None, band=None, datafile=None,
-                                  plot_dir=None, bias_line_resistance=None):
+                             show_plot=False, save_plot=True,
+                             plotname_append='', R_sh=None,
+                             phase_excursion_min=3., grid_on=False,
+                             R_op_target=0.007, pA_per_phi0=None,
+                             channel=None, band=None, datafile=None,
+                             plot_dir=None,
+                             bias_line_resistance=None):
         """
         Function to analyze a load curve from its raw file. Can be used to
           analyze IV's/generate plots separately from issuing commands.

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -27,7 +27,7 @@ from pysmurf.client.util.pub import set_action
 class SmurfIVMixin(SmurfBase):
 
     @set_action()
-    def slow_iv_all(self, bias_groups=None, wait_time=.1, bias=None,
+    def run_iv(self, bias_groups=None, wait_time=.1, bias=None,
                     bias_high=1.5, bias_low=0, bias_step=.005,
                     show_plot=False, overbias_wait=2., cool_wait=30,
                     make_plot=True, save_plot=True, plotname_append='',

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -394,7 +394,7 @@ class SmurfNoiseMixin(SmurfBase):
             self.log(f'Measuring for tone power {t}')
 
             # Tune the band with the new drive power
-            self.tune_band_serial(band, drive=t,
+            self.tune_band_serial(band, tone_power=t,
                 new_master_assignment=new_master_assignment,
                 from_old_tune=from_old_tune, old_tune=old_tune)
 
@@ -1442,7 +1442,7 @@ class SmurfNoiseMixin(SmurfBase):
 
         channel = self.which_on(2)
         n_channel = len(channel)
-        drive = self.freq_resp[band]['drive']
+        tone_power = self.freq_resp[band]['tone_power']
 
         self.log('Taking noise with all channels')
 
@@ -1454,7 +1454,7 @@ class SmurfNoiseMixin(SmurfBase):
             self.log(f'ch {ch:03} - {i+1} of {n_channel}')
             self.band_off(band)
             self.flux_ramp_on()
-            self.set_amplitude_scale_channel(band, ch, drive)
+            self.set_amplitude_scale_channel(band, ch, tone_power)
             self.set_feedback_enable_channel(band, ch, 1, wait_after=1)
             filename = self.take_stream_data(meas_time)
             ret[ch] = filename

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -290,7 +290,7 @@ class SmurfUtilMixin(SmurfBase):
             freq_dsp,resp_dsp=self.find_freq(band,subband=dsp_subbands)
             ## not really faster if reduce n_step or n_read...somehow.
             #freq_dsp,resp_dsp=self.full_band_ampl_sweep(band,
-            # subband=dsp_subbands, drive=drive, n_read=2, n_step=n_step)
+            # subband=dsp_subbands, tone_power=tone_power, n_read=2, n_step=n_step)
 
         # only preserve data in the subband half width
         freq_dsp_subset=[]
@@ -3909,7 +3909,7 @@ class SmurfUtilMixin(SmurfBase):
         return ret
 
 
-    def set_fixed_tone(self, freq_mhz, drive, write_log=False):
+    def set_fixed_tone(self, freq_mhz, tone_power, write_log=False):
         """
         Places a fixed tone at the requested frequency.  Asserts
         without doing anything if the requested resonator frequency
@@ -3922,7 +3922,7 @@ class SmurfUtilMixin(SmurfBase):
         ----
         freq_mhz : float
             The frequency in MHz at which to place a fixed tone.
-        drive : int
+        tone_power : int
             The amplitude for the fixed tone (0-15 in recent fw
             revisions).
         write_log : bool, optional, default False
@@ -3969,14 +3969,14 @@ class SmurfUtilMixin(SmurfBase):
 
         # Put a fixed tone at the requested frequency
         self.set_center_frequency_mhz_channel(band, channel, foff)
-        self.set_amplitude_scale_channel(band, channel, drive)
+        self.set_amplitude_scale_channel(band, channel, tone_power)
         self.set_feedback_enable_channel(band, channel, 0)
 
         # Unless asked to be quiet, print where we're putting a fixed
         # tone.
         if write_log:
             self.log(f'Setting a fixed tone at {freq_mhz:.2f} MHz' +
-                     f' and amplitude {drive}', self.LOG_USER)
+                     f' and amplitude {tone_power}', self.LOG_USER)
 
         return band, channel
 

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -165,7 +165,7 @@ class SmurfUtilMixin(SmurfBase):
 
     # Shawn needs to make this better and add documentation.
     @set_action()
-    def estimate_phase_delay(self, band, n_samples=2**19, make_plot=True,
+    def estimate_phase_delay(self, band, nsamp=2**19, make_plot=True,
             show_plot=True, save_plot=True, save_data=True, n_scan=5,
             timestamp=None, uc_att=24, dc_att=0, freq_min=-2.5E8, freq_max=2.5E8):
 
@@ -249,7 +249,7 @@ class SmurfUtilMixin(SmurfBase):
             resp_cable = real_resp_cable + 1j*complex_resp_cable
         else:
             self.log('Running full band resp')
-            freq_cable, resp_cable = self.full_band_resp(band, n_samples=n_samples,
+            freq_cable, resp_cable = self.full_band_resp(band, nsamp=nsamp,
                 make_plot=make_plot,
                 save_data=save_data,
                 n_scan=n_scan)
@@ -986,7 +986,7 @@ class SmurfUtilMixin(SmurfBase):
 
     @set_action()
     def read_stream_data(self, datafile, channel=None,
-                         n_samp=None, array_size=None,
+                         nsamp=None, array_size=None,
                          return_header=False,
                          return_tes_bias=False, write_log=True,
                          n_max=2048, make_freq_mask=False,
@@ -1003,7 +1003,7 @@ class SmurfUtilMixin(SmurfBase):
             The full path to the data to read.
         channel : int or int array or None, optional, default None
             Channels to load.
-        n_samp : int or None, optional, default None
+        nsamp : int or None, optional, default None
             The number of samples to read.
         array_size : int or None, optional, default None
             The size of the output arrays. If 0, then the size will be
@@ -1034,7 +1034,7 @@ class SmurfUtilMixin(SmurfBase):
         if gcp_mode:
             self.log('Data is in GCP mode.')
             return self.read_stream_data_gcp_save(datafile, channel=channel,
-                unwrap=True, downsample=1, n_samp=n_samp)
+                unwrap=True, downsample=1, nsamp=nsamp)
 
         try:
             datafile = glob.glob(datafile+'*')[-1]
@@ -1170,7 +1170,7 @@ class SmurfUtilMixin(SmurfBase):
 
     @set_action()
     def read_stream_data_gcp_save(self, datafile, channel=None,
-            unwrap=True, downsample=1, n_samp=None):
+            unwrap=True, downsample=1, nsamp=None):
         """
         Reads the special data that is designed to be a copy of the GCP data.
         This was the most common data writing mode until the Rogue 4 update.
@@ -1187,7 +1187,7 @@ class SmurfUtilMixin(SmurfBase):
             Whether to unwrap units of 2pi.
         downsample : int, optional, default 1
             The amount to downsample.
-        n_samp : int or None, optional, default None
+        nsamp : int or None, optional, default None
             The number of samples to read.
 
         Returns
@@ -1239,7 +1239,7 @@ class SmurfUtilMixin(SmurfBase):
             channel_mask[i] = keys_dict[f'data{c}']
 
         eval_n_samp = False
-        if n_samp is not None:
+        if nsamp is not None:
             eval_n_samp = True
 
         # Make holder arrays for phase and timestamp
@@ -1258,7 +1258,7 @@ class SmurfUtilMixin(SmurfBase):
                     timestamp2 = np.append(timestamp2, tmp_timestamp2[:counter%n])
                     break
                 elif eval_n_samp:
-                    if counter >= n_samp:
+                    if counter >= nsamp:
                         phase = np.hstack((phase, tmp_phase[:,:counter%n]))
                         timestamp2 = np.append(timestamp2,
                                                tmp_timestamp2[:counter%n])
@@ -4405,7 +4405,7 @@ class SmurfUtilMixin(SmurfBase):
             d *= (self._pA_per_phi0/2/np.pi)  # convert to pA
             d = np.transpose(d.T - np.mean(d.T, axis=0))
 
-            n_det, n_samp = np.shape(d)
+            n_det, nsamp = np.shape(d)
 
             # currents on lines
             if high_current_mode:
@@ -4416,8 +4416,8 @@ class SmurfUtilMixin(SmurfBase):
             i_bias = probe_amp / r_inline * 1.0E12  # Bias current in pA
 
             # sine/cosine decomp templates
-            s = np.sin(2*np.pi*np.arange(n_samp) / n_samp*probe_freq*probe_time)
-            c = np.cos(2*np.pi*np.arange(n_samp) / n_samp*probe_freq*probe_time)
+            s = np.sin(2*np.pi*np.arange(nsamp) / nsamp*probe_freq*probe_time)
+            c = np.cos(2*np.pi*np.arange(nsamp) / nsamp*probe_freq*probe_time)
             s /= np.sum(s**2)
             c /= np.sum(c**2)
 

--- a/scratch/eyy/debug/iv_test.py
+++ b/scratch/eyy/debug/iv_test.py
@@ -27,7 +27,7 @@ for ch in chs:
     phase = S.iq_to_phase(I[ch], Q[ch]) * 1.443
 
     print('Running IV analysis')
-    r, rn, idx = S.analyze_slow_iv(bias, phase, make_plot=True, 
+    r, rn, idx = S.analyze_iv(bias, phase, make_plot=True, 
         show_plot=True, save_plot=True, band=3, channel=ch, 
         basename='1537818492')
     ivs[ch] = {

--- a/scratch/eyy/test_scripts/profile_band.py
+++ b/scratch/eyy/test_scripts/profile_band.py
@@ -48,7 +48,7 @@ def make_html(data_path, loopback=False):
     if not loopback:
         n_res_found = len(status['which_on_before_check']['output'])
         n_res_track = len(status['which_on_after_check']['output'])
-        ivdict = np.load(status['slow_iv_all']['output'].split('_raw_data')[0]+'.npy',
+        ivdict = np.load(status['run_iv']['output'].split('_raw_data')[0]+'.npy',
             allow_pickle=True).item()
         n_tes = len(ivdict[band].keys())
 
@@ -306,10 +306,10 @@ def run(band, epics_root, config_file, shelf_manager, setup, no_band_off=False,
         # now take data using take_noise_psd and plot stuff
 
         # IV.
-        status = execute(status, lambda: S.slow_iv_all(np.arange(8),
+        status = execute(status, lambda: S.run_iv(np.arange(8),
             overbias_voltage=19.9, bias_high=10, bias_step=.01, wait_time=.1,
             high_current_mode=False, overbias_wait=.5, cool_wait=60,
-            make_plot=True), 'slow_iv_all')
+            make_plot=True), 'run_iv')
     else:
         # Randomly turn on channels and stream them
         x = np.random.randn(512) > 0


### PR DESCRIPTION
## Issue
This PR resolves #404, #405, #406.

## Description

Fixes some code inconsistency issues: convention for number of samples is now all `nsamp` (different functions had different conventions before such as `n_samp`, `n_samples`), tone power is now all `tone_power` (formerly `drive` or `drive_power`), and function `slow_iv_all` and other relation functions were renamed to `run_iv`, etc.

## Does this PR break any interface?
- [x] Yes
- [ ] No

### Which interface changed?

- `analyze_slow_iv` changed to `analyze_iv`
- `slow_iv_all` changed to `run_iv`
- `set_amplitude_scale_array_currentchans` argument `drive` changed to `tone_power`
- `analyze_slow_iv_from_file` changed to `analyze_iv_from_file`
- `tune_band_serial` argument `drive` changed to `tone_power`
- `set_amplitude_scale_channel` argument `drive` changed to `tone_power`
- `find_freq` argument `drive_power` changed to `tone_power`
- `setup_notches` argument `drive` changed to `tone_power`
- `tune_band` arguments `drive`, `n_samples` changed to `tone_power`, `nsamp` respectively
- `full_band_resp` argument `n_samples` changed to `nsamp`
- `freq_resp` dict key `drive` changed to `tone_power`
- `tune_band_serial` arguments `drive`, `n_samples` changed to `tone_power`, `nsamp` respectively
- `relock` argument `drive` changed to `tone_power`
- `eta_estimator` argument `drive` changed to `tone_power`
- `eta_scan` argument `drive` changed to `tone_power`
- `full_band_ampl_sweep` argument `drive` changed to `tone_power`
- `fast_eta_scan` argument `drive` changed to `tone_power`
- `estimate_phase_delay` argument `n_samples` changed to `nsamp`
- `read_stream_data` argument `n_samp` changed to `nsamp`
- `read_stream_data_gcp_save` argument `n_samp` changed to `nsamp`
- `set_fixed_tone` argument `drive` changed to `tone_power`

### What was the interface before the change
[Describe here how was the original interface]

### What will be the new interface after the change
[Describe here how is the new interface, and what the difference with the original interface]
