### PR TITLE
Fix SIGABRT on DualDataBuffer destruction

### DIFF
--- a/include/smurf/core/transmitters/DualDataBuffer.h
+++ b/include/smurf/core/transmitters/DualDataBuffer.h
@@ -55,7 +55,7 @@ namespace smurf
             	// - callbackFunc : A pointer to a function to be called when new data is ready.
                 // - trheadname   : A name to be given to the txTransmit thread. Omitted if empty.
                 DualDataBuffer(std::function<void(T)> callbackFunc, const std::string& threadName);
-                ~DualDataBuffer() {};
+                ~DualDataBuffer();
 
                 // Factory method
                 static DualDataBufferPtr<T> create(std::function<void(T)> callbackFunc, const std::string& threadName);

--- a/src/smurf/core/transmitters/DualDataBuffer.cpp
+++ b/src/smurf/core/transmitters/DualDataBuffer.cpp
@@ -43,6 +43,13 @@ sct::DualDataBuffer<T>::DualDataBuffer(std::function<void(T)> callbackFunc, cons
 }
 
 template <typename T>
+sct::DualDataBuffer<T>::~DualDataBuffer()
+{
+    runTxThread = false;
+    txThread.join();
+}
+
+template <typename T>
 sct::DualDataBufferPtr<T> sct::DualDataBuffer<T>::create(std::function<void(T)> callbackFunc, const std::string& threadName)
 {
     return std::make_shared< DualDataBuffer<T> >(callbackFunc, threadName);
@@ -97,9 +104,9 @@ void sct::DualDataBuffer<T>::txTransmitter()
         // Check if new data is ready
         if ( !txDataReady )
         {
-            // Wait until data is ready, with a 10s timeout
+            // Wait until data is ready, with a 1s timeout
             std::unique_lock<std::mutex> lock(txMutex);
-            txCV.wait_for( lock, std::chrono::seconds(10) );
+            txCV.wait_for( lock, std::chrono::seconds(1) );
         }
         else
         {


### PR DESCRIPTION
~DualDataBuffer is called without properly terminating the tx thread,
causing the main thread to receive a SIGABRT.
I proposed a reduction in the tx loop timeout so that the destructor
doesn't take 10 seconds to finish.

## Issue
~DualDataBuffer is called without properly terminating the transmitter thread, causing the main thread to receive a SIGABRT.

## Description
This patch causes the DualDataBuffer destructor to stop the transmitter thread before calling the thread destructor. It also reduces the timeout in the transmitter loop to 1s from 10s, to prevent the DualDataBuffer destructor from waiting up to 10s before being able to join the thread.

## Does this PR break any interface?
- [ ] Yes
- [x] No

### Which interface changed?

### What was the interface before the change

### What will be the new interface after the change
