### PR TITLE
Registers debug dat file with publisher

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -145,6 +145,7 @@ class SmurfUtilMixin(SmurfBase):
         self.set_streamdatawriter_close(True)
 
         self.log('Done taking data', self.LOG_USER)
+        self.pub.register_file(data_filename, 'debug', format='dat')
 
         if rf_iq:
             self.set_rf_iq_stream_enable(band, 0)


### PR DESCRIPTION
## Issue
This PR resolves #633.

## Description
Adds a `pub.register_file` call once the debug data file closes.

## Does this PR break any interface?
- [ ] Yes
- [X] No