### PR TITLE
Github Actions: Fix release generation script, which was still referencing Travis env vars

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,3 +1,22 @@
+#-----------------------------------------------------------------------------
+# Title      : PySMuRF CI/CD GitHub Action Workflow
+#-----------------------------------------------------------------------------
+# File       : ci-cd.yml
+# Created    : 2020-11-23
+#-----------------------------------------------------------------------------
+# Description:
+#    GitHub Action Workflow for Continuous Integration and Continuous
+#    Deployment.
+#-----------------------------------------------------------------------------
+# This file is part of the smurf software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the smurf software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
 name: CI/CD
 on: [push, pull_request]
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -183,6 +183,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      # Get the git tag from the environmental variables
+      # It will used to tag the docker image
+      - name: Get release tag
+        id: get_tag
+        run: echo ::set-output name=tag::"${GITHUB_REF#refs/tags/}"
+
       # Setup python 3.6
       - name: Setup python 3.6
         uses: actions/setup-python@v2
@@ -198,6 +204,10 @@ jobs:
 
       # Generate a release using the releaseGen.py script
       - name: Generate release notes
+        env:
+          REPO_SLUG: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.SLACLAB_TOKEN }}
+          TAG: ${{ steps.get_tag.outputs.tag }}
         run: python releaseGen.py
 
   # Server docker

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,18 +1,29 @@
-# This workflow will triage pull requests and apply a label based on the
-# paths that are modified in the pull request.
-#
-# To use this workflow, you will need to set up a .github/labeler.yml
-# file with configuration.  For more information, see:
-# https://github.com/actions/labeler/blob/master/README.md
+#-----------------------------------------------------------------------------
+# Title      : PySMuRF Labeler GitHub Action Workflow
+#-----------------------------------------------------------------------------
+# File       : label.yml
+# Created    : 2020-03-18
+#-----------------------------------------------------------------------------
+# Description:
+#    GitHub Action Workflow for applying labels to pull requests based on the
+#    file path that are modified. For more information about the labeler
+#    action see: https://github.com/actions/labeler/blob/master/README.md
+#-----------------------------------------------------------------------------
+# This file is part of the smurf software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the smurf software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
 
 name: Labeler
 on: [pull_request]
 
 jobs:
   label:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/labeler@v2
       with:

--- a/.github/workflows/verify-pr-labels.yml
+++ b/.github/workflows/verify-pr-labels.yml
@@ -1,6 +1,24 @@
-# This workflow will verify that all pull requests have at least
-# one of these labels: 'bug', 'enhancement', 'interface-change'
-# before they can be merged
+#-----------------------------------------------------------------------------
+# Title      : PySMuRF Verify Labels GitHub Action Workflow
+#-----------------------------------------------------------------------------
+# File       : verify-pr-labels.yml
+# Created    : 2020-03-20
+#-----------------------------------------------------------------------------
+# Description:
+#    GitHub Action Workflow for verifying that all pull requests have at
+#    least one of these labels: 'bug', 'enhancement', 'interface-change',
+#    before they can be merged. For more information about the
+#    verify-pr-label-action action see:
+#    https://github.com/jesusvasquez333/verify-pr-label-action/blob/master/README.md
+#-----------------------------------------------------------------------------
+# This file is part of the smurf software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the smurf software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
 
 name: verify-pr-label-action
 

--- a/releaseGen.py
+++ b/releaseGen.py
@@ -15,18 +15,18 @@ from github import Github # PyGithub
 from collections import OrderedDict as odict
 import re
 
-ghRepo = os.environ.get('TRAVIS_REPO_SLUG')
+ghRepo = os.environ.get('REPO_SLUG')
 token  = os.environ.get('GITHUB_TOKEN')
-newTag = os.environ.get('TRAVIS_TAG')
+newTag = os.environ.get('TAG')
 
 if ghRepo is None:
-    exit("TRAVIS_REPO_SLUG not in environment.")
+    exit("REPO_SLUG not in environment.")
 
 if token is None:
     exit("GITHUB_TOKEN not in environment.")
 
 if newTag is None:
-    exit("TRAVIS_TAG not in environment.")
+    exit("TAG not in environment.")
 
 # Check tag to make sure it is a proper release: va.b.c
 vpat = re.compile('v\d+\.\d+\.\d+')


### PR DESCRIPTION
## Issue
This PR resolves [ESCRYODET-766](https://jira.slac.stanford.edu/browse/ESCRYODET-766).

## Description

This PR fixes a remaining issue regarding the migration from Travis to Github Action done in #560. 

The `releaseGen.py` script was still using some Travis-specific environmental variables, which are fixed and made generic in this PR.

This PR also adds the license headers to all the GitHub Action Workflow files, which were missing.

## Does this PR break any interface?
- [ ] Yes
- [X] No