### PR TITLE
Generate stable docker images from this repository

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,3 +21,7 @@ client:
   - cfg_files/**/*              # All the configuration files
   - scratch/**/*                # All the file in the scratch area
   - docs/**/*                   # This contains documentation only for the client code
+
+# Add label 'firmware-change' to any change to the docker server definition file
+firmware-change:
+  - docker/server/definitions.sh # The docker server definition file

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,6 +52,23 @@ jobs:
       - name: Flake8 Checks
         run: flake8 --count python/
 
+  # Validate the server docker image definitions
+  docker-definitions:
+    name: Docker Definition Validation
+    runs-on: ubuntu-18.04
+    steps:
+      # Validate the server 'definitions.sh' file.
+      # Note about tokens: In this stage we need to use the SLACLAB TOKEN
+      # to be able to access the other private repositories (GITHUB_TOKEN
+      # only gives access to this repository).
+      - name: Validate the server definitions
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.SLACLAB_TOKEN }}
+        run: |
+          cd docker/server/
+          ./validate.sh
+          cd -
 
   ###################
   # Test jobs       #

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       # Checkout the code.
       # We use ssh key authentication to be able to access other private
-      # repositories.
+      # repositories (like the firmware repository).
       - name: Checkout code
         uses: actions/checkout@v2
         with:
@@ -278,9 +278,13 @@ jobs:
     needs: [test-docs, test-server, test-client]  # Run only if all tests passed
     if: startsWith(github.ref, 'refs/tags/')      # Run only on tagged releases
     steps:
-      # Checkout the code
+      # Checkout the code.
+      # We use ssh key authentication to be able to access other private
+      # repositories (like the firmware repository).
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.SLACLAB_KEY }}
 
       # Setup docker build environment
       - name: Set up Docker Buildx

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Validate the server definitions
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.SLACLAB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd docker/server/
           ./validate.sh

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Validate the server definitions
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SLACLAB_TOKEN }}
         run: |
           cd docker/server/
           ./validate.sh

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -257,12 +257,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # Get the git tag from the environmental variables
-      # It will used to tag the docker image
-      - name: Get release tag
-        id: get_tag
-        run: echo ::set-output name=tag::"${GITHUB_REF#refs/tags/}"
-
       # Setup docker build environment
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -275,14 +269,18 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Build and push the docker image
+      # Note about tokens: In this stage we need to use the SLACLAB TOKEN
+      # to be able to access the other private repositories (GITHUB_TOKEN
+      # only gives access to this repository).
       - name: Build and push image to Dockerhub
-        uses: docker/build-push-action@v2
-        with:
-          context: ./docker/server
-          file: ./docker/server/Dockerfile
-          push: true
-          tags: tidair/pysmurf-server-base:${{ steps.get_tag.outputs.tag }}
-          build-args: branch=${{ steps.get_tag.outputs.tag }}
+        id: build
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.SLACLAB_TOKEN }}
+        run: |
+          cd docker/server/
+          ./build.sh
+          cd -
 
   # Client docker
   deploy-client:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -55,7 +55,7 @@ jobs:
   # Validate the server docker image definitions
   docker-definitions:
     name: Docker Definition Validation
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # Checkout the code
       - name: Checkout code

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -138,6 +138,7 @@ jobs:
       # Build docker image
       - name: Build docker image
         run: |
+          mkdir docker/server/local_files
           docker image build \
             --file ./docker/server/Dockerfile \
             --build-arg branch=${{ steps.branch_name.outputs.branch }} \

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -81,7 +81,7 @@ jobs:
   test-docs:
     name: Documentation Build Tests
     runs-on: ubuntu-18.04
