### PR TITLE
Update smurf-rogue base image to version R2.8.3

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.8.2
+FROM tidair/smurf-rogue:R2.8.3
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src


### PR DESCRIPTION
## Issue
This PR resolves [ESCRYODET-728](https://jira.slac.stanford.edu/browse/ESCRYODET-728).

## Description

This PR updates Rogue to version [v4.11.7](https://github.com/slaclab/rogue/releases/tag/v4.11.7). This version of Rogue contains a fix for the unbound memory usage increase described in [ESCRYODET-728](https://jira.slac.stanford.edu/browse/ESCRYODET-728).

## Does this PR break any interface?
- [ ] Yes
- [X] No