### PR TITLE
Smurf Server Publisher modifications

### DIFF
--- a/python/pysmurf/core/utilities/_SmurfPublisher.py
+++ b/python/pysmurf/core/utilities/_SmurfPublisher.py
@@ -149,10 +149,17 @@ class SmurfPublisher(object):
             'type': msgtype,
         }
         self.seq_no += 1
-        # Add in the data and convert to json.
+        # Add in the data
         output['payload'] = data
-        jtext = json.dumps(output)
-        # Send.
+
+        # Convert to JSON, catching and logging exceptions
+        try:
+            jtext = json.dumps(output)
+        except Exception as e:
+            self.log(f'Exception "{e}", trying to convert "{output}" to JSON')
+            return
+
+        # Send, if the JSON conversion succeed
         self._backend(jtext)
 
     def log(self, message):

--- a/python/pysmurf/core/utilities/_SmurfPublisher.py
+++ b/python/pysmurf/core/utilities/_SmurfPublisher.py
@@ -22,6 +22,7 @@ import json
 import os
 import sys
 import time
+import numpy as np
 
 DEFAULT_ENV_ROOT = 'SMURFPUB_'
 DEFAULT_UDP_PORT = 8200
@@ -196,4 +197,18 @@ class SmurfPublisher(object):
         return self.publish(file_data, 'data_file')
 
     def _varListen(self, path, varVal):
-        self.publish(data=f'{path}={varVal.value}', msgtype='metadata')
+
+        # Extract the variable value
+        value = varVal.value
+
+        # Get the variable type, as a string
+        type_str = type(value).__name__
+
+        # In the variable is a numpy array, convert it to a list in
+        # order to be JSON serializable (but keeping the original type)
+        if isinstance(value, np.ndarray):
+            value = value.tolist()
+
+        # Publish the data, as a "metadata" type
+        self.publish(data={"path": path, "value": value, "type": type_str},
+            msgtype='metadata')

--- a/python/pysmurf/core/utilities/_SmurfPublisher.py
+++ b/python/pysmurf/core/utilities/_SmurfPublisher.py
@@ -197,7 +197,16 @@ class SmurfPublisher(object):
         return self.publish(file_data, 'data_file')
 
     def _varListen(self, path, varVal):
+        """
+        Callback function used to publish metadata.
 
+        Args
+        ----
+        path : str
+            Rogue register path.
+        varVal : pyrogue.VariableValue
+            Variable object.
+        """
         # Extract the variable value
         value = varVal.value
 

--- a/python/pysmurf/core/utilities/_SmurfPublisher.py
+++ b/python/pysmurf/core/utilities/_SmurfPublisher.py
@@ -22,6 +22,7 @@ import json
 import os
 import sys
 import time
+
 import numpy as np
 
 DEFAULT_ENV_ROOT = 'SMURFPUB_'

--- a/python/pysmurf/core/utilities/_SmurfPublisher.py
+++ b/python/pysmurf/core/utilities/_SmurfPublisher.py
@@ -196,4 +196,4 @@ class SmurfPublisher(object):
         return self.publish(file_data, 'data_file')
 
     def _varListen(self, path, varVal):
-        self.publish(data=f'{path}={varVal.value}',msgtype='general')
+        self.publish(data=f'{path}={varVal.value}', msgtype='metadata')


### PR DESCRIPTION
## Issue
This PR resolves #588.

## Description

