### PR TITLE
fixes the payload size issue by replacing the manual determination of the payload size

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -863,10 +863,9 @@ class SmurfUtilMixin(SmurfBase):
             Whether to write to the log file.
         update_payload_size : bool, optional, default True
             Whether to update the payload size (the number of channels
-            written to disk). If the number of channels on is greater
-            than the payload size, then only the first N channels are
-            written. This bool will update the payload size to be the
-            same as the number of channels on across all bands)
+            written to disk). If this is True, will set the payload size to
+            0, which tells rogue to automatically adjust it based on the
+            channel count.
         reset_filter : bool, optional, default True
             Whether to reset the filter before taking data.
         reset_unwrapper : bool, optional, default True
@@ -890,7 +889,8 @@ class SmurfUtilMixin(SmurfBase):
                      'value already in pyrogue:'+
                      f' {downsample_factor}')
 
-        self.set_payload_size(0)
+        if update_payload_size:
+            self.set_payload_size(0)
 
         # Check if flux ramp is non-zero
         ramp_max_cnt = self.get_ramp_max_cnt()

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -890,19 +890,7 @@ class SmurfUtilMixin(SmurfBase):
                      'value already in pyrogue:'+
                      f' {downsample_factor}')
 
-        # Check payload size
-        n_chan_in_mask = len(self.get_channel_mask())
-        payload_size = self.get_payload_size()
-        if n_chan_in_mask > payload_size:
-            if update_payload_size:
-                self.log('Updating payload size')
-                self.set_payload_size(n_chan_in_mask,
-                                      write_log=write_log)
-            else:
-                self.log('Warning : The payload size is smaller than ' +
-                    'the number of channels that are on. Only ' +
-                    f'writing the first {payload_size} channels. ')
-
+        self.set_payload_size(0)
 
         # Check if flux ramp is non-zero
         ramp_max_cnt = self.get_ramp_max_cnt()


### PR DESCRIPTION
## Issue
This PR resolves #626 

## Description
This PR fixes the payload size issue by replacing the manual determination of the payload size with `S.set_payload_size(0)`. I'm not sure why the other way wasn't working, but we tested at U-chicago, and this does indeed create .dat files with the correct payload size, which drastically decreases the file size when you're not streaming with a full UFM.

## Does this PR break any interface?
- [ ] Yes
- [X] No