### PR TITLE
Adding flag to skip IV analysis functions after running S.run_iv()

### DIFF
--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -163,7 +163,7 @@ class SmurfIVMixin(SmurfBase):
         R_sh=self._R_sh
 
         if do_analysis:
-            self.log('Analysis flag set to false.')
+            self.log(f'Analyzing IV (do_analysis={do_analysis}).')
 
             self.analyze_iv_from_file(fn_iv_raw_data, make_plot=make_plot,
                 show_plot=show_plot, save_plot=save_plot,

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -164,7 +164,7 @@ class SmurfIVMixin(SmurfBase):
 
         if do_analysis:
             self.log('Analysis flag set to false.')
-            
+
             self.analyze_iv_from_file(fn_iv_raw_data, make_plot=make_plot,
                 show_plot=show_plot, save_plot=save_plot,
                 plotname_append=plotname_append, R_sh=R_sh, grid_on=grid_on,

--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -33,7 +33,8 @@ class SmurfIVMixin(SmurfBase):
                make_plot=True, save_plot=True, plotname_append='',
                channels=None, band=None, high_current_mode=True,
                overbias_voltage=8., grid_on=True,
-               phase_excursion_min=3., bias_line_resistance=None):
+               phase_excursion_min=3., bias_line_resistance=None,
+               do_analysis=True):
         """Takes a slow IV
 
         Steps the TES bias down slowly. Starts at bias_high to
@@ -84,6 +85,8 @@ class SmurfIVMixin(SmurfBase):
         bias_line_resistance : float or None, optional, default None
             The resistance of the bias lines in Ohms. If None, loads value
             in config file
+        do_analysis: bool, optional, default True
+            Whether to do the pysmurf IV analysis
 
         Returns
         -------
@@ -158,11 +161,15 @@ class SmurfIVMixin(SmurfBase):
         self.pub.register_file(path, 'iv_raw', format='npy')
 
         R_sh=self._R_sh
-        self.analyze_iv_from_file(fn_iv_raw_data, make_plot=make_plot,
-            show_plot=show_plot, save_plot=save_plot,
-            plotname_append=plotname_append, R_sh=R_sh, grid_on=grid_on,
-            phase_excursion_min=phase_excursion_min, channel=channels,
-            band=band, bias_line_resistance=bias_line_resistance)
+
+        if do_analysis:
+            self.log('Analysis flag set to false.')
+            
+            self.analyze_iv_from_file(fn_iv_raw_data, make_plot=make_plot,
+                show_plot=show_plot, save_plot=save_plot,
+                plotname_append=plotname_append, R_sh=R_sh, grid_on=grid_on,
+                phase_excursion_min=phase_excursion_min, channel=channels,
+                band=band, bias_line_resistance=bias_line_resistance)
 
         return path
 


### PR DESCRIPTION
## Issue
This PR resolves https://github.com/slaclab/pysmurf/issues/512. 

## Description

Adds a flag to the [S.run_iv() function](https://github.com/slaclab/pysmurf/blob/491f56f8884ba1e18747c2f64205f6c93e430592/python/pysmurf/client/debug/smurf_iv.py#L37) in order to skip the analysis functions after taking data. Also issues a warning to the log when analysis is skipped. 

## Does this PR break any interface?
- [ ] Yes
- [x ] No

### Which interface changed?
No interface changed. 

### What was the interface before the change
N/A

### What will be the new interface after the change
N/A

Main concern is that this branch (iv-analysis-flag) is based on `issue508` branch, which is being used at UCSD because of a known bug in the firmware interacting with our carrier. I'm not sure what the proper way is to merge the changes here to main so that it merges in cleanly, but also how to pull this and update the `issue508` branch we're using correctly so that the new update is included but without screwing up the bug fix we're using. 