### PR TITLE
add channel assignment tracking to tune file

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -1571,6 +1571,7 @@ class SmurfTuneMixin(SmurfBase):
             old_file=self.channel_assignment_files[f'band_{band}']
             self.log(f'Old master assignment file: {old_file}')
         self.channel_assignment_files[f'band_{band}'] = filename
+        self.freq_resp[band]['channel_assignment'] = filename
         self.log(f'New master assignment file: {filename}')
 
     @set_action()


### PR DESCRIPTION
## Issue
This PR resolves #608.

## Description
It adds a new key to the tune file information that tracks which channel assignment is used for each band. This will help maintain transparency if someone loads an old tune file and starts building off it instead. I've tested in on our SMuRF system in Chicago and verified that it works as described in the issue post.

## Does this PR break any interface?
- [ ] Yes
- [x] No

### Which interface changed?
It hasn't changed anything for the user
