### PR TITLE
RTM reset

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -3631,7 +3631,7 @@ class SmurfCommandMixin(SmurfBase):
         """
         Toggles the cpld reset bit.
         """
-        self.reset_rtm(1, **kwargs)
+        self.reset_rtm(**kwargs)
 
     _k_relay_reg = 'KRelay'
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -3631,8 +3631,7 @@ class SmurfCommandMixin(SmurfBase):
         """
         Toggles the cpld reset bit.
         """
-        self.set_cpld_reset(1, wait_done=True, **kwargs)
-        self.set_cpld_reset(0, wait_done=True, **kwargs)
+        self.reset_rtm(1, **kwargs)
 
     _k_relay_reg = 'KRelay'
 


### PR DESCRIPTION
## Issue
This uses the resetRtm Rogue function to toggle CPLD reset.

## Description
Previously PySmurf directly toggled CPLD reset PV.  Now use a Rogue command that does

        @self.command(description="Reset RTM CPLD")
        def resetRtm():
            # Toggle reset bit
            self.CpldReset.set(0x1)
            time.sleep(0.100)
            self.CpldReset.set(0x0)
            # Reset all registers
            self.writeBlocks(force=True, recurse=True)
            self.checkBlocks(recurse=True)

[Describe what this PR does here]

## Does this PR break any interface?
- [ ] Yes
- [x] No

### Which interface changed?
[Indicate here what is the interface that changed, preferable with a link to the code where the interface is defined]

### What was the interface before the change
[Describe here how was the original interface]

### What will be the new interface after the change
[Describe here how is the new interface, and what the difference with the original interface]
