### PR TITLE
Expanded refPhaseDelay config file limits from 4 to 5 bits.

### DIFF
--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -426,7 +426,7 @@ class SmurfConfig:
                 "feedbackLimitkHz" : And(Use(float), lambda f: f > 0),
 
                 # Number of cycles to delay phase reference
-                'refPhaseDelay': And(int, lambda n: 0 <= n < 2**4),
+                'refPhaseDelay': And(int, lambda n: 0 <= n < 2**5),
                 # Finer phase reference delay, 307.2MHz clock ticks.  This
                 # goes in the opposite direction as refPhaseDelay.
                 'refPhaseDelayFine': And(int, lambda n: 0 <= n < 2**8),


### PR DESCRIPTION
## Issue
This PR resolves https://github.com/slaclab/pysmurf/issues/508.
