### PR TITLE
Pin version of the python packages used in the client docker image

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -10,8 +10,14 @@ RUN apt-get update && \
     python3-matplotlib \
  && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install scipy pandas seaborn jupyter pytest GitPython \
-        schema==0.7.1
+RUN pip3 install \
+    scipy==1.5.2 \
+    pandas==1.1.0 \
+    seaborn==0.10.1 \
+    jupyter==1.0.0 \
+    pytest==6.0.1 \
+    GitPython==3.1.7 \
+    schema==0.7.1
 
 # Install pysmurf
 ARG branch

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     python3-matplotlib \
  && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install scipy pandas pyyaml seaborn jupyter pytest GitPython \
+RUN pip3 install scipy pandas seaborn jupyter pytest GitPython \
         schema==0.7.1
 
 # Install pysmurf

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
 RUN pip3 install \
     scipy==1.5.2 \
     pandas==1.1.0 \
+    PyYAML==5.3.1 \
     seaborn==0.10.1 \
     jupyter==1.0.0 \
     pytest==6.0.1 \


### PR DESCRIPTION
## Issue
This PR resolves #377.

## Description

This PR pin the version of the python packages install in the client docker image to the version currently used by our latest release (`v4.1.0`):
```bash
cryo@smurf-srv06:/usr/local/src/pysmurf$ pip3 list | grep -E 'scipy|pandas|PyYAML|seaborn|jupyter|pytest|GitPython|schema'
GitPython (3.1.7)
jsonschema (3.2.0)
jupyter (1.0.0)
jupyter-client (6.1.6)
jupyter-console (6.1.0)
jupyter-core (4.6.3)
pandas (1.1.0)
pytest (6.0.1)
PyYAML (5.3.1)
schema (0.7.1)
scipy (1.5.2)
seaborn (0.10.1)
```

## Does this PR break any interface?
- [ ] Yes
- [X] No