### PR TITLE
Fix the GitHub token used during the generation of release notes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Generate release notes
         env:
           REPO_SLUG: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ secrets.SLACLAB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.get_tag.outputs.tag }}
         run: python releaseGen.py
 


### PR DESCRIPTION
## Issue
No issue associated to this PR.

## Description

Fix the GitHub token used during the generation of release notes.

## Does this PR break any interface?
- [ ] Yes
- [X] No