### PR TITLE
Issue524

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3390,11 +3390,18 @@ class SmurfTuneMixin(SmurfBase):
         min_gap : int, optional, default 2
             Minimum number of samples between resonances.
         '''
+        band_center = self.get_band_center_mhz(band)
         if subband is None:
-            band_center = self.get_band_center_mhz(band)
             start_subband = self.freq_to_subband(band, band_center + start_freq)
             stop_subband = self.freq_to_subband(band, band_center + stop_freq)
-            subband = np.arange(start_subband, stop_subband+1)
+            step = 1
+            if stop_subband < start_subband:
+                step = -1
+            subband = np.arange(start_subband, stop_subband+1, step)
+        else:
+            sb, sbc = self.get_subband_centers(band)
+            start_freq = sbc[subband[0]]
+            stop_freq  = sbc[subband[-1]]
 
         # Turn off all tones in this band first.  May want to make
         # this only turn off tones in each sub-band before sweeping,
@@ -3406,7 +3413,7 @@ class SmurfTuneMixin(SmurfBase):
             self.log('No tone_power given. Using value in config ' +
                      f'file: {tone_power}')
 
-        self.log('Sweeping across frequencies')
+        self.log(f'Sweeping across frequencies {start_freq + band_center}MHz to {stop_freq + band_center}MHz')
         f, resp = self.full_band_ampl_sweep(band, subband, tone_power, n_read)
 
         timestamp = self.get_timestamp()

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3342,10 +3342,11 @@ class SmurfTuneMixin(SmurfBase):
             make_plot=make_plot, flux_ramp=False, **kwargs)
 
     @set_action()
-    def find_freq(self, band, subband=None, tone_power=None,
-            n_read=2, make_plot=False, save_plot=True, plotname_append='',
-            window=50, rolling_med=True, make_subband_plot=False,
-            show_plot=False, grad_cut=.05, amp_cut=.25, pad=2, min_gap=2):
+    def find_freq(self, band, start_freq=-250, stop_freq=250, subband=None, 
+            tone_power=None, n_read=2, make_plot=False, save_plot=True,
+            plotname_append='', window=50, rolling_med=True, 
+            make_subband_plot=False, show_plot=False, grad_cut=.05, 
+            amp_cut=.25, pad=2, min_gap=2):
         '''
         Finds the resonances in a band (and specified subbands)
 
@@ -3353,9 +3354,13 @@ class SmurfTuneMixin(SmurfBase):
         ----
         band : int
             The band to search.
-        subband : numpy.ndarray of int or None, optional, default None
+        start_freq : start frequency in MHz (from band center, default -250)
+        stop_freq : stop frequency in MHz (from band center, default 250)
+        subband : deprecated, use start_freq/stop_freq.
+            numpy.ndarray of int or None, optional, default None
             An int array for the subbands.  If None, set to all
             processed subbands =numpy.arange(13,115).
+            Takes precedent over start_freq/stop_freq.
         tone_power : int or None, optional, default None
             The drive amplitude.  If None, takes from cfg.
         n_read : int, optional, default 2
@@ -3384,7 +3389,10 @@ class SmurfTuneMixin(SmurfBase):
             Minimum number of samples between resonances.
         '''
         if subband is None:
-            subband = np.arange(13,115)
+            band_center = self.get_band_center_mhz(band)
+            start_subband = self.freq_to_subband(band, band_center + start_freq)
+            stop_subband = self.freq_to_subband(band, band_center + stop_freq)
+            subband = np.arange(start_subband, stop_subband+1)
 
         # Turn off all tones in this band first.  May want to make
         # this only turn off tones in each sub-band before sweeping,

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3342,10 +3342,10 @@ class SmurfTuneMixin(SmurfBase):
             make_plot=make_plot, flux_ramp=False, **kwargs)
 
     @set_action()
-    def find_freq(self, band, start_freq=-250, stop_freq=250, subband=None, 
+    def find_freq(self, band, start_freq=-250, stop_freq=250, subband=None,
             tone_power=None, n_read=2, make_plot=False, save_plot=True,
-            plotname_append='', window=50, rolling_med=True, 
-            make_subband_plot=False, show_plot=False, grad_cut=.05, 
+            plotname_append='', window=50, rolling_med=True,
+            make_subband_plot=False, show_plot=False, grad_cut=.05,
             amp_cut=.25, pad=2, min_gap=2):
         '''
         Finds the resonances in a band (and specified subbands)
@@ -3354,8 +3354,10 @@ class SmurfTuneMixin(SmurfBase):
         ----
         band : int
             The band to search.
-        start_freq : start frequency in MHz (from band center, default -250)
-        stop_freq : stop frequency in MHz (from band center, default 250)
+        start_freq : float, optional, default -250
+            The scan start frequency in MHz (from band center)
+        stop_freq : float, optional, default 250
+            The scan stop frequency in MHz (from band center)
         subband : deprecated, use start_freq/stop_freq.
             numpy.ndarray of int or None, optional, default None
             An int array for the subbands.  If None, set to all

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -383,7 +383,7 @@ class SmurfUtilMixin(SmurfBase):
         self.set_ref_phase_delay_fine(band,refPhaseDelayFine)
 
         self.log('Running find_freq')
-        freq_dsp_corr,resp_dsp_corr=self.find_freq(band,dsp_subbands)
+        freq_dsp_corr,resp_dsp_corr=self.find_freq(band,subband=dsp_subbands)
 
         freq_dsp_corr_subset=[]
         resp_dsp_corr_subset=[]

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2277,7 +2277,7 @@ class SmurfUtilMixin(SmurfBase):
         Returns
         -------
         subband_no : int
-            Subband (0..128) of the frequency within the band.
+            Subband (0..n_subbands-1) of the frequency within the band.
         offset : float
             Offset from subband center.
 


### PR DESCRIPTION
## Issue
This PR resolves #524 .

## Description

We currently specify find_freq by subbands. We now have smurf firmware releases with different number of subbands. X-ray applications may use 64-128 subbands while CMB 512.

## Does this PR break any interface?
- [x] Yes
- [] No

### Which interface changed?
Changes find_freq interface to start_freq, stop_freq.  subband argument is now deprecated (still takes priority over start_freq/stop_freq)

### What was the interface before the change
subbands to scan

### What will be the new interface after the change
start_freq MHz from band center (default -250)
stop_freq MHz from band center (default +250)
