### PR TITLE
Fix mutex lock scopes related to the unwrapper data

### DIFF
--- a/src/smurf/core/processors/SmurfProcessor.cpp
+++ b/src/smurf/core/processors/SmurfProcessor.cpp
@@ -509,6 +509,10 @@ void scp::SmurfProcessor::acceptFrame(ris::FramePtr frame)
 
     // Map and unwrap data at the same time
     {
+        // Acquire the lock while the unwrapper vectors are used.
+        // Acquire this lock outside the loop, to increase performance.
+        std::lock_guard<std::mutex> lock(mutUnwrapper);
+
         // Move the current data to the previous data
         previousData.swap(currentData);
 
@@ -520,10 +524,6 @@ void scp::SmurfProcessor::acceptFrame(ris::FramePtr frame)
         std::vector<fw_t>::iterator     previousIt { previousData.begin() };
         std::vector<unwrap_t>::iterator inputIt    { inputData.begin()    };
         std::vector<unwrap_t>::iterator wrapIt     { wrapCounter.begin()  };
-
-        // Acquire the lock while the unwrapper vectors are used.
-        // Acquire this lock outside the loop, to increase performance.
-        std::lock_guard<std::mutex> lock(mutUnwrapper);
 
         // Map and unwrap data in a single loop
         for(auto const& m : mask)

--- a/src/smurf/core/processors/SmurfProcessor.cpp
+++ b/src/smurf/core/processors/SmurfProcessor.cpp
@@ -572,6 +572,9 @@ void scp::SmurfProcessor::acceptFrame(ris::FramePtr frame)
             // Acquire the lock while the filter parameters are used.
             std::lock_guard<std::mutex> lockParam(mutFilter);
 
+            // Acquire the lock for the unwrapper, as we are using the 'inputData' vector.
+            std::lock_guard<std::mutex> lockUnwrapper(mutUnwrapper);
+
             // The pass sample buffer x and y have the following structure:
             //
             //  |     .....    |     .....    |      ...     |     .....    |
@@ -687,6 +690,9 @@ void scp::SmurfProcessor::acceptFrame(ris::FramePtr frame)
         {
             // Hold the mutex while we copy the data
             std::lock_guard<std::mutex> lock(outDataMutex);
+
+            // Acquire the lock for the unwrapper, as we are using the 'inputData' vector.
+            std::lock_guard<std::mutex> lockUnwrapper(mutUnwrapper);
 
             // Check if the filter was disabled. If it was disabled, use the 'inputData' vector as source.
             // Otherwise, use the 'y' vector, applying the gain and casting.


### PR DESCRIPTION
## Issue
This PR resolves [ESCRYODET-758](https://jira.slac.stanford.edu/browse/ESCRYODET-758).

## Description

This PR fixes a bug related to the mutex locks in the smurf processor code which was causing the server to crash under some conditions. 

As reported by SO here: https://github.com/simonsobs/smurf-issues/issues/10, the issue seen to be caused by resetting the Unwrapper module. I was able to reproduce that issue by:
- Start data streaming (I tested with a 4kHz frame rate), 
- Set a big channel mask size (I tried with 1000 for example).
- Then, on the client side do this loop:
```bash
cryo@smurf-srv06:/$ while :; do caput smurf_server_s2:AMCc:SmurfProcessor:Unwrapper:reset 1 ; sleep 1; done;
``` 

This will eventually make the server to crash as reported bay SO:
```bash
cryo@smurf-srv06:/$ while :; do caput smurf_server_s2:AMCc:SmurfProcessor:Unwrapper:reset 1 ; sleep 1; done;
Old : smurf_server_s2:AMCc:SmurfProcessor:Unwrapper:reset 0
New : smurf_server_s2:AMCc:SmurfProcessor:Unwrapper:reset 1

(***snip***)

New : smurf_server_s2:AMCc:SmurfProcessor:Unwrapper:reset 1
Old : smurf_server_s2:AMCc:SmurfProcessor:Unwrapper:reset 1
CA.Client.Exception...............................................
    Warning: "Virtual circuit disconnect"
    Context: "localhost:44511"
    Source File: ../cac.cpp line 1223
    Current Time: Tue Dec 01 2020 23:56:07.523665222
..................................................................
```

So, I found out the the unwrapper mutex was not being correctly protecting its data. 

After the fixes in the PR, I tested the system again as describe above and was not able to reproduce the issue. I also stress tested the system by stream data at 10kHz, with a channel mask size of 4000, and reseting the unwrapper every 100ms (instead of every second), and was not able to reproduce the issue. 

## Does this PR break any interface?
- [ ] Yes
- [X] No