### PR TITLE
Update FW to version v1.0.6 (8ccb67e)

### DIFF
--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -21,7 +21,7 @@ config_repo=https://github.com/slaclab/smurf_cfg
 # define it here. On the other hand, the ZIP file follows this naming convention:
 # 'rogue_${fw_repo_tag}.zip', so you don't need to define it here.
 # The files will be downloaded from the release list of assets.
-fw_repo_tag=MicrowaveMuxBpEthGen2_v1.0.5
+fw_repo_tag=MicrowaveMuxBpEthGen2_v1.0.6
 mcs_file_name=MicrowaveMuxBpEthGen2-0x00000100-20210504090351-jvasquez-8ccb67e.mcs.gz
 
 # Define the configuration version:


### PR DESCRIPTION
## Issue
There is not open issue for this PR.

## Description

This PR updates the FW to version [v1.0.6 (8ccb67e)](https://github.com/slaclab/cryo-det/releases/tag/MicrowaveMuxBpEthGen2_v1.0.6).

This version of the FW fixes a wrong eta phase shift done in rogue code (see https://github.com/slaclab/pysmurf/pull/643). This change only changes rogue code, so the firmware image (i.e. MCS file) is the same respect to the previous version. 

## Does this PR break any interface?
- [ ] Yes
- [X] No