### PR TITLE
Fix GitHub Action job used to generate release notes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -201,6 +201,8 @@ jobs:
       # Checkout the code
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       # Get the git tag from the environmental variables
       # It will used to tag the docker image


### PR DESCRIPTION
## Issue
No issue associated to this PR.

## Description

The release note generation script needs to be run with a deep checkout, so that is can find the tags.

## Does this PR break any interface?
- [ ] Yes
- [X] No