### PR TITLE
Update version of the `verify-pr-label-action` action to support PRs from forks

### DIFF
--- a/.github/workflows/verify-pr-labels.yml
+++ b/.github/workflows/verify-pr-labels.yml
@@ -5,7 +5,7 @@
 name: verify-pr-label-action
 
 on:
-  pull_request:
+  pull_request_target:
    types: [opened, labeled, unlabeled, synchronize]
 
 jobs:
@@ -14,8 +14,9 @@ jobs:
     name: Verify that the PR has a valid label
     steps:
     - name: Verify Pull Request Labels
-      uses: jesusvasquez333/verify-pr-label-action@v1.1.0
+      uses: jesusvasquez333/verify-pr-label-action@v1.3.1
       id: verify-pr-label
       with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
           valid-labels: 'bug, enhancement, interface-change'
+          pull-request-number: '${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Issue
This PR resolves #561 

## Description

This PR updates the version of the `verify-pr-label-action` GitHub Action to support PRs from forks.

This version also avoid creating duplicates reviews: if the last review done by this modules was approved/requested changes, and the new state it is the same, the module won't redo the same action.

## Does this PR break any interface?
- [ ] Yes
- [X] No