### PR TITLE
Add predataEmulator:Disable hooks

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5848,7 +5848,7 @@ class SmurfCommandMixin(SmurfBase):
     def set_predata_emulator_disable(self, val, **kwargs):
         """
         Sets the predata emulator disable status.
-        
+
         Args
         ----
         val : bool

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5843,6 +5843,32 @@ class SmurfCommandMixin(SmurfBase):
         """
         return self._caget(self._predata_emulator + 'enable', **kwargs)
 
+    _predata_emulator_disable = "Disable"
+
+    def set_predata_emulator_disable(self, val, **kwargs):
+        """
+        Sets the predata emulator disable status.
+        Args
+        ----
+        val : int
+            0 to set to False
+            1 to set to True
+        """
+        self._caput(self._predata_emulator + self._predata_emulator_disable, val,
+                    **kwargs)
+
+    def get_predata_emulator_disable(self, **kwargs):
+        """
+        Gets the predata emulator disable status.
+
+        Returns
+        -------
+        int
+            0 - False, 1 - True
+            """
+        return self._caget(self._predata_emulator + self._predata_emulator_disable,
+                           **kwargs)
+
     _predata_emulator_type = "Type"
 
     def set_predata_emulator_type(self, val, **kwargs):

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5848,14 +5848,13 @@ class SmurfCommandMixin(SmurfBase):
     def set_predata_emulator_disable(self, val, **kwargs):
         """
         Sets the predata emulator disable status.
+        
         Args
         ----
-        val : int
-            0 to set to False
-            1 to set to True
+        val : bool
         """
-        self._caput(self._predata_emulator + self._predata_emulator_disable, val,
-                    **kwargs)
+        self._caput(self._predata_emulator + self._predata_emulator_disable,
+            val, **kwargs)
 
     def get_predata_emulator_disable(self, **kwargs):
         """
@@ -5863,11 +5862,10 @@ class SmurfCommandMixin(SmurfBase):
 
         Returns
         -------
-        int
-            0 - False, 1 - True
-            """
+        type : bool
+        """
         return self._caget(self._predata_emulator + self._predata_emulator_disable,
-                           **kwargs)
+            **kwargs)
 
     _predata_emulator_type = "Type"
 


### PR DESCRIPTION
## Issue
This PR resolves #624.

## Description

Creates two hooks for setting and getting the value of the `Disable` field in the `predataEmulator`. One can now set and get the values using the following:

```python
S.set_predata_emulator_disable(True)
value = S.get_predata_emulator_disable()
```

## Does this PR break any interface?
- [ ] Yes
- [X] No
