### PR TITLE
Fix for resetting RF DACs after first setup in latest software versions.

### DIFF
--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -407,6 +407,13 @@ class SmurfControl(SmurfCommandMixin,
         dacs = [0, 1]
         for val in [1, 0]:
             for bay in self.bays:
+
+                # In newer software versions, setDefaults disables
+                # DBG:enable after loading the defaults.yml.  This
+                # makes sure we can reset the RF DACs.
+                self.set_dbg_enable(True)
+
+                # Reset all RF DACs in use.
                 for dac in dacs:
                     self.set_dac_reset(
                         bay, dac, val, write_log=write_log)

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -411,7 +411,7 @@ class SmurfControl(SmurfCommandMixin,
                 # In newer software versions, setDefaults disables
                 # DBG:enable after loading the defaults.yml.  This
                 # makes sure we can reset the RF DACs.
-                self.set_dbg_enable(True)
+                self.set_dbg_enable(bay, True)
 
                 # Reset all RF DACs in use.
                 for dac in dacs:

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5205,6 +5205,48 @@ class SmurfCommandMixin(SmurfBase):
             self._trigger_channel_reg_dest_sel_reg.format(chan),
             val, **kwargs)
 
+    _dbg_enable_reg = "enable"
+
+    def set_dbg_enable(self, bay, val, **kwargs):
+        r"""Enables/disables write access to DBG registers.
+
+        Args
+        ----
+        bay : int
+            Which bay [0 or 1].
+        val : bool
+            True for enable, False for disable.
+        \**kwargs
+            Arbitrary keyword arguments.  Passed directly to the
+            `_caput` call.
+        """
+        self._caput(
+            self.DBG.format(bay) + self._dbg_enable_reg,
+            val, **kwargs)
+
+    def get_dbg_enable(self, bay, **kwargs):
+        r"""Whether or not write access is enabled for DBG registers.
+
+        If disabled (=False), user cannot write to any of the DBG
+        registers.
+
+        Args
+        ----
+        bay : int
+            Which bay [0 or 1].
+        \**kwargs
+            Arbitrary keyword arguments.  Passed directly to the
+            `_caget` call.
+
+        Returns
+        -------
+        bool
+            True for enabled, False for disabled.
+        """
+        self._caget(
+            self.DBG.format(bay) + self._dbg_enable_reg,
+            **kwargs)
+
     _dac_reset_reg = 'dacReset[{}]'
 
     def set_dac_reset(self, bay, dac, val, **kwargs):

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5243,7 +5243,7 @@ class SmurfCommandMixin(SmurfBase):
         bool
             True for enabled, False for disabled.
         """
-        self._caget(
+        return self._caget(
             self.DBG.format(bay) + self._dbg_enable_reg,
             **kwargs)
 


### PR DESCRIPTION
## Issue
This PR resolves https://github.com/slaclab/pysmurf/issues/554.

## Description

Adds two new functions `get_dbg_enable` and `set_dbg_enable` which provide read/write access to the DBG:enable register.  Now explicitly sets DBG:enable=True in setup so that pysmurf can subsequently keep writing to any of the DBG registers (including hitting DAC reset in a subsequent setup, although ideally no one should be running setup twice in the same session).  For details on why this change is needed, see the linked issue and JIRA ticket https://jira.slac.stanford.edu/projects/ESCRYODET/issues/ESCRYODET-765.

## Does this PR break any interface?
- [ ] Yes
- [x] No