### PR TITLE
Add `jupyterlab` to the client docker image

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -18,7 +18,8 @@ RUN pip3 install \
     jupyter==1.0.0 \
     pytest==6.0.1 \
     GitPython==3.1.7 \
-    schema==0.7.1
+    schema==0.7.1 \
+    jupyterlab==2.2.9
 
 # Install pysmurf
 ARG branch


### PR DESCRIPTION
## Issue
This PR resolves [ESCRYODET-747](https://jira.slac.stanford.edu/browse/ESCRYODET-747).

## Description

This PR adds the python package `jupyterlab` (version `2.2.9`) to the pysmurf client docker image.

## Does this PR break any interface?
- [ ] Yes
- [X] No