### PR TITLE
Update `set_default_pv` to handle the new `RuntimeError` exception

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -597,10 +597,16 @@ class SmurfCommandMixin(SmurfBase):
                 # We successfully exit the loop when we are able to
                 # read the "ConfiguringInProgress" flag and it is set
                 # to "False".  Otherwise we keep trying.
-                if self.get_configuring_in_progress(
-                        timeout=caget_timeout_sec, **kwargs) is False:
-                    success=True
-                    break
+                # We disable the retry_on_fail feature and instead we catch any
+                # RuntimeError exception and keep trying.
+                try:
+                    if self.get_configuring_in_progress(
+                            timeout=caget_timeout_sec,
+                            retry_on_fail=False, **kwargs) is False:
+                        success=True
+                        break
+                except RuntimeError:
+                    pass
 
             # If after out maximum defined timeout, we weren't able to
             # read the "ConfiguringInProgress" flags as "False", we


### PR DESCRIPTION
## Issue
This PR resolves #598.

## Description

This PR makes the [set_default_pv method](https://github.com/slaclab/pysmurf/blob/8899e9e362ad44bd89d20693316002dd81ac53d1/python/pysmurf/client/command/smurf_command.py#L522) behaves the same it was before introducing the changes in #590.

In order to do that, we need to [read the status of the configuration in progress PV](https://github.com/slaclab/pysmurf/blob/8899e9e362ad44bd89d20693316002dd81ac53d1/python/pysmurf/client/command/smurf_command.py#L600), disabling the new `retry_on_fail` and instead catching the `RuntimeError` exceptions and keep retying for `num_retries`. 

I tested this in a system where I modified the `AppTop.Init()` method to always fail (which will be the worse case scenario) and then trying to setup the system from the client. This is what you will see:
- On the client:
```python
In [4]: S = pysmurf.client.SmurfControl(epics_root=epics_prefix, setup=True, cfg_file=config_file, make_logfile=False)
[ 2021-02-02 22:43:59 ]  Setting up...
[ 2021-02-02 22:43:59 ]  Toggling DACs
[ 2021-02-02 22:43:59 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:DBG:dacReset[0] 1
[ 2021-02-02 22:43:59 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:DBG:dacReset[1] 1
[ 2021-02-02 22:43:59 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:DBG:dacReset[0] 0
[ 2021-02-02 22:43:59 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:DBG:dacReset[1] 0
[ 2021-02-02 22:43:59 ]  caput smurf_server_s2:AMCc:ReadAll 1
[ 2021-02-02 22:44:04 ]  Waiting 20.00 seconds after...
[ 2021-02-02 22:44:24 ]  Done waiting.
[ 2021-02-02 22:44:24 ]  caget smurf_server_s2:AMCc:SmurfApplication:SmurfVersion
[ 2021-02-02 22:44:24 ]  4.2.1+9.g02aa2cc1
[ 2021-02-02 22:44:24 ]  caput smurf_server_s2:AMCc:setDefaults 1
CA.Client.Exception...............................................
    Warning: "Virtual circuit unresponsive"
    Context: "localhost:5064"
    Source File: ../tcpiiu.cpp line 920
    Current Time: Tue Feb 02 2021 22:44:59.859849152
..................................................................
[ 2021-02-02 22:44:59 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:45:09 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:45:19 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:45:29 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:45:39 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:45:49 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:45:59 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:46:09 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:46:19 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:46:29 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:46:39 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:46:49 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:46:59 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:47:09 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:47:19 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:47:29 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:47:39 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:47:49 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:47:59 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:48:09 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:48:19 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:48:29 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:48:39 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:48:49 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:48:59 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:49:09 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:49:19 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:49:29 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:49:39 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:49:49 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:49:59 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:50:09 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:50:19 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:50:29 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:50:39 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:50:49 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:50:59 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:51:09 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:51:19 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:51:29 ]  caget smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
cannot connect to smurf_server_s2:AMCc:SmurfApplication:ConfiguringInProgress
[ 2021-02-02 22:51:39 ]  The system configuration did not finish after 400.0 seconds.
[ 2021-02-02 22:51:39 ]  ERROR : System configuration/setDefaults failed!  Do not proceed!  Reboot or ask someone for help.  You are strongly encouraged to report this as an issue on the pysmurf github repo at https://github.com/slaclab/pysmurf/issues (please provide a state dump using the pysmurf set_read_all/save_state functions).
[ 2021-02-02 22:51:39 ]  Setup failed!
[ 2021-02-02 22:51:39 ]  ERROR : System setup failed!  Proceed at your own risk!

In [5]:
```

- On the server:
```
Setting defaults from file /tmp/fw/smurf_cfg/defaults/defaults_c03_lb_none.yml (try number 0)
AMCc.FpgaTopLevel.AppTop.writeBlocks()
AMCc.FpgaTopLevel.AppTop.AppCore.MicrowaveMuxCore[0].writeBlocks()
WARNING:pyrogue.VirtualClient.VirtualClient:I have not heard from AMCc in 10 seconds. It may be busy, continuing to wait...
AMCc.FpgaTopLevel.AppTop.Init()
Re-executing AppTop.Init(): retryCnt = 1
Re-executing AppTop.Init(): retryCnt = 2
Re-executing AppTop.Init(): retryCnt = 3
Re-executing AppTop.Init(): retryCnt = 4
Re-executing AppTop.Init(): retryCnt = 5
Re-executing AppTop.Init(): retryCnt = 6
Re-executing AppTop.Init(): retryCnt = 7
ERROR:pyrogue.Command.BaseCommand.AMCc.FpgaTopLevel.AppTop.Init:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries
ERROR:pyrogue.Command.BaseCommand.AMCc.LoadConfig:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 234, in <lambda>
    excGroups='NoConfig'),
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 730, in loadYaml
    if not writeEach: self._write()
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 624, in _write
    self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_TopLevel.py", line 89, in writeBlocks
    super().writeBlocks(**kwargs)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 315, in writeBlocks
    self.Init()
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 98, in __call__
    return self._doFunc(arg)
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 120, in _doFunc
    raise e
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries

ERROR: Setting defaults try number 0 failed with: AppTop.Init(): Too many retries and giving up on retries

Setting defaults from file /tmp/fw/smurf_cfg/defaults/defaults_c03_lb_none.yml (try number 1)
WARNING:pyrogue.VirtualClient.VirtualClient:I have finally heard from AMCc. All is good!
AMCc.FpgaTopLevel.AppTop.writeBlocks()
AMCc.FpgaTopLevel.AppTop.AppCore.MicrowaveMuxCore[0].writeBlocks()
WARNING:pyrogue.VirtualClient.VirtualClient:I have not heard from AMCc in 10 seconds. It may be busy, continuing to wait...
AMCc.FpgaTopLevel.AppTop.Init()
Re-executing AppTop.Init(): retryCnt = 1
Re-executing AppTop.Init(): retryCnt = 2
Re-executing AppTop.Init(): retryCnt = 3
Re-executing AppTop.Init(): retryCnt = 4
Re-executing AppTop.Init(): retryCnt = 5
Re-executing AppTop.Init(): retryCnt = 6
Re-executing AppTop.Init(): retryCnt = 7
ERROR:pyrogue.Command.BaseCommand.AMCc.FpgaTopLevel.AppTop.Init:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries
ERROR:pyrogue.Command.BaseCommand.AMCc.LoadConfig:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 234, in <lambda>
    excGroups='NoConfig'),
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 730, in loadYaml
    if not writeEach: self._write()
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 624, in _write
    self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_TopLevel.py", line 89, in writeBlocks
    super().writeBlocks(**kwargs)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 315, in writeBlocks
    self.Init()
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 98, in __call__
    return self._doFunc(arg)
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 120, in _doFunc
    raise e
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries

ERROR: Setting defaults try number 1 failed with: AppTop.Init(): Too many retries and giving up on retries

Setting defaults from file /tmp/fw/smurf_cfg/defaults/defaults_c03_lb_none.yml (try number 2)
WARNING:pyrogue.VirtualClient.VirtualClient:I have finally heard from AMCc. All is good!
AMCc.FpgaTopLevel.AppTop.writeBlocks()
AMCc.FpgaTopLevel.AppTop.AppCore.MicrowaveMuxCore[0].writeBlocks()
WARNING:pyrogue.VirtualClient.VirtualClient:I have not heard from AMCc in 10 seconds. It may be busy, continuing to wait...
AMCc.FpgaTopLevel.AppTop.Init()
Re-executing AppTop.Init(): retryCnt = 1
Re-executing AppTop.Init(): retryCnt = 2

Re-executing AppTop.Init(): retryCnt = 3
Re-executing AppTop.Init(): retryCnt = 4
Re-executing AppTop.Init(): retryCnt = 5
Re-executing AppTop.Init(): retryCnt = 6
Re-executing AppTop.Init(): retryCnt = 7
ERROR:pyrogue.Command.BaseCommand.AMCc.FpgaTopLevel.AppTop.Init:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries
ERROR:pyrogue.Command.BaseCommand.AMCc.LoadConfig:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 234, in <lambda>
    excGroups='NoConfig'),
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 730, in loadYaml
    if not writeEach: self._write()
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 624, in _write
    self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_TopLevel.py", line 89, in writeBlocks
    super().writeBlocks(**kwargs)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 315, in writeBlocks
    self.Init()
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 98, in __call__
    return self._doFunc(arg)
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 120, in _doFunc
    raise e
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries

ERROR: Setting defaults try number 2 failed with: AppTop.Init(): Too many retries and giving up on retries

Setting defaults from file /tmp/fw/smurf_cfg/defaults/defaults_c03_lb_none.yml (try number 3)
WARNING:pyrogue.VirtualClient.VirtualClient:I have finally heard from AMCc. All is good!
AMCc.FpgaTopLevel.AppTop.writeBlocks()
AMCc.FpgaTopLevel.AppTop.AppCore.MicrowaveMuxCore[0].writeBlocks()
WARNING:pyrogue.VirtualClient.VirtualClient:I have not heard from AMCc in 10 seconds. It may be busy, continuing to wait...
AMCc.FpgaTopLevel.AppTop.Init()
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 1
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 2
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 3
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 4
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 5
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 6
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 7
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
ERROR:pyrogue.Command.BaseCommand.AMCc.FpgaTopLevel.AppTop.Init:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries
ERROR:pyrogue.Command.BaseCommand.AMCc.LoadConfig:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 234, in <lambda>
    excGroups='NoConfig'),
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 730, in loadYaml
    if not writeEach: self._write()
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 624, in _write
    self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_TopLevel.py", line 89, in writeBlocks
    super().writeBlocks(**kwargs)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 315, in writeBlocks
    self.Init()
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 98, in __call__
    return self._doFunc(arg)
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 120, in _doFunc
    raise e
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries

ERROR: Setting defaults try number 3 failed with: AppTop.Init(): Too many retries and giving up on retries


ERROR: Failed to set defaults after 4 retries. Aborting!

Aborting!

WARNING:pyrogue.VirtualClient.VirtualClient:I have finally heard from AMCc. All is good!








WARNING:pyrogue.VirtualClient.VirtualClient:I have not heard from AMCc in 10 seconds. It may be busy, continuing to wait...
WARNING:pyrogue.VirtualClient.VirtualClient:I have finally heard from AMCc. All is good!
Setting defaults from file /tmp/fw/smurf_cfg/defaults/defaults_c03_lb_none.yml (try number 0)
AMCc.FpgaTopLevel.AppTop.writeBlocks()
AMCc.FpgaTopLevel.AppTop.AppCore.MicrowaveMuxCore[0].writeBlocks()
WARNING:pyrogue.VirtualClient.VirtualClient:I have not heard from AMCc in 10 seconds. It may be busy, continuing to wait...
AMCc.FpgaTopLevel.AppTop.Init()
Re-executing AppTop.Init(): retryCnt = 1
Re-executing AppTop.Init(): retryCnt = 2
Re-executing AppTop.Init(): retryCnt = 3
Re-executing AppTop.Init(): retryCnt = 4
Re-executing AppTop.Init(): retryCnt = 5
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: DataValid = 1011, PositionErr = 512, AlignErr = 0
Re-executing AppTop.Init(): retryCnt = 6
Re-executing AppTop.Init(): retryCnt = 7
ERROR:pyrogue.Command.BaseCommand.AMCc.FpgaTopLevel.AppTop.Init:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries
ERROR:pyrogue.Command.BaseCommand.AMCc.LoadConfig:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 234, in <lambda>
    excGroups='NoConfig'),
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 730, in loadYaml
    if not writeEach: self._write()
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 624, in _write
    self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_TopLevel.py", line 89, in writeBlocks
    super().writeBlocks(**kwargs)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 315, in writeBlocks
    self.Init()
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 98, in __call__
    return self._doFunc(arg)
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 120, in _doFunc
    raise e
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries

ERROR: Setting defaults try number 0 failed with: AppTop.Init(): Too many retries and giving up on retries

Setting defaults from file /tmp/fw/smurf_cfg/defaults/defaults_c03_lb_none.yml (try number 1)
WARNING:pyrogue.VirtualClient.VirtualClient:I have finally heard from AMCc. All is good!
AMCc.FpgaTopLevel.AppTop.writeBlocks()
AMCc.FpgaTopLevel.AppTop.AppCore.MicrowaveMuxCore[0].writeBlocks()
WARNING:pyrogue.VirtualClient.VirtualClient:I have not heard from AMCc in 10 seconds. It may be busy, continuing to wait...
AMCc.FpgaTopLevel.AppTop.Init()
Re-executing AppTop.Init(): retryCnt = 1
Re-executing AppTop.Init(): retryCnt = 2
Re-executing AppTop.Init(): retryCnt = 3
Re-executing AppTop.Init(): retryCnt = 4
Re-executing AppTop.Init(): retryCnt = 5
Re-executing AppTop.Init(): retryCnt = 6
Re-executing AppTop.Init(): retryCnt = 7
ERROR:pyrogue.Command.BaseCommand.AMCc.FpgaTopLevel.AppTop.Init:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries
ERROR:pyrogue.Command.BaseCommand.AMCc.LoadConfig:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 234, in <lambda>
    excGroups='NoConfig'),
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 730, in loadYaml
    if not writeEach: self._write()
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 624, in _write
    self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_TopLevel.py", line 89, in writeBlocks
    super().writeBlocks(**kwargs)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 315, in writeBlocks
    self.Init()
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 98, in __call__
    return self._doFunc(arg)
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 120, in _doFunc
    raise e
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries

ERROR: Setting defaults try number 1 failed with: AppTop.Init(): Too many retries and giving up on retries

Setting defaults from file /tmp/fw/smurf_cfg/defaults/defaults_c03_lb_none.yml (try number 2)
WARNING:pyrogue.VirtualClient.VirtualClient:I have finally heard from AMCc. All is good!
AMCc.FpgaTopLevel.AppTop.writeBlocks()
AMCc.FpgaTopLevel.AppTop.AppCore.MicrowaveMuxCore[0].writeBlocks()
WARNING:pyrogue.VirtualClient.VirtualClient:I have not heard from AMCc in 10 seconds. It may be busy, continuing to wait...
AMCc.FpgaTopLevel.AppTop.Init()
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 1
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 2
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 3
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 4
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 5
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 6
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
Re-executing AppTop.Init(): retryCnt = 7
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
AppTop.Init().AMCc.FpgaTopLevel.AppTop.AppTopJesd[0].JesdRx: Link Not Locked: SysRefPeriodmin = 14, SysRefPeriodmax = 16
ERROR:pyrogue.Command.BaseCommand.AMCc.FpgaTopLevel.AppTop.Init:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries
ERROR:pyrogue.Command.BaseCommand.AMCc.LoadConfig:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 234, in <lambda>
    excGroups='NoConfig'),
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 730, in loadYaml
    if not writeEach: self._write()
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 624, in _write
    self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_TopLevel.py", line 89, in writeBlocks
    super().writeBlocks(**kwargs)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 315, in writeBlocks
    self.Init()
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 98, in __call__
    return self._doFunc(arg)
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 120, in _doFunc
    raise e
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries

ERROR: Setting defaults try number 2 failed with: AppTop.Init(): Too many retries and giving up on retries

Setting defaults from file /tmp/fw/smurf_cfg/defaults/defaults_c03_lb_none.yml (try number 3)
WARNING:pyrogue.VirtualClient.VirtualClient:I have finally heard from AMCc. All is good!
AMCc.FpgaTopLevel.AppTop.writeBlocks()
AMCc.FpgaTopLevel.AppTop.AppCore.MicrowaveMuxCore[0].writeBlocks()
WARNING:pyrogue.VirtualClient.VirtualClient:I have not heard from AMCc in 10 seconds. It may be busy, continuing to wait...
AMCc.FpgaTopLevel.AppTop.Init()
Re-executing AppTop.Init(): retryCnt = 1
Re-executing AppTop.Init(): retryCnt = 2
Re-executing AppTop.Init(): retryCnt = 3
Re-executing AppTop.Init(): retryCnt = 4
Re-executing AppTop.Init(): retryCnt = 5
Re-executing AppTop.Init(): retryCnt = 6
Re-executing AppTop.Init(): retryCnt = 7
ERROR:pyrogue.Command.BaseCommand.AMCc.FpgaTopLevel.AppTop.Init:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries
ERROR:pyrogue.Command.BaseCommand.AMCc.LoadConfig:AppTop.Init(): Too many retries and giving up on retries
Traceback (most recent call last):
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 234, in <lambda>
    excGroups='NoConfig'),
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 730, in loadYaml
    if not writeEach: self._write()
  File "/usr/local/src/rogue/python/pyrogue/_Root.py", line 624, in _write
    self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_TopLevel.py", line 89, in writeBlocks
    super().writeBlocks(**kwargs)
  File "/usr/local/src/rogue/python/pyrogue/_Device.py", line 296, in writeBlocks
    value.writeBlocks(force=force, recurse=True, checkEach=checkEach)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 315, in writeBlocks
    self.Init()
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 98, in __call__
    return self._doFunc(arg)
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 120, in _doFunc
    raise e
  File "/usr/local/src/rogue/python/pyrogue/_Command.py", line 116, in _doFunc
    return pr.varFuncHelper(self._function,pargs, self._log,self.path)
  File "/usr/local/src/rogue/python/pyrogue/_Variable.py", line 868, in varFuncHelper
    return func(**args)
  File "/tmp/fw/rogue_MicrowaveMuxBpEthGen2_v1.0.3.zip/python/AmcCarrierCore/AppTop/_AppTop.py", line 288, in Init
    raise pr.DeviceError('AppTop.Init(): Too many retries and giving up on retries')
pyrogue._Device.DeviceError: AppTop.Init(): Too many retries and giving up on retries

ERROR: Setting defaults try number 3 failed with: AppTop.Init(): Too many retries and giving up on retries


ERROR: Failed to set defaults after 4 retries. Aborting!

Aborting!
```

Of course, this test intentionally failed at the end, in order to test the worse case scenario, and make sure that the client waits until the end of the process (compare this with the example shown in #598 when the client didn't wait and failed before the server finished trying to setup the system). In a different situation, the server will eventually recover and the setting defaults will succeed. In that situation, the client code will be able to continuer normally.

## Does this PR break any interface?
- [ ] Yes
- [X] No