### PR TITLE
SMuRF header: Use Unix Epoch time for word 6

### DIFF
--- a/README.SmurfPacket.md
+++ b/README.SmurfPacket.md
@@ -16,7 +16,7 @@ The header is 128-byte long and contains the following information:
 |                |       3           |         1         | Smurf timing Configuration                    | (clock lock / unlock), (external ref, fiber timing ref)
 |                |       4           |         4         | Number of channels of data                    | 32 bit word giving number channels of following data
 |       1        |       8           |        40         | TES DAC 0-15                                  | TES DAC values. 16X 20 bit in 10X32 bit words, or 5X 65 bit
-|       6        |      48           |         8         | 64 bit unix time                              | 64 bit unix time nanoseconds
+|       6        |      48           |         8         | 64-bit epoch UNIX time                        | 64-bit UNIX epoch time, in nanoseconds
 |       7        |      56           |         4         | Flux ramp increment                           | signed 32 bit integer for increment
 |                |      60           |         4         | Flux ramp offset                              | signed 32 it integer for offset
 |       8        |      64           |         4         | Counter 0, since last 1Hz marker              | 32 bit counter since last 1Hz marker

--- a/include/smurf/core/common/Helpers.h
+++ b/include/smurf/core/common/Helpers.h
@@ -67,11 +67,11 @@ namespace helpers
     };
 
     // Get the current time in nanoseconds.
-    // Use the steady clock which guarantees to be monotonically increasing.
+    // Use 'system_clock' which represents the system-wide real time wall clock.
     inline uint64_t getTimeNS()
     {
         return std::chrono::time_point_cast<std::chrono::nanoseconds>(
-            std::chrono::steady_clock::now()).time_since_epoch().count();
+            std::chrono::system_clock::now()).time_since_epoch().count();
     };
 }
 


### PR DESCRIPTION
## Issue
This PR resolves #505 

## Description

Use the UNIX Epoch Time (expressed in nanoseconds) in word 6 of the SMuRF header.

## Does this PR break any interface?
- [X] Yes
- [ ] No

### Which interface changed?
Word 6 in the [SMuRF packet header](https://github.com/slaclab/pysmurf/blob/main/README.SmurfPacket.md).

### What was the interface before the change
Word 6 contained the time obtained using [steady_clock](https://en.cppreference.com/w/cpp/chrono/steady_clock), which was a monotonic clock that will never be adjusted (in nanoseconds).

### What will be the new interface after the change
Word 6 now contains the time obtained using [system_clock](https://en.cppreference.com/w/cpp/chrono/system_clock) instead, which is the wall clock time from the system-wide realtime clock, converted to time since Epoch in nanoseconds.