### PR TITLE
Bug in emulator period data type handling

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5958,6 +5958,7 @@ class SmurfCommandMixin(SmurfBase):
         val : int
             Number of frames that make up a period.
         """
+        if not isinstance(val, str):
             val = str(val)
         self._caput(self._postdata_emulator + self._postdata_emulator_period,
             val, **kwargs)

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5860,14 +5860,26 @@ class SmurfCommandMixin(SmurfBase):
         val : int
             Number of frames that make up a period.
         """
+        # Cast as str
+        if not instance(val, str):
+            val = str(val)
         self._caput(self._predata_emulator + self._predata_emulator_period, val,
             **kwargs)
 
     def get_predata_emulator_period(self, **kwargs):
         """
+        Expressed as the number of incoming frames. It must be greater that 2.
+        This period will be expressed in term of the period of the received
+        frames, which in turn is related to the flux ramp period.
+
+        Returns
+        -------
+        period : int
+            Number of frames that make up a period
         """
-        return self._caget(self.smurf_processor + self._predata_emulator_period,
-            **kwargs)
+        # Get as string and then cast as int
+        return int(self._caget(self._predata_emulator +
+            self._predata_emulator_period, as_string=True, **kwargs))
 
     def set_postdata_emulator_enable(self, val, **kwargs):
         """
@@ -5946,14 +5958,20 @@ class SmurfCommandMixin(SmurfBase):
         val : int
             Number of frames that make up a period.
         """
+        if not instance(val, str):
+            val = str(val)
         self._caput(self._postdata_emulator + self._postdata_emulator_period,
             val, **kwargs)
 
     def get_postdata_emulator_period(self, **kwargs):
         """
+        Returns
+        -------
+        period : int
+            Number of frames that make up a period.
         """
-        return self._caget(self._postdata_emulator +
-            self._postdata_emulator_period, **kwargs)
+        return int(self._caget(self._postdata_emulator +
+            self._postdata_emulator_period, as_string=True, **kwargs))
 
     _stream_data_source_enable = "SourceEnable"
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5861,7 +5861,7 @@ class SmurfCommandMixin(SmurfBase):
             Number of frames that make up a period.
         """
         # Cast as str
-        if not instance(val, str):
+        if not isinstance(val, str):
             val = str(val)
         self._caput(self._predata_emulator + self._predata_emulator_period, val,
             **kwargs)
@@ -5958,7 +5958,6 @@ class SmurfCommandMixin(SmurfBase):
         val : int
             Number of frames that make up a period.
         """
-        if not instance(val, str):
             val = str(val)
         self._caput(self._postdata_emulator + self._postdata_emulator_period,
             val, **kwargs)


### PR DESCRIPTION
## Issue
This PR resolves #594 .

## Description
the set and get function to emulator periods are strings. Handle that properly.

## Does this PR break any interface?
- [ ] Yes
- [x] No

### Which interface changed?
[Indicate here what is the interface that changed, preferable with a link to the code where the interface is defined]

### What was the interface before the change
[Describe here how was the original interface]

### What will be the new interface after the change
[Describe here how is the new interface, and what the difference with the original interface]
