### PR TITLE
Bug fix: During `setup()`, check if `set_defaults_pv` succeeded before continue with setup.

### DIFF
--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -444,37 +444,40 @@ class SmurfControl(SmurfCommandMixin,
                 self.LOG_ERROR)
             success = False
 
-        #
-        # setDefaults runs the JesdHealth check, so just need to poll
-        # status.
-        jesd_health_status = self.get_jesd_status(write_log=write_log)
+        # Only proceed with the rest of setup if the defaults were set
+        # correctly.
+        if success:
+            # setDefaults runs the JesdHealth check, so just need to poll
+            # status.
+            jesd_health_status = self.get_jesd_status(write_log=write_log)
 
-        # Checking if JesdHealth is Locked is only supported for Rogue
-        # ZIP file versions >=0.3.0 and pysmurf core code versions
-        # >=4.1.0.  If it's not supported, self.set_check_jesd will
-        # return None if the JesdHealth registers in SmurfApplication
-        # aren't present or 'Not found' if they are present but the
-        # JesdHealth method isn't implemented in the loaded Rogue ZIP
-        # file.  Overriding None with True to skip this check for
-        # older versions of pysmurf that don't support the JesdHealth
-        # check.  Log an error if the JesdHealth check reports that
-        # JESD is unlocked.
-        if ( jesd_health_status is not None and
-             jesd_health_status != 'Not found' and
-             jesd_health_status != 'Locked' ):
-            self.log(
-                'ERROR : JESD is not locked!  Do not proceed!'
-                ' Reboot or ask someone for help.  You are strongly'
-                ' encouraged to report this as an issue on the'
-                ' pysmurf github repo at'
-                ' https://github.com/slaclab/pysmurf/issues (please'
-                ' provide a state dump using the pysmurf'
-                ' set_read_all/save_state functions).',
-                self.LOG_ERROR)
-            success = False
+            # Checking if JesdHealth is Locked is only supported for Rogue
+            # ZIP file versions >=0.3.0 and pysmurf core code versions
+            # >=4.1.0.  If it's not supported, self.set_check_jesd will
+            # return None if the JesdHealth registers in SmurfApplication
+            # aren't present or 'Not found' if they are present but the
+            # JesdHealth method isn't implemented in the loaded Rogue ZIP
+            # file.  Overriding None with True to skip this check for
+            # older versions of pysmurf that don't support the JesdHealth
+            # check.  Log an error if the JesdHealth check reports that
+            # JESD is unlocked.
+            if ( jesd_health_status is not None and
+                 jesd_health_status != 'Not found' and
+                 jesd_health_status != 'Locked' ):
+                self.log(
+                    'ERROR : JESD is not locked!  Do not proceed!'
+                    ' Reboot or ask someone for help.  You are strongly'
+                    ' encouraged to report this as an issue on the'
+                    ' pysmurf github repo at'
+                    ' https://github.com/slaclab/pysmurf/issues (please'
+                    ' provide a state dump using the pysmurf'
+                    ' set_read_all/save_state functions).',
+                    self.LOG_ERROR)
+                success = False
 
-        # Only proceed with the rest of setup if basic system checks
-        # succeeded, otherwise we risk giving users false hope.
+        # Only proceed with the rest of setup if defaults were set
+        # correctly and basic system checks succeeded, otherwise we
+        # risk giving users false hope.
         if success:
             # The per band configs. May want to make available per-band
             # values.

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -249,7 +249,7 @@ class Common(pyrogue.Root):
     # "False" otherwise.
     def _load_config(self):
         success = False
-        max_retries = 10
+        max_retries = 4
 
         for i in range(max_retries):
             print(f'Setting defaults from file {self._config_file} (try number {i})')

--- a/scratch/eyy/test_scripts/profile_band.py
+++ b/scratch/eyy/test_scripts/profile_band.py
@@ -233,6 +233,10 @@ def run(band, epics_root, config_file, shelf_manager, setup, no_band_off=False,
     if setup:
         status = execute(status, lambda: S.setup(), 'setup')
 
+        # Check if setup succeeded
+        if not status['setup']['output']:
+            raise RuntimeError('Setup failed. Aborting test')
+
     # Band off
     if not no_band_off:
         bands = S.config.get('init').get('bands')


### PR DESCRIPTION
## Issue
This PR resolves [ESCRYODET-791](https://jira.slac.stanford.edu/browse/ESCRYODET-791).

## Description

This PR fixes a bug in `setup()`, which was continuing with the setup process when `set_defaults_pv` fails. It also reduces the number of number of times the server retries to load defaults to 4, to be equivalent to the 400s timeout the client uses.

This PR also adds a fix to `profile_band.py` test, which should check if `setup()` succeed before continuing with the test.

## Does this PR break any interface?
- [ ] Yes
- [X] No