-    needs: checks   # Run only if checks passed
+    needs: [checks, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
       - name: Checkout code
@@ -110,7 +110,7 @@ jobs:
   test-server:
     name: Server Tests
     runs-on: ubuntu-18.04
-    needs: checks   # Run only if checks passed
+    needs: [checks, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
       - name: Checkout code
@@ -177,7 +177,7 @@ jobs:
   test-client:
     name: Client Tests
     runs-on: ubuntu-18.04
-    needs: checks   # Run only if checks passed
+    needs: [checks, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
       - name: Checkout code

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -55,11 +55,15 @@ jobs:
   # Validate the server docker image definitions
   docker-definitions:
     name: Docker Definition Validation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
-      # Checkout the code
+      # Checkout the code.
+      # We use ssh key authentication to be able to access other private
+      # repositories.
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.SLACLAB_KEY }}
 
       # Validate the server 'definitions.sh' file.
       # Note about tokens: In this stage we need to use the SLACLAB TOKEN

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,6 +57,10 @@ jobs:
     name: Docker Definition Validation
     runs-on: ubuntu-18.04
     steps:
+      # Checkout the code
+      - name: Checkout code
+        uses: actions/checkout@v2
+
       # Validate the server 'definitions.sh' file.
       # Note about tokens: In this stage we need to use the SLACLAB TOKEN
       # to be able to access the other private repositories (GITHUB_TOKEN

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -65,16 +65,18 @@ The `start_server.sh` script is in change of:
 You can address the target FPGA either using the card's ATCA shelfmanager's name and slot number (using arguments `-S` and `-N`), or by directly giving its IP address (using argument `-a`). If you use the shelfmanager name and slot number, the script will automatically detect the FPGA's IP address by reading the crate's ID and using the slot number, following the SLAC's convention: `IP address = 10.<crate's ID higher byte>.<crate's ID lower byte>.<100 + slot number>`. On the other hand, if you use the IP address, then the shelfmanager name and slot number arguments are ignored. The final IP address, either passed by the user or auto-detected by the script, is passed to the next startup script using the `-a` argument.
 
 #### Pyrogue ZIP file detection
-The script looks a pyrogue zip file to be present in `/tmp/fw/`. If found, the location of that file will be passed to the next startup script using the argument `-z`. If no zip file is found, the script will then look for a local checked out repository in the same location; if found, the python directories under it will be added to the PYTHONPATH environmental variable. The python directories must match these patterns:
+The script looks a pyrogue `zip` file to be present in `/tmp/fw/`. If found, the location of that file will be passed to the next startup script using the argument `-z`. If no zip file is found, the script will then look for a local checked out repository in the same location; if found, the python directories under it will be added to the PYTHONPATH environmental variable. The python directories must match these patterns:
 ```
 /tmp/fw/*/firmware/python/
 /tmp/fw/*/firmware/submodules/*/python/
 ```
 
-The docker images contains all these files in the `/tmp/fw/` directory. However, you can use a different version of these files by mounting a local copy from the host CPU inside the container as `/tmp/fw/`, which will replace the internal files.
+The docker images contains the `zip` file file in the `/tmp/fw/` directory. However, you can use a different version by mounting a local copy from the host CPU inside the container as `/tmp/fw/`, which will replace the internal files.
 
 #### Firmware version checking
-On the other hand, the scripts also looks for a MCS file in `/tmp/fw/`. The file name must include the short githash version of the firmware and an extension `mcs` or `mcs.gz`, following this expression: `*-<short-githash>.mcs[.gz]`. The script will also read the firmware short githash from the specified FPGA. If the version from the MCS file and the FPGA don't match, then the script will automatically load the MCS file into the FPGA. So, when starting the server you must have a local copy of this MCS file in the host CPU, and mount that directory inside the container as `/tmp/fw/`. This automatic version checking can be disabled either by passing the argument `-D|--no-check-fw`, or by addressing the FPGA by IP address instead of ATCA's shelfmanager_name/slot_number.
+On the other hand, the scripts also looks for a MCS file in `/tmp/fw/`. The file name must include the short githash version of the firmware and an extension `mcs` or `mcs.gz`, following this expression: `*-<short-githash>.mcs[.gz]`. The script will also read the firmware short githash from the specified FPGA. If the version from the MCS file and the FPGA don't match, then the script will automatically load the MCS file into the FPGA. This automatic version checking can be disabled either by passing the argument `-D|--no-check-fw`, or by addressing the FPGA by IP address instead of ATCA's shelfmanager_name/slot_number.
+
+The docker images contains the `mcs.gz` files in the `/tmp/fw/` directory. However, you can use a different version of these files by mounting a local copy from the host CPU inside the container as `/tmp/fw/`, which will replace the internal files.
 
 #### Hardware type auto-detection
 The script will try to auto-detect the type of carrier and AMC boards, and automatically generate server startup arguments based on the hardware type.

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -4,11 +4,19 @@
 
 Docker images for both the server and client applications are built automatically from this repository.
 
+For the server application, two docker images are generated:
+- An **stable** version called **pysmurf-server**. This image contains, besides the pysmurf server application, the firmware and its configuration files in it. The versions of these files are defined in the [definition.sh file](docker/server/definitions.sh).
+- A **base** version called **pysmurf-server-base**. Historically, this image contained only the pysmurf server application (without any firmware-related file) and was used for testing development firmware images. However, now this image is exactly the same **estable** image described above; as you can mount an external directory with development firmware files on top of the directory contained in the stable docker image when starting the container, there is not really necessary to maintained two different images. Although this image is not really necessary, is still being published to maintain backward compatibility with existing scripts; although you should use the stable image instead as this images will be deprecated in the future.
+
+On the other hand,
 The docker image for the server is called **pysmurf-server-base**, while the docker image for the client is called **pysmurf-client**.
 
 ## Building the image
 
-When a tag is pushed to this github repository, two new Docker images, one for the server and one for the client applications, are automatically built and push to their Dockehub repositories: [Dockerhub server repository](https://hub.docker.com/r/tidair/pysmurf-server-base) and [Dockerhub client repository](https://hub.docker.com/r/tidair/pysmurf-client) respectively, using GitHub Actions.
+When a tag is pushed to this github repository, three new Docker images, two for the server and one for the client applications, are automatically built and push to their Dockerhub repositories using GitHub Actions. The three Dockerhub repositories are:
+- Stable server repository: https://hub.docker.com/r/tidair/pysmurf-server
+- Base server repository: https://hub.docker.com/r/tidair/pysmurf-server-base, and
+- Client repository: https://hub.docker.com/r/tidair/pysmurf-client
 
 The resulting docker images are tagged with the same git tag string (as returned by `git describe --tags --always`).
 
@@ -19,7 +27,7 @@ The files used to generate the docker images are located in the [docker/server] 
 To get the docker image, first you will need to install the docker engine in you host OS. Then you can pull a copy by running:
 
 ```
-docker pull tidair/pysmurf-server-base:<TAG>
+docker pull tidair/pysmurf-server:<TAG>
 ```
 
 for the server, and
@@ -62,7 +70,8 @@ The script looks a pyrogue zip file to be present in `/tmp/fw/`. If found, the l
 /tmp/fw/*/firmware/python/
 /tmp/fw/*/firmware/submodules/*/python/
 ```
-So, when starting the container you must have either a local copy of a pyrogue zip file, or a local checked out repository, in the host CPU, and mount that directory inside the container as `/tmp/fw/`.
+
+The docker images contains all these files in the `/tmp/fw/` directory. However, you can use a different version of these files by mounting a local copy from the host CPU inside the container as `/tmp/fw/`, which will replace the internal files.
 
 #### Firmware version checking
 On the other hand, the scripts also looks for a MCS file in `/tmp/fw/`. The file name must include the short githash version of the firmware and an extension `mcs` or `mcs.gz`, following this expression: `*-<short-githash>.mcs[.gz]`. The script will also read the firmware short githash from the specified FPGA. If the version from the MCS file and the FPGA don't match, then the script will automatically load the MCS file into the FPGA. So, when starting the server you must have a local copy of this MCS file in the host CPU, and mount that directory inside the container as `/tmp/fw/`. This automatic version checking can be disabled either by passing the argument `-D|--no-check-fw`, or by addressing the FPGA by IP address instead of ATCA's shelfmanager_name/slot_number.
@@ -174,16 +183,16 @@ With all that in mind, the command to run the container looks something like thi
 ```
 docker run -ti --rm \
     -v <local_data_dir>:/data \
-    -v <local_fw_files_dir>:/tmp/fw/ \
-    tidair/pysmurf-server-base:<TAG> \
+    tidair/pysmurf-server:<TAG> \
     <arguments>
 ```
 
 Where:
 - **local_data_dir**: is a local directory in the host CPU where the persistent data can be written to if needed,
-- **local_fw_files_dir**: is a local directory in the host CPU with the firmware's MCS and pyrogue zip files,
 - **TAG**: is the tagged version of the container your want to run,
 - **arguments**: are the arguments passed to start_server.sh.
+
+Optionally, you can add an argument `-v <local_fw_files_dir>:/tmp/fw/` to the command above, where **local_fw_files_dir** is a local directory in the host CPU with the firmware's MCS and pyrogue zip files, if you want to use a different version respect to the ones includes in the docker image.
 
 For example, to start the server using PCIe communication, on the carrier card located in slot 2 on a crate with shelfmanager node name `shm-smrf-sp01`, you will use the following arguments:
 

--- a/docker/server/.gitignore
+++ b/docker/server/.gitignore
@@ -1,0 +1,1 @@
+local_files/

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,5 +1,13 @@
 FROM tidair/smurf-rogue:R2.8.3
 
+# Copy all firmware related files, which are in the local_files directory
+# Note: we use a wild card here ([]) to avoid the docker image to failed
+# if the 'local_files' directory does not exist (which is the case for some
+# of our CI tests). But we use a wild card that will only match the exact
+# 'local_files' directory.
+RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/
+COPY local_file[s] /tmp/fw/
+
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src
 RUN git clone https://github.com/slaclab/smurf-pcie.git -b v2.0.0
@@ -26,4 +34,8 @@ RUN mkdir -p /usr/local/src/pysmurf_utilities
 ADD scripts/* /usr/local/src/pysmurf_utilities/
 ENV PATH /usr/local/src/pysmurf_utilities:${PATH}
 
+# Set the working directory to the root
+WORKDIR /
+
+# Define the entrypoint
 ENTRYPOINT ["start_server.sh"]

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,12 +1,8 @@
 FROM tidair/smurf-rogue:R2.8.3
 
 # Copy all firmware related files, which are in the local_files directory
-# Note: we use a wild card here ([]) to avoid the docker image to failed
-# if the 'local_files' directory does not exist (which is the case for some
-# of our CI tests). But we use a wild card that will only match the exact
-# 'local_files' directory.
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/
-COPY local_file[s] /tmp/fw/
+COPY local_files /tmp/fw/
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src

--- a/docker/server/build.sh
+++ b/docker/server/build.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# This script builds the stable pysmurf server docker image, which includes the firmware and
+# configuration files, as well as pysmurf.
+#
+# The firmware and configuration files versions are defined in the 'definitions.sh' file, while the
+# version of pysmurf is extracted from this copy of the repository (using the  `git describe --tags
+# --always' command).
+#
+# This scripts downloads the firmware and configuration files into a temporal directory called
+# 'local_files' which is then used by the Dockerfile to generate the final docker image.
+# Finally, the docker image is pushed to Dockerhub, to the repository defined by the variables
+# ${dockerhub_org_name} and ${dockerhub_repo_stable}.
+#
+# A 'base' pysmurf server image is not longer generated, but in order to be backward compatible
+# with scripts that use that image, the same stable image is pushed to the Dockerhub repository
+# defined by ${dockerhub_org_name} and ${dockerhub_repo_base} as well; this image can be used as
+# base image as well, just like previous images. Finally, the docker images are tag with the same
+# tag from this repository.
+
+# Load the user definitions
+. definitions.sh
+
+# Call the validation script
+. validate.sh
+
+# Dockerhub repositories definitions
+dockerhub_org_name='tidair'
+dockerhub_repo_stable='pysmurf-server'
+dockerhub_repo_base='pysmurf-server-base'
+
+# Get the git tag, which will be used to tag the docker image.
+# At the moment, this script runs only on tagged releases.
+tag=`git describe --tags --always`
+
+# Create temporal local file directory to hold firmware and configuration
+# files which will later be copied to the docker image
+rm -rf local_files && mkdir local_files
+
+# Get the  MCS file from the assets
+echo "Downloading MCS file..."
+(cd local_files && get_private_asset ${fw_repo} ${fw_repo_tag} ${mcs_file_name}) || exit 1
+
+# Get the ZIP file from the assets
+echo "Downloading ZIP file..."
+(cd local_files && get_private_asset ${fw_repo} ${fw_repo_tag} ${zip_file_name}) || exit 1
+
+#  Get the configuration files. We clone the whole repository
+echo "Downloading configuration files..."
+git -C local_files clone -c advice.detachedHead=false ${config_repo} -b ${config_repo_tag} || exit 1
+
+# Build the docker image. This same image will be pushed to both the stable
+# and the base dockerhub repositories.
+echo "Building docker image..."
+docker image build --build-arg branch=${tag} -t docker_image . || exit 1
+
+# Tag and push the image to the stable dockerhub repository
+docker image tag docker_image ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}
+# docker image push ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}
+echo "Docker image '${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}' pushed"
+
+# Tag and push the image to the stable dockerhub repository
+docker image tag docker_image ${dockerhub_org_name}/${dockerhub_repo_base}:${tag}
+# docker image push ${dockerhub_org_name}/${dockerhub_repo_base}:${tag}
+echo "Docker image '${dockerhub_org_name}/${dockerhub_repo_base}:${tag}' pushed"

--- a/docker/server/build.sh
+++ b/docker/server/build.sh
@@ -56,10 +56,10 @@ docker image build --build-arg branch=${tag} -t docker_image . || exit 1
 
 # Tag and push the image to the stable dockerhub repository
 docker image tag docker_image ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}
-# docker image push ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}
+docker image push ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}
 echo "Docker image '${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}' pushed"
 
 # Tag and push the image to the stable dockerhub repository
 docker image tag docker_image ${dockerhub_org_name}/${dockerhub_repo_base}:${tag}
-# docker image push ${dockerhub_org_name}/${dockerhub_repo_base}:${tag}
+docker image push ${dockerhub_org_name}/${dockerhub_repo_base}:${tag}
 echo "Docker image '${dockerhub_org_name}/${dockerhub_repo_base}:${tag}' pushed"

--- a/docker/server/build.sh
+++ b/docker/server/build.sh
@@ -56,10 +56,10 @@ docker image build --build-arg branch=${tag} -t docker_image . || exit 1
 
 # Tag and push the image to the stable dockerhub repository
 docker image tag docker_image ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}
-docker image push ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}
+#docker image push ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}
 echo "Docker image '${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}' pushed"
 
 # Tag and push the image to the stable dockerhub repository
 docker image tag docker_image ${dockerhub_org_name}/${dockerhub_repo_base}:${tag}
-docker image push ${dockerhub_org_name}/${dockerhub_repo_base}:${tag}
+#docker image push ${dockerhub_org_name}/${dockerhub_repo_base}:${tag}
 echo "Docker image '${dockerhub_org_name}/${dockerhub_repo_base}:${tag}' pushed"

--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Define repositories:
+# ====================
+# These variables define the firmware and YML configuration repositories URLs.
+# Under normal conditions, you should not have to change these definitions.
+# - fw_repo: points to the firmware repository, which contains both the
+#   MCS and the ZIP files.
+# - config_repo: points to the configuration repository, which contains the
+#   the YML files.
+fw_repo=https://github.com/slaclab/cryo-det
+config_repo=https://github.com/slaclab/smurf_cfg
+
+# Define the firmware version:
+# ============================
+# Define the firmware version to use. This is were you define which firmware
+# version to include in the docker image.
+# - fw_repo_tag: Set this variable to the tag version you want to use.
+# - mcs_file_name: Set this variable to the MCS file name.
+# The name of the MCS file is independent from the tag name, so you need to
+# define it here. On the other hand, the ZIP file follows this naming convention:
+# 'rogue_${fw_repo_tag}.zip', so you don't need to define it here.
+# The files will be downloaded from the release list of assets.
+fw_repo_tag=MicrowaveMuxBpEthGen2_v1.0.4
+mcs_file_name=MicrowaveMuxBpEthGen2-0x00000100-20210106214208-mdewart-e8c5d46.mcs.gz
+
+# Define the configuration version:
+# =================================
+# Define the YML configuration version to use. This is were you define which
+# configuration version to include in the docker image.
+# - 'yml_repo_tag': Set this variable to the tag version you want to use.
+config_repo_tag=v1.4.0

--- a/docker/server/validate.sh
+++ b/docker/server/validate.sh
@@ -37,8 +37,9 @@ check_if_public_asset_exist()
 check_if_private_tag_exist()
 {
     # Need to insert the token in the url
-    local repo=$(echo $1 | sed -e "s|https://github.com/|git@github.com:|g")
+    local repo=$(echo $1 | sed -e "s|https://github.com/|https://"${GITHUB_TOKEN}"@github.com/|g")
     local tag=$2
+    echo repo
     git ls-remote --refs --tag ${repo} | grep -q refs/tags/${tag} > /dev/null
 }
 

--- a/docker/server/validate.sh
+++ b/docker/server/validate.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+
+# Validate definitions.sh
+
+#############
+# FUNCTIONS #
+#############
+# Check if a tag exists on a github public repository
+# Arguments:
+# - first: github public repository url,
+# - second: tag name
+check_if_public_tag_exist()
+{
+    local repo=$1
+    local tag=$2
+    git ls-remote --refs --tag ${repo} | grep -q refs/tags/${tag} > /dev/null
+}
+
+# Check if a asset file exist on a tag version on a github public repository
+# Arguments:
+# - first: github public repository url,
+# - second: tag name,
+# - third: asset file name
+check_if_public_asset_exist()
+{
+    local repo=$1
+    local tag=$2
+    local file=$3
+    curl --head --silent --fail ${repo}/releases/download/${tag}/${file} > /dev/null
+}
+
+# Check if a tag exists on a github pivate repository.
+# It requires ssh key authentication.
+# Arguments:
+# - first: github private repository url,
+# - second: tag name
+check_if_private_tag_exist()
+{
+    # Need to insert the token in the url
+    local repo=$(echo $1 | sed -e "s|https://github.com/|git@github.com:|g")
+    local tag=$2
+    git ls-remote --refs --tag ${repo} | grep -q refs/tags/${tag} > /dev/null
+}
+
+# Check if a asset file exist on a tag version on a github private repository.
+# It requires the access token to be defined in $GITHUB_TOKEN.
+# Arguments:
+# - first: github private repository url,
+# - second: tag name,
+# - third: asset file name
+check_if_private_asset_exist()
+{
+    local repo=$(echo $1 | sed -e "s|https://github.com|https://api.github.com/repos|g")
+    local tag=$2
+    local file=$3
+
+    # Search the asset ID in the specified release
+    local r=$(curl --silent --header "Authorization: token ${GITHUB_TOKEN}" "${repo}/releases/tags/${tag}")
+    eval $(echo "${r}" | grep -C3 "name.:.\+${file}" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
+
+    # return is the asset tag was found
+    [ "${id}" ]
+}
+
+# Download the asset file on a tagged version on a github private repository.
+# It requires the access token to be defined in $GITHUB_TOKEN.
+# Arguments:
+# - first: github private repository url,
+# - second: tag name,
+# - third: asset file name
+get_private_asset()
+{
+    local repo=$(echo $1 | sed -e "s|https://github.com|https://api.github.com/repos|g")
+    local tag=$2
+    local file=$3
+
+    # Check if the asset exist, and get it's ID
+    check_if_private_asset_exist ${repo} ${tag} ${file} || exit 1
+
+    echo "Downloading ${file}..."
+
+    # Try to download the asset
+    curl --fail --location --remote-header-name --remote-name --progress-bar \
+         --header "Authorization: token ${GITHUB_TOKEN}" \
+         --header "Accept: application/octet-stream" \
+         "${repo}/releases/assets/${id}"
+}
+
+# Check if file exist on a tag version on a github repository
+# Arguments:
+# - first: github repository url,
+# - second: tag name,
+# - third: file name (must be a full path on that repository)
+check_if_file_exist()
+{
+    local repo=$1
+    local tag=$2
+    local file=$3
+    curl --head --silent --fail ${repo}/blob/${tag}/${file} > /dev/null
+}
+
+# Exit with an error message, and with return code = 1
+exit_on_error()
+{
+    echo
+    echo "Validation failed! The 'definitions.sh' file is incorrect!"
+    echo
+    exit 1
+}
+
+# Exist with a success message and with return core = 0
+exit_on_success()
+{
+    echo
+    echo "Success! The 'definitions.sh' file is correct!"
+    echo
+}
+
+#############
+# MAIN BODY #
+#############
+
+# Load the user definitions
+. definitions.sh
+
+# Extra definitions, generated from the user definitions
+zip_file_name=rogue_${fw_repo_tag}.zip
+
+# Validate if repositories were defined
+echo "======================================================================================"
+echo "Repository names validation"
+echo "======================================================================================"
+
+printf "Checking if firmware repository was defined...      "
+if [ -z ${fw_repo} ]; then
+    echo "Failed!"
+    echo
+    echo "Firmware repository not define! Please check that the variable 'fw_repo' is defined in the 'definitions.sh' file."
+    exit_on_error
+fi
+echo "${fw_repo}"
+
+printf "Checking if configuration repository was defined... "
+if [ -z ${config_repo} ]; then
+    echo "Failed!"
+    echo
+    echo "Configuration repository not define! Please check that the variable 'config_repo' is defined in the 'definitions.sh' file."
+    exit_on_error
+fi
+echo "${config_repo}"
+
+# At this point all repository name definition are correct.
+echo "Done! All repository names were defined!"
+echo
+
+# Validate the firmware version
+echo "======================================================================================"
+echo "Firmware version validation"
+echo "======================================================================================"
+
+printf "Checking if the tag version was defined...          "
+if [ -z ${fw_repo_tag} ]; then
+    echo "Failed!"
+    echo
+    echo "Firmware tag version not defined! Please check that the variable 'fw_repo_tag' is defined in the 'definitions.sh' file."
+    exit_on_error
+fi
+echo "${fw_repo_tag}"
+
+printf "Checking if MCS file name was defined...            "
+if [ -z ${mcs_file_name} ]; then
+    echo "Failed!"
+    echo
+    echo "MCS file name not defined! Please check that the variable 'mcs_file_name' is defined in the 'definitions.sh' file."
+    exit_on_error
+fi
+echo "${mcs_file_name}"
+
+printf "Checking if release exist...                        "
+check_if_private_tag_exist ${fw_repo} ${fw_repo_tag}
+if [ $? != 0 ]; then
+    echo "Failed!"
+    echo
+    echo "Release '${fw_repo_tag}' does not exist in repository '${fw_repo}'!"
+    exit_on_error
+fi
+echo "Release exist!"
+
+printf "Checking if MCS file is in the list of assets...    "
+check_if_private_asset_exist ${fw_repo} ${fw_repo_tag} ${mcs_file_name}
+if [ $? != 0 ]; then
+    echo "Failed!"
+    echo
+    echo "File '${mcs_file_name}' does not exist in the assets list of release '${fw_repo_tag}'!"
+    exit_on_error
+fi
+echo "File exist!"
+
+printf "Checking if ZIP file is in the list of assets...    "
+check_if_private_asset_exist ${fw_repo} ${fw_repo_tag} ${zip_file_name}
+if [ $? != 0 ]; then
+    echo "Failed!"
+    echo
+    echo "File '${zip_file_name}' does not exist in the assets list of release '${fw_repo_tag}'!"
+    exit_on_error
+fi
+echo "File exist!"
+
+# At this points all the definition of the firmware version are correct.
+echo "Done! A correct firmware version was defined"
+echo
+
+
+# Validate the configuration version
+echo "======================================================================================"
+echo "Configuration version validation"
+echo "======================================================================================"
+
+printf "Checking if the tag version was defined...          "
+if [ -z ${config_repo_tag} ]; then
+    echo "Failed!"
+    echo
+    echo "Configuration tag version not defined! Please check that the variable 'config_repo_tag' is defined in the 'definitions.sh' file."
+fi
+echo "${config_repo_tag}"
+
+printf "Checking if release exist...                        "
+check_if_public_tag_exist ${config_repo} ${config_repo_tag}
+if [ $? != 0 ]; then
+    echo "Failed!"
+    echo
+    echo "Release '${config_repo_tag}' does not exist in repository '${config_repo}'!"
+    exit_on_error
+fi
+echo "Release exist!"
+
+# At this point all the definitions of the configuration version are correct.
+echo "Done! A correct configuration version was defined"
+
+# At this point all definition where correct
+exit_on_success

--- a/docker/server/validate.sh
+++ b/docker/server/validate.sh
@@ -32,12 +32,12 @@ check_if_public_asset_exist()
 # Check if a tag exists on a github pivate repository.
 # It requires ssh key authentication.
 # Arguments:
-# - first: github private repository url,
+# - first: github private repository url (https),
 # - second: tag name
 check_if_private_tag_exist()
 {
     # Need to insert the token in the url
-    local repo=$(echo $1 | sed -e "s|https://github.com/|git@github.com:|g")
+    local repo=$(echo $1 | sed -e "s|https://github.com/|https://${GITHUB_TOKEN}@github.com/|g")
     local tag=$2
     git ls-remote --refs --tag ${repo} | grep -q refs/tags/${tag} > /dev/null
 }
@@ -45,7 +45,7 @@ check_if_private_tag_exist()
 # Check if a asset file exist on a tag version on a github private repository.
 # It requires the access token to be defined in $GITHUB_TOKEN.
 # Arguments:
-# - first: github private repository url,
+# - first: github private repository url (https),
 # - second: tag name,
 # - third: asset file name
 check_if_private_asset_exist()
@@ -65,7 +65,7 @@ check_if_private_asset_exist()
 # Download the asset file on a tagged version on a github private repository.
 # It requires the access token to be defined in $GITHUB_TOKEN.
 # Arguments:
-# - first: github private repository url,
+# - first: github private repository url (https),
 # - second: tag name,
 # - third: asset file name
 get_private_asset()

--- a/docker/server/validate.sh
+++ b/docker/server/validate.sh
@@ -37,10 +37,9 @@ check_if_public_asset_exist()
 check_if_private_tag_exist()
 {
     # Need to insert the token in the url
-    local repo=$(echo $1 | sed -e "s|https://github.com/|https://"${GITHUB_TOKEN}"@github.com/|g")
+    local repo=$(echo $1 | sed -e "s|https://github.com/|git@github.com:|g")
     local tag=$2
-    echo ${repo}
-    git ls-remote --refs --tag ${repo} | grep -q refs/tags/${tag}
+    git ls-remote --refs --tag ${repo} | grep -q refs/tags/${tag} > /dev/null
 }
 
 # Check if a asset file exist on a tag version on a github private repository.

--- a/docker/server/validate.sh
+++ b/docker/server/validate.sh
@@ -37,7 +37,7 @@ check_if_public_asset_exist()
 check_if_private_tag_exist()
 {
     # Need to insert the token in the url
-    local repo=$(echo $1 | sed -e "s|https://github.com/|https://${GITHUB_TOKEN}@github.com/|g")
+    local repo=$(echo $1 | sed -e "s|https://github.com/|git@github.com:|g")
     local tag=$2
     git ls-remote --refs --tag ${repo} | grep -q refs/tags/${tag} > /dev/null
 }

--- a/docker/server/validate.sh
+++ b/docker/server/validate.sh
@@ -39,7 +39,7 @@ check_if_private_tag_exist()
     # Need to insert the token in the url
     local repo=$(echo $1 | sed -e "s|https://github.com/|https://"${GITHUB_TOKEN}"@github.com/|g")
     local tag=$2
-    echo repo
+    echo ${repo}
     git ls-remote --refs --tag ${repo} | grep -q refs/tags/${tag} > /dev/null
 }
 

--- a/docker/server/validate.sh
+++ b/docker/server/validate.sh
@@ -40,7 +40,7 @@ check_if_private_tag_exist()
     local repo=$(echo $1 | sed -e "s|https://github.com/|https://"${GITHUB_TOKEN}"@github.com/|g")
     local tag=$2
     echo ${repo}
-    git ls-remote --refs --tag ${repo} | grep -q refs/tags/${tag} > /dev/null
+    git ls-remote --refs --tag ${repo} | grep -q refs/tags/${tag}
 }
 
 # Check if a asset file exist on a tag version on a github private repository.

--- a/releaseGen.py
+++ b/releaseGen.py
@@ -45,7 +45,7 @@ oldTag = git.Git('.').describe('--abbrev=0','--tags',newTag + '^')
 loginfo = git.Git('.').log(f"{oldTag}...{newTag}",'--grep','Merge pull request')
 
 # Grouping of recors
-records= odict({'Core':      odict({'Bug' : [], 'Enhancement':[], 'Interface-change':[]}),
+records= odict({'Core':      odict({'Bug' : [], 'Enhancement':[], 'Interface-change':[], 'Firmware-change':[]}),
                 'Client':    odict({'Bug' : [], 'Enhancement':[], 'Interface-change':[]}),
                 'Other':     odict({'Bug' : [], 'Enhancement':[], 'Interface-change':[]}),
                 'Unlabeled': [] })
@@ -112,13 +112,13 @@ for line in loginfo.splitlines():
         if entry['Labels'] is not None:
             # if the PR does not have a 'core' nor a 'client' label, add it to the 'Other' section
             if not any(x in entry['Labels'] for x in ['core', 'client']):
-                for label in ['Bug','Enhancement', 'Interface-change']:
+                for label in ['Bug','Enhancement', 'Interface-change', 'Firmware-change']:
                     if label.lower() in entry['Labels']:
                         records['Other'][label].append(entry)
                         found = True
             else:
                 for section in ['Client','Core']:
-                    for label in ['Bug','Enhancement', 'Interface-change']:
+                    for label in ['Bug','Enhancement', 'Interface-change', 'Firmware-change']:
                         if section.lower() in entry['Labels'] and label.lower() in entry['Labels']:
                             records[section][label].append(entry)
                             found = True
@@ -136,7 +136,7 @@ md = f'# Pull Requests Since {oldTag}\n'
 for section in ['Client','Core', 'Other']:
     subSec = ""
 
-    for label in ['Interface-change', 'Bug','Enhancement']:
+    for label in ['Firmware-change', 'Interface-change', 'Bug','Enhancement']:
         subLab = ""
         entries = sorted(records[section][label], key=lambda v : v['changes'], reverse=True)
         for entry in entries:


### PR DESCRIPTION
## Issue
This PR resolves [ESCRYODET-818](https://jira.slac.stanford.edu/browse/ESCRYODET-818).

## Description

This PR brings a simplified version of the **stable** docker image generation from the [pysmurf-stable-docker](https://github.com/slaclab/pysmurf-stable-docker). With this, the **stable** images will be generated from this repository instead. The firmware version is defined in the [definitions.sh file](docker/server/definitions.sh). So now, the stable images will be generated from this repository, when a tag is pushed to it.

On the other hand, now I realize that it not necessary to have a **base** image (the image previously generate from this repository, which didn't contained any firmware file in it). We can simply use the stable image and mount an external FW image in it, when running a **system-dev-fw**. However, in order to maintain backward compatible with existing release scripts, the same generated **stable** image is renamed and pushed to the base repository as well, so that the user can use either the `tidair/pysmurf-server-base` or the `tidair/pysmurf-server` image (both images will be the same).  In the future, we can deprecated the **base** image.

Additionally, as now we can defined which firmware version is release with each pysmurf release, I added a new PR label called **firmware-change** will be automatically applied to PRs that change the `definitions.sh` file. The release note will now have a new section on top describing the PR that changed the firmware version.

## Does this PR break any interface?
- [ ] Yes
- [X] No
