### PR TITLE
Band delay us

### DIFF
--- a/cfg_files/stanford/experiment_fp31_cc03-02_lbOnlyBay0.cfg
+++ b/cfg_files/stanford/experiment_fp31_cc03-02_lbOnlyBay0.cfg
@@ -7,9 +7,7 @@
 	"band_0" : {
 		"iq_swap_in" : 0,
 		"iq_swap_out" : 0,
-		# Measured for 8234f45 by SWH on 8/1/19
-		"refPhaseDelay" : 6,
-		"refPhaseDelayFine" : 16,
+		"bandDelayUs" : 8.8,
 		"trigRstDly" : 15, # 0xF
 		"feedbackEnable": 1,
 		"feedbackGain" : 256,
@@ -24,9 +22,7 @@
 	"band_1" : {
 		"iq_swap_in" : 0,
 		"iq_swap_out" : 0,
-		# Measured for 8234f45 by SWH on 8/1/19
-		"refPhaseDelay" : 6,
-		"refPhaseDelayFine" : 19,
+		"bandDelayUs" : 8.8,
 		"trigRstDly" : 15, # 0xF
 		"feedbackEnable": 1,
 		"feedbackGain" : 256,
@@ -41,9 +37,7 @@
 	"band_2" : {
 		"iq_swap_in" : 0,
 		"iq_swap_out" : 0,
-		# Measured for bdc4981 by SWH on 7/17/20
-		"refPhaseDelay" : 6,
-		"refPhaseDelayFine" : 63,
+		"bandDelayUs" : 8.8,
 		"trigRstDly" : 15, # 0xF
 		"feedbackEnable": 1,
 		"feedbackGain" : 256,
@@ -58,9 +52,7 @@
 	"band_3" : {
 		"iq_swap_in" : 0,
 		"iq_swap_out" : 0,
-		# Measured for 8234f45 by SWH on 8/1/19
-		"refPhaseDelay" : 6,
-		"refPhaseDelayFine" : 16,
+		"bandDelayUs" : 8.8,
 		"trigRstDly" : 15, # 0xF
 		"feedbackEnable": 1,
 		"feedbackGain" : 256,

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -420,7 +420,7 @@ class SmurfConfig:
                 # Global feedback gain (might no longer be used in dspv3).
                 "feedbackLimitkHz" : And(Use(float), lambda f: f > 0),
 
-## TODO remove refPhaseDelay and refPhaseDelayFine
+                ## TODO remove refPhaseDelay and refPhaseDelayFine
                 # refPhaseDelay and refPhaseDelayFine are deprected
                 # use bandDelayUs instead
 
@@ -446,7 +446,7 @@ class SmurfConfig:
                 And([Use(int)], list, lambda l: len(l) == 2 and
                     l[0] != l[1] and all(0 <= ll <= 9 for ll in l)),
 
-## TODO remove lmsDelay
+                ## TODO remove lmsDelay
                 # lmsDelay is deprected use bandDelayUs instead
 
                 # Matches system latency for LMS feedback (9.6 MHz

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -420,11 +420,18 @@ class SmurfConfig:
                 # Global feedback gain (might no longer be used in dspv3).
                 "feedbackLimitkHz" : And(Use(float), lambda f: f > 0),
 
+## TODO remove refPhaseDelay and refPhaseDelayFine
+                # refPhaseDelay and refPhaseDelayFine are deprected
+                # use bandDelayUs instead
+
                 # Number of cycles to delay phase reference
-                'refPhaseDelay': And(int, lambda n: 0 <= n < 2**5),
+                Optional('refPhaseDelay', default=0): And(int, lambda n: 0 <= n < 2**5),
                 # Finer phase reference delay, 307.2MHz clock ticks.  This
                 # goes in the opposite direction as refPhaseDelay.
-                'refPhaseDelayFine': And(int, lambda n: 0 <= n < 2**8),
+                Optional('refPhaseDelayFine', default=0): And(int, lambda n: 0 <= n < 2**8),
+
+                # use bandDelayUs (microseconds) instead of refPhaseDelay(Fine)
+                Optional('bandDelayUs', default=None): And(Use(float), lambda n : 0 <= n < 30),
 
                 # RF attenuator on SMuRF output.  UC=up convert.  0.5dB steps.
                 'att_uc': And(int, lambda n: 0 <= n < 2**5),
@@ -438,6 +445,9 @@ class SmurfConfig:
                          default=default_data_out_mux_dict[band]) : \
                 And([Use(int)], list, lambda l: len(l) == 2 and
                     l[0] != l[1] and all(0 <= ll <= 9 for ll in l)),
+
+## TODO remove lmsDelay
+                # lmsDelay is deprected use bandDelayUs instead
 
                 # Matches system latency for LMS feedback (9.6 MHz
                 # ticks, use multiples of 52).  For dspv3 to adjust to

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -2340,6 +2340,8 @@ class SmurfConfigPropertiesMixin:
     def band_delay_us(self, value):
         self._band_delay_us = value
 
+    ## End band_delay_us property definition
+    ###########################################################################
 
     ###########################################################################
     ## Start lms_delay property definition

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -2234,7 +2234,7 @@ class SmurfConfigPropertiesMixin:
     @property
     def ref_phase_delay_fine(self):
         """DEPRECATED
-        
+
         Fine adjust for (analog + digital) round-trip delay.
 
         Gets or sets fine adjustment for the total (analog + digital)

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -147,6 +147,7 @@ class SmurfConfigPropertiesMixin:
         self._iq_swap_out = None
         self._ref_phase_delay = None
         self._ref_phase_delay_fine = None
+        self._band_delay_us = None
         self._att_uc = None
         self._att_dc = None
         self._trigger_reset_delay = None
@@ -303,6 +304,9 @@ class SmurfConfigPropertiesMixin:
             for band in bands}
         self.ref_phase_delay_fine = {
             band:smurf_init_config[f'band_{band}']['refPhaseDelayFine']
+            for band in bands}
+        self.band_delay_us = {
+            band:smurf_init_config[f'band_{band}']['bandDelayUs']
             for band in bands}
         self.att_uc = {
             band:smurf_init_config[f'band_{band}']['att_uc']
@@ -2142,7 +2146,8 @@ class SmurfConfigPropertiesMixin:
     # Getter
     @property
     def ref_phase_delay(self):
-        """Coarse (analog + digital) round-trip delay.
+        """DEPRECATED
+        Coarse (analog + digital) round-trip delay.
 
         Gets or sets the coarse (analog + digital) round-trip delay.
         This is the total time it takes a tone to traverse the
@@ -2228,7 +2233,9 @@ class SmurfConfigPropertiesMixin:
     # Getter
     @property
     def ref_phase_delay_fine(self):
-        """Fine adjust for (analog + digital) round-trip delay.
+        """DEPRECATED
+        
+        Fine adjust for (analog + digital) round-trip delay.
 
         Gets or sets fine adjustment for the total (analog + digital)
         round-trip delay.  This allows for fine adjustment of the
@@ -2307,12 +2314,42 @@ class SmurfConfigPropertiesMixin:
     ###########################################################################
 
     ###########################################################################
+    ## Start band_delay_us property definition
+
+    # Getter
+    @property
+    def band_delay_us(self):
+        """Total compensation for system latency - cable, ADC/DAC, and DSP
+
+        Returns
+        -------
+        double
+           Adjustment for (analog + digital) round-trip delay in
+           micro seconds.
+
+        See Also
+        --------
+        :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.estimate_phase_delay` :
+              Measures `band_delay_us`.
+
+        """
+        return self._band_delay_us
+
+    # Setter
+    @band_delay_us.setter
+    def band_delay_us(self, value):
+        self._band_delay_us = value
+
+
+    ###########################################################################
     ## Start lms_delay property definition
 
     # Getter
     @property
     def lms_delay(self):
-        """Short description.
+        """DEPRECATED
+
+        Short description.
 
         Gets or sets ?.
         Units are ?.

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -487,26 +487,36 @@ class SmurfControl(SmurfCommandMixin,
                 self.set_iq_swap_out(band, self._iq_swap_out[band],
                                      write_log=write_log, **kwargs)
 
-                self.set_ref_phase_delay(
-                    band,
-                    self._ref_phase_delay[band],
-                    write_log=write_log, **kwargs)
-                self.set_ref_phase_delay_fine(
-                    band,
-                    self._ref_phase_delay_fine[band],
-                    write_log=write_log, **kwargs)
-
-                # in DSPv3, lmsDelay should be 4*refPhaseDelay (says
-                # Mitch).  If none provided in cfg, enforce that
-                # constraint.  If provided in cfg, override with provided
-                # value.
-                if self._lms_delay[band] is None:
-                    self.set_lms_delay(
-                        band, int(4*self._ref_phase_delay[band]),
+                if self._ref_phase_delay[band]:
+                    self.set_ref_phase_delay(
+                        band,
+                        self._ref_phase_delay[band],
                         write_log=write_log, **kwargs)
+                    self.set_ref_phase_delay_fine(
+                        band,
+                        self._ref_phase_delay_fine[band],
+                        write_log=write_log, **kwargs)
+
+                    # in DSPv3, lmsDelay should be 4*refPhaseDelay (says
+                    # Mitch).  If none provided in cfg, enforce that
+                    # constraint.  If provided in cfg, override with provided
+                    # value.
+                    if self._lms_delay[band] is None:
+                        self.set_lms_delay(
+                            band, int(4*self._ref_phase_delay[band]),
+                            write_log=write_log, **kwargs)
+                    else:
+                        self.set_lms_delay(
+                            band, self._lms_delay[band],
+                            write_log=write_log, **kwargs)
+                # we'll use the next band_delay_us
                 else:
-                    self.set_lms_delay(
-                        band, self._lms_delay[band],
+                    if self._band_delay_us[band] is None:
+                        raise RuntimeError("Must define either refPhaseDelay " + 
+                                           "and refPhaseDelayFine or bandDelayUs")
+                    self.set_band_delay_us(
+                        band,
+                        self._band_delay_us[band],
                         write_log=write_log, **kwargs)
 
                 self.set_lms_gain(

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -512,7 +512,7 @@ class SmurfControl(SmurfCommandMixin,
                 # we'll use the next band_delay_us
                 else:
                     if self._band_delay_us[band] is None:
-                        raise RuntimeError("Must define either refPhaseDelay " + 
+                        raise RuntimeError("Must define either refPhaseDelay " +
                                            "and refPhaseDelayFine or bandDelayUs")
                     self.set_band_delay_us(
                         band,

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -1729,8 +1729,7 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_ref_phase_delay(self, band, val, **kwargs):
         """
-        Corrects for roundtrip cable delay freqError = IQ * etaMag,
-        rotated by etaPhase+refPhaseDelay
+        Deprecated.  Use set_band_delay_us instead.
         """
         self._caput(
             self._band_root(band) + self._ref_phase_delay_reg,
@@ -1738,8 +1737,7 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_ref_phase_delay(self, band, **kwargs):
         """
-        Corrects for roundtrip cable delay freqError = IQ * etaMag,
-        rotated by etaPhase+refPhaseDelay
+        Deprecated.  Use get_band_delay_us instead.
         """
         return self._caget(
             self._band_root(band) + self._ref_phase_delay_reg,
@@ -1749,6 +1747,7 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_ref_phase_delay_fine(self, band, val, **kwargs):
         """
+        Deprecated.  Use set_band_delay_us instead.
         """
         self._caput(
             self._band_root(band) + self._ref_phase_delay_fine_reg,
@@ -1756,9 +1755,31 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_ref_phase_delay_fine(self, band, **kwargs):
         """
+        Deprecated.  Use get_band_delay_us instead.
         """
         return self._caget(
             self._band_root(band) + self._ref_phase_delay_fine_reg,
+            **kwargs)
+
+    _band_delay_us_reg = 'bandDelayUs'
+
+    def set_band_delay_us(self, band, val, **kwargs):
+        """
+        Set band delay compensation, microseconds.  Corrects
+        for total system delay (cable, DSP, etc.).  Internally
+        configures both ref_phase_delay and ref_phase_delay_fine
+        """
+        self._caput(
+            self._band_root(band) + self._band_delay_us_reg,
+            val, **kwargs)
+
+    def get_band_delay_us(self, band, **kwargs):
+        """
+        Get band delay compensation, microseconds.  Corrects
+        for total system delay (cable, DSP, etc.).
+        """
+        return self._caget(
+            self._band_root(band) + self._band_delay_us_reg,
             **kwargs)
 
     _tone_scale_reg = 'toneScale'

--- a/python/pysmurf/client/command/test_sphinx.py
+++ b/python/pysmurf/client/command/test_sphinx.py
@@ -1472,8 +1472,7 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_ref_phase_delay(self, band, val, **kwargs):
         """
-        Corrects for roundtrip cable delay freqError = IQ * etaMag,
-        rotated by etaPhase+refPhaseDelay
+        Deprecated.  Use set_band_delay_us instead.
         """
         self._caput(
             self._band_root(band) + self._ref_phase_delay_reg,
@@ -1481,8 +1480,7 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_ref_phase_delay(self, band, **kwargs):
         """
-        Corrects for roundtrip cable delay freqError = IQ * etaMag,
-        rotated by etaPhase+refPhaseDelay
+        Deprecated.  Use get_band_delay_us instead.
         """
         return self._caget(
             self._band_root(band) + self._ref_phase_delay_reg,
@@ -1492,6 +1490,7 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_ref_phase_delay_fine(self, band, val, **kwargs):
         """
+        Deprecated.  Use set_band_delay_us instead.
         """
         self._caput(
             self._band_root(band) + self._ref_phase_delay_fine_reg,
@@ -1499,9 +1498,31 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_ref_phase_delay_fine(self, band, **kwargs):
         """
+        Deprecated.  Use get_band_delay_us instead.
         """
         return self._caget(
             self._band_root(band) + self._ref_phase_delay_fine_reg,
+            **kwargs)
+
+    _band_delay_us_reg = 'bandDelayUs'
+
+    def set_band_delay_us(self, band, val, **kwargs):
+        """
+        Set band delay compensation, microseconds.  Corrects
+        for total system delay (cable, DSP, etc.).  Internally
+        configures both ref_phase_delay and ref_phase_delay_fine
+        """
+        self._caput(
+            self._band_root(band) + self._band_delay_us_reg,
+            val, **kwargs)
+
+    def get_band_delay_us(self, band, **kwargs):
+        """
+        Get band delay compensation, microseconds.  Corrects
+        for total system delay (cable, DSP, etc.).
+        """
+        return self._caget(
+            self._band_root(band) + self._band_delay_us_reg,
             **kwargs)
 
     _tone_scale_reg = 'toneScale'

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -704,11 +704,11 @@ class SmurfTuneMixin(SmurfBase):
             # Take PSDs of ADC, DAC, and cross
             fs = self.get_digitizer_frequency_mhz() * 1.0E6
             f, p_dac = signal.welch(dac, fs=fs, nperseg=nsamp/2,
-                                    return_onesided=True)
+                                    return_onesided=False)
             f, p_adc = signal.welch(adc, fs=fs, nperseg=nsamp/2,
-                                    return_onesided=True)
+                                    return_onesided=False)
             f, p_cross = signal.csd(dac, adc, fs=fs, nperseg=nsamp/2,
-                                    return_onesided=True)
+                                    return_onesided=False)
 
             # Sort frequencies
             idx = np.argsort(f)

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -254,7 +254,6 @@ class SmurfUtilMixin(SmurfBase):
         # save time)
         n_subbands = self.get_number_sub_bands(band)
         digitizer_frequency_mhz = self.get_digitizer_frequency_mhz(band)
-        channel_frequency_mhz = self.get_channel_frequency_mhz(band)
         subband_half_width_mhz = digitizer_frequency_mhz/\
             n_subbands
         subbands,subband_centers=self.get_subband_centers(band)
@@ -442,8 +441,7 @@ class SmurfUtilMixin(SmurfBase):
         cable_residuals=cable_phase-(cable_p(f_cable_plot*1.0E6))
         ax[2].plot(f_cable_plot,cable_residuals-np.median(cable_residuals),
             label='Cable (full_band_resp)',c='g')
-        dsp_residuals=dsp_phase-(dsp_p(f_dsp_plot*1.0E6))
-        ax[2].plot(f_dsp_plot,dsp_corr_phase-np.median(dsp_corr_phase),
+        ax[2].plot(f_dsp_corr_plot,dsp_corr_phase-np.median(dsp_corr_phase),
             label='DSP (find_freq)', c='c')
         ax[2].set_title(f'AMC in Bay {bay}, Band {band} Residuals'.format(bay,band))
         ax[2].set_ylabel("Residual [rad]")

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -481,7 +481,7 @@ class SmurfUtilMixin(SmurfBase):
         if show_plot:
             plt.show()
 
-        return processing_delay_us, dsp_corr_delay_us
+        return dsp_delay_us, dsp_corr_delay_us
 
     def process_data(self, filename, dtype=np.uint32):
         """ Reads a file taken with take_debug_data and processes it into data

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -302,18 +302,27 @@ class SmurfUtilMixin(SmurfBase):
         #### done measuring cable delay
 
         #### start measuring dsp delay (cable+processing)
-        self.set_band_delay_us(band, 0)
+## FIXME -- should be able to scan with "0" delay, not working
+        self.set_band_delay_us(band, 1)
 
         self.log('Running find_freq')
+        #freq_dsp,resp_dsp=self.find_freq(band, start_freq=freq_min, stop_freq=freq_max)
         freq_dsp,resp_dsp=self.find_freq(band,subband=dsp_subbands)
 
         # only preserve data in the subband half width
         freq_dsp_subset=[]
         resp_dsp_subset=[]
+        est_delay=[]
         for sb,sbc in zip(subbands,subband_centers):
             freq_subband=freq_dsp[sb]-sbc
             idx = np.where( ( freq_subband > subband_freq_min ) &
                 (freq_subband < subband_freq_max) )
+            if len(idx[0]) > 0:
+                dsp_z = np.polyfit(freq_dsp[sb][idx]*1e6, np.unwrap(np.angle(resp_dsp[sb][idx])), 1)
+                dsp_p = np.poly1d(dsp_z)
+                dsp_delay_us=np.abs(1.e6*dsp_z[0]/2/np.pi)
+                dsp_delay_us=dsp_delay_us + self.get_band_delay_us(band)
+                est_delay.append(dsp_delay_us)
             freq_dsp_subset.extend(freq_dsp[sb][idx])
             resp_dsp_subset.extend(resp_dsp[sb][idx])
 
@@ -334,11 +343,14 @@ class SmurfUtilMixin(SmurfBase):
         dsp_z = np.polyfit(freq_dsp_subset, np.unwrap(np.angle(resp_dsp_subset)), 1)
         dsp_p = np.poly1d(dsp_z)
         dsp_delay_us=np.abs(1.e6*dsp_z[0]/2/np.pi)
+        dsp_delay_us=dsp_delay_us + self.get_band_delay_us(band)
+        dsp_delay_us=np.mean(est_delay)
 
         processing_delay_us=dsp_delay_us-cable_delay_us
 
         print('-------------------------------------------------------')
         print(f'Estimated cable_delay_us={cable_delay_us}')
+        print(f'Estimated dsp_delay_us={dsp_delay_us}')
         print(f'Estimated processing_delay_us={processing_delay_us}')
         print('-------------------------------------------------------')
 
@@ -352,9 +364,18 @@ class SmurfUtilMixin(SmurfBase):
 
         freq_dsp_corr_subset=[]
         resp_dsp_corr_subset=[]
+        first = True
         for sb,sbc in zip(subbands,subband_centers):
             freq_subband=freq_dsp_corr[sb]-sbc
             idx = np.where( ( freq_subband > subband_freq_min ) & (freq_subband < subband_freq_max) )
+            if len(idx[0]) > 0:
+                if not first:
+                    last_phase = np.angle(resp_dsp_corr_subset[-1])
+                    new_phase  = np.angle(resp_dsp_corr[sb][idx[0]])
+                    resp_dsp_corr[sb][idx] = resp_dsp_corr[sb][idx] * np.exp(1j*(last_phase - new_phase))
+
+                if first:
+                    first = False
             freq_dsp_corr_subset.extend(freq_dsp_corr[sb][idx])
             resp_dsp_corr_subset.extend(resp_dsp_corr[sb][idx])
 
@@ -422,21 +443,13 @@ class SmurfUtilMixin(SmurfBase):
         ax[2].plot(f_cable_plot,cable_residuals-np.median(cable_residuals),
             label='Cable (full_band_resp)',c='g')
         dsp_residuals=dsp_phase-(dsp_p(f_dsp_plot*1.0E6))
-        ax[2].plot(f_dsp_plot,dsp_residuals-np.median(dsp_residuals),
+        ax[2].plot(f_dsp_plot,dsp_corr_phase-np.median(dsp_corr_phase),
             label='DSP (find_freq)', c='c')
-        ax[2].plot(f_dsp_corr_plot,dsp_corr_phase-np.median(dsp_corr_phase),
-            label='DSP corrected (find_freq)', c='m')
         ax[2].set_title(f'AMC in Bay {bay}, Band {band} Residuals'.format(bay,band))
         ax[2].set_ylabel("Residual [rad]")
         ax[2].set_xlabel('Frequency offset from band center [MHz]')
         ax[2].set_ylim([-5,5])
 
-        ax[2].text(.97, .92, f'refPhaseDelay={refPhaseDelay}',
-                   transform=ax[2].transAxes, fontsize=8,
-                   bbox=bbox,horizontalalignment='right')
-        ax[2].text(.97, .84, f'refPhaseDelayFine={refPhaseDelayFine}',
-                   transform=ax[2].transAxes, fontsize=8,
-                   bbox=bbox,horizontalalignment='right')
         ax[2].text(.97, .76,
                    f'processing delay={processing_delay_us:.5f} us (fw={fw_abbrev_sha})',
                    transform=ax[2].transAxes, fontsize=8,
@@ -466,6 +479,9 @@ class SmurfUtilMixin(SmurfBase):
 
         self.set_att_uc(band, uc_att0, write_log=True)
         self.set_att_dc(band, dc_att0, write_log=True)
+
+        if show_plot:
+            plt.show()
 
         return processing_delay_us, dsp_corr_delay_us
 


### PR DESCRIPTION
## Issue
This issue deprecates refPhaseDelay, refPhaseDelayFine and lmsDelay.  We've introduced a new PV bandDelayUs which handles those 3 variables under the hood.  This also improves estimate_phase_delay.

## Description

[Describe what this PR does here]

## Does this PR break any interface?
- [x] Yes
- [ ] No

### Which interface changed?
refPhaseDelay, refPhaseDelayFine, and lmsDelay are now deprecated.  These are handled by Rogue in the bandDelayUs PV.

### What was the interface before the change
refPhaseDelay, refPhaseDelayFine and lmsDelay in the configuration file

### What will be the new interface after the change
bandDelayUs in the configuration file
