### PR TITLE
Update smurf-rogue base image to version R2.8.2

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.8.1
+FROM tidair/smurf-rogue:R2.8.2
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src


### PR DESCRIPTION
## Issue
This PR resolves [ESCRYODET-683](https://jira.slac.stanford.edu/browse/ESCRYODET-683).

## Description

This PR updates Rogue to version [v4.11.6](https://github.com/slaclab/rogue/releases/tag/v4.11.6). This version of Rogue container fixes for float value precision lost though the EPICS interface as describe in [ESCRYODET-683](https://jira.slac.stanford.edu/browse/ESCRYODET-683). 

In the previous version (rogue `v4.11.2`),  if we try to read a register with a float value from python, for example *AMCc/FpgaTopLevel/AppTop/AppCore/SysgenCryo/Base[0]/digitizerFrequencyMHz*, which value is:
```bash
cryo@smurf-srv06:/$ caget smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:SysgenCryo:Base[0]:digitizerFrequencyMHz
smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:SysgenCryo:Base[0]:digitizerFrequencyMHz 614.4
```

we saw something like this:
```python
>>> import epics
>>> epics.caget('smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:SysgenCryo:Base[0]:digitizerFrequencyMHz')
614.4000244140625
```

Now, after this PR, we see the correct result:
```python
>>> import epics
>>> epics.caget('smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:SysgenCryo:Base[0]:digitizerFrequencyMHz')
614.4
```

This version of Rogue also contains enhancements for improvement the GUI tree entries expansion as described in [ESCRYODET-713](https://jira.slac.stanford.edu/browse/ESCRYODET-713).

## Does this PR break any interface?
- [ ] Yes
- [X] No