This PR adds the following changes to the [Publisher class](https://github.com/slaclab/pysmurf/blob/main/python/pysmurf/core/utilities/_SmurfPublisher.py) as requested in #588: 
- Metadata publishes will now have `msgtype` set to `metadata`, instead of `general`,
- When publishing metadata, the content of the `data` field will now be key, value pairs, in JSON format, containing the Rogue register path (`path`), the register value (`value`), and the value type (`type`).

I tested this changes, with the [default variable group](https://github.com/slaclab/pysmurf/blob/main/python/pysmurf/core/server_scripts/_VariableGroupExample.py), and modifying the [_backend_null](https://github.com/slaclab/pysmurf/blob/main/python/pysmurf/core/utilities/_SmurfPublisher.py#L122-L123) method to print the received messages, and obtained this:
```
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611797885.3430576, "seq_no": 1565, "type": "metadata", "payload": {"path": "AMCc.SmurfProcessor.ChannelMapper.NumChannels", "value": 1, "type": "int"}}
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611797885.3466105, "seq_no": 1566, "type": "metadata", "payload": {"path": "AMCc.SmurfProcessor.FrameRxStats.FrameLossCnt", "value": 123, "type": "int"}}
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611797885.3493185, "seq_no": 1567, "type": "metadata", "payload": {"path": "AMCc.SmurfProcessor.PreDataEmulator.Amplitude", "value": 65535, "type": "int"}}
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611797885.3505917, "seq_no": 1568, "type": "metadata", "payload": {"path": "AMCc.SmurfProcessor.FileWriter.TotalSize", "value": 0, "type": "int"}}
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611797885.3531475, "seq_no": 1569, "type": "metadata", "payload": {"path": "AMCc.SmurfProcessor.PostDataEmulator.Amplitude", "value": 4294967295, "type": "int"}}
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611797885.355861, "seq_no": 1570, "type": "metadata", "payload": {"path": "AMCc.SmurfProcessor.FileWriter.CurrentSize", "value": 0, "type": "int"}}
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611797885.3562307, "seq_no": 1571, "type": "metadata", "payload": {"path": "AMCc.SmurfProcessor.FrameRxStats.FrameSize", "value": 8320, "type": "int"}}
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611797885.3567724, "seq_no": 1572, "type": "metadata", "payload": {"path": "AMCc.SmurfProcessor.PostDataEmulator.Offset", "value": 0, "type": "int"}}
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611797885.3584292, "seq_no": 1573, "type": "metadata", "payload": {"path": "AMCc.SmurfProcessor.FileWriter.FrameCount", "value": 0, "type": "int"}}
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611797885.3591156, "seq_no": 1574, "type": "metadata", "payload": {"path": "AMCc.SmurfProcessor.FrameRxStats.BadFrameCnt", "value": 0, "type": "int"}}
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611797885.359428, "seq_no": 1575, "type": "metadata", "payload": {"path": "AMCc.SmurfProcessor.PreDataEmulator.Offset", "value": 0, "type": "int"}}
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611797885.3594973, "seq_no": 1576, "type": "metadata", "payload": {"path": "AMCc.SmurfProcessor.FrameRxStats.FrameCnt", "value": 791596, "type": "int"}}
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611797885.36481, "seq_no": 1577, "type": "metadata", "payload": {"path": "AMCc.SmurfProcessor.FrameRxStats.FrameOutOrderCnt", "value": 0, "type": "int"}}
```

I added a numpy array variable (`np.zeros(5)`) for testing and got this message:
```
{"host": "smurf-srv06", "id": "undeclared", "script": "PySmurf_Server", "time": 1611858311.23576, "seq_no": 1239, "type": "metadata", "payload": {"path": "AMCc.SmurfApplication.NPArrayTest", "value": [0.0, 0.0, 0.0, 0.0, 0.0], "type": "ndarray"}}
```

Additionally, I added `try-exception` statement when converting the message to JSON to catch exceptions. If an exception occurs, the error message is logged.

## Does this PR break any interface?
- [X] Yes
- [ ] No

### Which interface changed?
The content of the metadata send to the `Publisher`

### What was the interface before the change
- `msgtype` was `general`,
- `data` was a string containing `register_path=register_value` 

### What will be the new interface after the change
- `msgtype` is now `metadata`,
- `data` is now formed by the following key, value pairs in JSON format:
  - `path` : Register path,
  - `value` : Register value (numpy arrays are converted to lists)
  - `type` : the value type, as a string.   
