### PR TITLE
Add more restrictions to the find method used to check if `JesdHealth` exists

### DIFF
--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -246,7 +246,7 @@ class Common(pyrogue.Root):
         # Check if the 'AppTop.JesdHelath' command exist. The 'self._jesd_health_found'
         # flag will indicated if it was found, and if it was found, a reference to the
         # command will be available in 'self._jesd_health_cmd'.
-        c = self.FpgaTopLevel.AppTop.find(name='JesdHealth', recurse=False)
+        c = self.FpgaTopLevel.AppTop.find(name='^JesdHealth$', typ=pyrogue.Command, recurse=False)
         if c:
             self._jesd_health_found = True
             self._jesd_health_cmd = c[0]


### PR DESCRIPTION
## Issue
This PR resolves [ESCRYODET-778](https://jira.slac.stanford.edu/browse/ESCRYODET-778).

## Description

Make the `find` call look for exactly a `Command` called `JesdHealth`. This avoid having false results. 

This called was finding the `Variable` called `JesdHealthStatus`, added [here](https://github.com/slaclab/amc-carrier-core/pull/321) instead, and breaking the `SmurfApplication/CheckJesd` command.

## Does this PR break any interface?
- [ ] Yes
- [X] No