### PR TITLE
Fixes bug that was causing find_freq to crash if not given a start/stop_freq or subband arg.

### DIFF
--- a/cfg_files/nist/cmb/experiment_nistcmb_cc02-02_lbOnlyBay0.cfg
+++ b/cfg_files/nist/cmb/experiment_nistcmb_cc02-02_lbOnlyBay0.cfg
@@ -195,7 +195,7 @@
 
 "high_current_mode_bool": 0,
 
-"all_bias_groups": [3],
+"all_bias_groups": [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],
 
 "tune_band" : {
 	"reset_rate_khz" : 4.0,

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -587,6 +587,7 @@ class SmurfControl(SmurfCommandMixin,
 
             self.set_cpld_reset(0, write_log=write_log)
             self.cpld_toggle(write_log=write_log)
+            self.all_off()
 
             # Make sure flux ramp starts off
             self.flux_ramp_off(write_log=write_log)

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3392,8 +3392,8 @@ class SmurfTuneMixin(SmurfBase):
         '''
         band_center = self.get_band_center_mhz(band)
         if subband is None:
-            start_subband = self.freq_to_subband(band, band_center + start_freq)
-            stop_subband = self.freq_to_subband(band, band_center + stop_freq)
+            start_subband = self.freq_to_subband(band, band_center + start_freq)[0]
+            stop_subband = self.freq_to_subband(band, band_center + stop_freq)[0]
             step = 1
             if stop_subband < start_subband:
                 step = -1


### PR DESCRIPTION
## Issue
This PR resolves https://github.com/slaclab/pysmurf/issues/556.

## Description

Fixes minor bug in `find_freq`.  See issue for more details.

## Does this PR break any interface?
- [ ] Yes
- [x] No