### PR TITLE
Adding config_file documentation and phase flipping optional variable in find_freq

### DIFF
--- a/README.config_file.md
+++ b/README.config_file.md
@@ -1,0 +1,68 @@
+The configuration file defines basic default parameters that are implementation specific. There is one configuration file per physical hardware setup.
+
+# Organization
+
+The configuration files are stored in the `cfg_files` folder in the pysmurf git repository ([https://github.com/slaclab/pysmurf/tree/main/cfg_files](https://github.com/slaclab/pysmurf/tree/main/cfg_files)). There are subfolders for each institution/site. Some subdirectories also have a README file that describes the config file. We encourage this to be included so the specific details of the files can be understood in the future. 
+
+# Quick Start
+
+1. If it does not exist, make a directory for your site. 
+2. Copy the default config file
+3. Check amplifier values
+
+# Important Variables
+
+## init
+
+### band_#
+
+- `refPhaseDelay` - The phase delay parameter. Solve for this using the function `S.estimate_phase_delay(band)`
+- `refPhaseDelayFine` - The fine phase delay parameter. Solve for this using the function `S.estimate_phase_delay(band)`
+- `att_uc` - The upconverter (DAC) attenuator
+- `att_dc` - The downconverter (ADC) attenuator
+- `amplitude_scale` - The probe tone power.
+
+## bad_mask
+
+A list of bad channels. Resonators in the bad mask will not be turned on. The bad mask is defined by frequency. Below is a bad mask that excludes resonators between 5000-5100 MHz and 5171.64-5171.74 MHz.  
+
+```yaml
+"bad_mask": {
+"0": [
+	5000,
+  5100
+      ],
+"1": [
+	5171.64,
+	5171.74
+]
+}
+```
+
+## amplifier
+
+The 4K and 50K amplifier bias values. This also holds the conversion between volts and DAC bits.
+
+## pic_to_bias_group
+
+The relation between PIC on the cryocard and bias group pair. See the documenation [here](https://confluence.slac.stanford.edu/pages/viewpage.action?spaceKey=SMuRF&title=Cryostat+board).
+
+## bias_group_to_pair
+
+The TES bias uses a bipolar pair of DACs. This defines the pair of DACs that form a bias group.
+
+## constant
+
+- `pA_per_phi0` - The conversion between units oh phi0 and pA. This is number depends on the resonator/mulitplexing chips installed.
+
+## timing
+
+## Others
+
+These are other variables that are in the top level of the config table. Several of these should probably be moved, but for now just know they exist.
+
+- `R_sh` - The resistance of the shunt resistor in Ohms
+- `bias_line_resistance`- The resistance of cabling from cryocard to the TES.
+- `tune_dir`- The directory where the tuning files are stored. Tuning files define the resonator frequencies and the channel assignments
+- `default_data_dir`- The directory where the output data is stored. Output data can include anything from eta-scans to tracked resonator timestreams
+- `high_low_current_ratio` - The ratio between the high current mode (no filtering) and low current mode (with lowpass filter)

--- a/README.config_file.md
+++ b/README.config_file.md
@@ -7,8 +7,12 @@ The configuration files are stored in the `cfg_files` folder in the pysmurf git 
 # Quick Start
 
 1. If it does not exist, make a directory for your site. 
-2. Copy the default config file
-3. Check amplifier values
+2. Copy the template config file from `cfg_files/template/template.cfg` into your directory you created in step 1. 
+3. Update the amplifier values if needed.
+4. If you know it, update the `bias_line_resistance` and `R_sh` fields.
+5. Save
+
+You should be able to call this config file when you instantiate your `SmurfControl` object. One of the first steps you'll do is run `estimate_phase_delay`. You can save the outputs into your config file so you will not need to run it in the future. 
 
 # Important Variables
 
@@ -56,6 +60,8 @@ The TES bias uses a bipolar pair of DACs. This defines the pair of DACs that for
 - `pA_per_phi0` - The conversion between units oh phi0 and pA. This is number depends on the resonator/mulitplexing chips installed.
 
 ## timing
+
+This defines which timing master to use. The available values are "ext_ref" and "backplane". 
 
 ## Others
 

--- a/cfg_files/b33/experiment_2xLB_testing_Feb2021.cfg
+++ b/cfg_files/b33/experiment_2xLB_testing_Feb2021.cfg
@@ -1,0 +1,488 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_4" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_5" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_6" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_7" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask" : {
+},
+
+"amplifier": {
+	     "hemt_Vg" : 0.490,
+	     "bit_to_V_hemt" : 1.92e-6,
+	     "hemt_Id_offset" : 0.12891,
+	     "LNA_Vg" : -0.75,
+	     # 32 if using a C02 cryostat card.  Some C01s were
+	     # kludged to provide a 50k gate voltage for ASU 50K LNAs
+	     # in early testing.  For those, use 2.	     
+	     "dac_num_50k" : 32,
+	     "50k_Id_offset" : 0,
+	     "bit_to_V_50k" : 3.88e-6,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24],
+        "12" : [25,26],
+        "13" : [27,28],
+        "14" : [29,30]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 25479,
+"high_low_current_ratio" : 12.50,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [3],
+
+"tune_band" : {
+	"reset_rate_khz" : 4.0,
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.495,
+	"delta_freq" : {
+		    "0" : 0.02,	
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02,
+		    "4" : 0.02,
+		    "5" : 0.02,
+		    "6" : 0.02,
+		    "7" : 0.02
+	},		
+	"lms_freq": {
+		    "0" : 16500,	
+		    "1" : 16500,
+		    "2" : 16500,
+		    "3" : 16500,
+		    "4" : 16500,
+		    "5" : 16500,
+		    "6" : 16500,
+		    "7" : 16500
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,	
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05,
+		    "4" : 0.05,
+		    "5" : 0.05,
+		    "6" : 0.05,
+		    "7" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,		    
+		    "2" : 0.98,
+		    "3" : 0.98,
+		    "4" : 0.98,
+		    "5" : 0.98,
+		    "6" : 0.98,
+		    "7" : 0.98		    
+	},	
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,		    
+		    "2" : 1e-4,
+		    "3" : 1e-4,
+		    "4" : 1e-4,
+		    "5" : 1e-4,
+		    "6" : 1e-4,
+		    "7" : 1e-4		    
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        },
+	"gradient_descent_converge_hz": {
+		    "0" : 500,
+		    "1" : 500,		    
+		    "2" : 500,
+		    "3" : 500,
+		    "4" : 500,
+		    "5" : 500,
+		    "6" : 500,
+		    "7" : 500		    
+        },
+	"gradient_descent_step_hz": {
+		    "0" : 1000,
+		    "1" : 1000,		    
+		    "2" : 1000,
+		    "3" : 1000,
+		    "4" : 1000,
+		    "5" : 1000,
+		    "6" : 1000,
+		    "7" : 1000		    
+        },
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,		    
+		    "2" : 0,
+		    "3" : 0,
+		    "4" : 0,
+		    "5" : 0,
+		    "6" : 0,
+		    "7" : 0
+        },
+	"gradient_descent_momentum": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1
+        },	
+	"eta_scan_del_f": {
+                    "0": 5000,
+                    "1": 5000,
+                    "2": 5000,
+                    "3": 5000,
+                    "4": 5000,
+                    "5": 5000,
+                    "6": 5000,
+                    "7": 5000		    
+        },
+        "eta_scan_amplitude":{
+                    "0" : 12,
+                    "1" : 12,
+                    "2" : 12,
+                    "3" : 12,
+                    "4" : 12,
+                    "5" : 12,
+                    "6" : 12,		    
+                    "7" : 12		    
+        },
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "ext_ref"
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 0,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+# For remote commanding
+#"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/cfg_files/b33/experiment_b33_lbOnlyBay0.cfg
+++ b/cfg_files/b33/experiment_b33_lbOnlyBay0.cfg
@@ -1,0 +1,304 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		# Measured for 8234f45 by SWH on 8/1/19
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 16,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 6,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		# Measured for 8234f45 by SWH on 8/1/19
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 19,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 6,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		# Measured for 8234f45 by SWH on 8/1/19
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 11,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 6,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		# Measured for 8234f45 by SWH on 8/1/19
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 16,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 6,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask" : {
+},
+
+"amplifier": {
+	     "hemt_Vg" : -1.12,
+	     "bit_to_V_hemt" : 3.8592e-06,
+	     "hemt_Id_offset" : 0.941,
+	     "LNA_Vg" : -0.74,
+	     "50k_Id_offset" : 0.4963,	     
+	     # 32 if using a C02 cryostat card.  Some C01s were
+	     # kludged to provide a 50k gate voltage for ASU 50K LNAs
+	     # in early testing.  For those, use 2.	     
+	     "dac_num_50k" : 32,
+	     "bit_to_V_50k" : 3.8592e-06,
+	     "hemt_gate_min_voltage" : -1.2,
+	     "hemt_gate_max_voltage" :  0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24],
+        "12" : [25,26],
+        "13" : [27,28],
+        "14" : [29,30]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 15800,
+"high_low_current_ratio" : 6.08,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [7],
+
+"tune_band" : {
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.489,
+	"reset_rate_khz": 4.0,
+	"delta_freq": {
+		    "0" : 0.02,	
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02
+        },		
+	"lms_freq": {
+		    "0" : 16500,	
+		    "1" : 19945,
+		    "2" : 19986,
+		    "3" : 20218
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,	
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,		    
+		    "2" : 0.98,
+		    "3" : 0.98
+	},
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,		    
+		    "2" : 1e-4,
+		    "3" : 1e-4
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1
+        },
+	"gradient_descent_converge_hz":{
+		    "0" : 500,
+		    "1" : 500,
+		    "2" : 500,
+		    "3" : 500
+	},
+	"gradient_descent_step_hz":{
+		    "0" : 1000,
+		    "1" : 1000,
+		    "2" : 1000,
+		    "3" : 1000
+	},
+	"gradient_descent_momentum":{
+		    "0" : 1,
+		    "1" : 1,
+		    "2" : 1,
+		    "3" : 1
+	},
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,
+		    "2" : 0,
+		    "3" : 0
+	},
+	"eta_scan_del_f": {
+		    "0": 5000,
+		    "1": 5000,
+		    "2": 5000,
+		    "3": 5000
+	},
+	"eta_scan_amplitude":{
+		    "0" : 12,
+		    "1" : 12,
+		    "2" : 12,
+		    "3" : 12
+	},
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "ext_ref"
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 4,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+# For remote commanding
+#"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/cfg_files/b33/experiment_b33_lbOnlyBay0_flip_hemt_polarity.cfg
+++ b/cfg_files/b33/experiment_b33_lbOnlyBay0_flip_hemt_polarity.cfg
@@ -1,0 +1,304 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		# Measured for 8234f45 by SWH on 8/1/19
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 16,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 6,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		# Measured for 8234f45 by SWH on 8/1/19
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 19,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 6,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		# Measured for 8234f45 by SWH on 8/1/19
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 11,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 6,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		# Measured for 8234f45 by SWH on 8/1/19
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 16,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 6,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask" : {
+},
+
+"amplifier": {
+	     "hemt_Vg" : 1.00,
+	     "bit_to_V_hemt" : 3.8592e-06,
+	     "hemt_Id_offset" : 0.941,
+	     "LNA_Vg" : -0.74,
+	     "50k_Id_offset" : 0.4963,	     
+	     # 32 if using a C02 cryostat card.  Some C01s were
+	     # kludged to provide a 50k gate voltage for ASU 50K LNAs
+	     # in early testing.  For those, use 2.	     
+	     "dac_num_50k" : 32,
+	     "bit_to_V_50k" : 3.8592e-06,
+	     "hemt_gate_min_voltage" : -1.2,
+	     "hemt_gate_max_voltage" :  0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24],
+        "12" : [25,26],
+        "13" : [27,28],
+        "14" : [29,30]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 15800,
+"high_low_current_ratio" : 6.08,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [7],
+
+"tune_band" : {
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.489,
+	"reset_rate_khz": 4.0,
+	"delta_freq": {
+		    "0" : 0.02,	
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02
+        },		
+	"lms_freq": {
+		    "0" : 16500,	
+		    "1" : 19945,
+		    "2" : 19986,
+		    "3" : 20218
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,	
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,		    
+		    "2" : 0.98,
+		    "3" : 0.98
+	},
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,		    
+		    "2" : 1e-4,
+		    "3" : 1e-4
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1
+        },
+	"gradient_descent_converge_hz":{
+		    "0" : 500,
+		    "1" : 500,
+		    "2" : 500,
+		    "3" : 500
+	},
+	"gradient_descent_step_hz":{
+		    "0" : 1000,
+		    "1" : 1000,
+		    "2" : 1000,
+		    "3" : 1000
+	},
+	"gradient_descent_momentum":{
+		    "0" : 1,
+		    "1" : 1,
+		    "2" : 1,
+		    "3" : 1
+	},
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,
+		    "2" : 0,
+		    "3" : 0
+	},
+	"eta_scan_del_f": {
+		    "0": 5000,
+		    "1": 5000,
+		    "2": 5000,
+		    "3": 5000
+	},
+	"eta_scan_amplitude":{
+		    "0" : 12,
+		    "1" : 12,
+		    "2" : 12,
+		    "3" : 12
+	},
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "ext_ref"
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 4,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+# For remote commanding
+#"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/cfg_files/b33/smurf_startup.cfg
+++ b/cfg_files/b33/smurf_startup.cfg
@@ -1,0 +1,82 @@
+cpwd=$PWD
+
+# name of shelf manager (SMuRF server default is shm-smrf-sp01).
+shelfmanager=shm-smrf-sp01
+crate_id=1
+
+# COMTEL max fan level is 100, ASIS is 15, ELMA is 15 # We're using an
+#ELMA crate on campus right now.
+max_fan_level=8
+# Badly named ; actually only sets the max fan level to the value
+# specified above by max_fan_level.
+set_crate_fans_to_full=true
+
+# If double_setup=true, runs pysmurf setup twice.  Only supported in
+# serial setup mode.  Added to help resolve the "double tap"
+# configuration issue we see on some systems, where we find we have to
+# run setup twice consecutively in order to get the JESD to properly
+# configure.
+double_setup=false
+# If attach_at_end=true, attaches to the smurf tmux session after done
+# configuring all slots in the same terminal that the user first ran
+# shawnhammer from.
+attach_at_end=true
+# Whether or not to run pysmurf.setup after instantiating a pysmurf
+# object.
+configure_pysmurf=true
+# If reboot=true, deactivates and re-activates the carriers in each
+# slot.
+reboot=true
+# If using_timing_master=true, checks if timing master docker is up
+# (looks for a docker named "tpg_ioc".  If none found, exits without
+# proceeding to configure.  Also displays tpg_ioc docker logs in a
+# split of the tmux smurf:utils panel.
+using_timing_master=false
+# If disable_streaming=true, runs pysmurf set_stream_enable(0) after
+# setup.  Only supported in serial setup mode.
+disable_streaming=false
+# If write_config=true, writes the rogue configuration file to
+# /data/smurf_data/${ctime}_slot${slot_number}.yml
+write_config=false
+# Whether or not to start atca_monitor docker.  Assumes atca_monitor
+# docker can be started by /home/cryo/docker/atca_monitor/run.sh
+# script.
+start_atca_monitor=false
+# If parallel_setup=true, will run setup on all slots simultaneously.
+# Otherwise, setup will be run on each slot serially.
+parallel_setup=false
+
+# Directory on server file system of pysmurf docker directory.  Will
+# use the run.sh script in this directory to instantiate pysmurf
+# dockers.
+pysmurf=/home/cryo/docker/pysmurf/dev/v4.1.0
+
+# only used if slot_cfgs is not provided.  Assumes
+# rogue directory is /home/cryo/docker/smurf/current
+# for every slot.
+#slots_in_configure_order=(5)
+
+# slot_cfgs first column is slot number (1-7)
+#           2nd column is rogue docker directory
+#(optional) 3rd column is pysmurf cfg.  If specified for any slot,
+#     	    must be explicitly specified for all slots.  If the
+#     	    pysmurf cfg file is in the pysmurf directory, can specify
+#     	    it relative to it ;
+#     	    e.g. cfg_files/stanford/experiment_fp30_cc02-03_lbOnlyBay0.cfg
+unset slot_cfgs
+read -r -d '' slot_cfgs << EOM
+2    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/b33/experiment_b33_lbOnlyBay0.cfg
+EOM
+
+# can either specify a global pysmurf init script
+# for every slot, or specify the pysmurf cfg
+# to use for each slot in the 3rd column of
+# slot_cfgs above.  If pysmurf cfg is already
+# provided in 3rd column of slot_cfgs, it will
+# override the global pysmurf_init_script
+# variable.
+#pysmurf_init_script=scratch/shawn/scripts/init_stanford.py
+
+tmux_session_name=smurf
+
+#script_to_run=scratch/shawn/deterministic_latency.py

--- a/cfg_files/b33/smurf_startup_c03-15.cfg
+++ b/cfg_files/b33/smurf_startup_c03-15.cfg
@@ -1,0 +1,82 @@
+cpwd=$PWD
+
+# name of shelf manager (SMuRF server default is shm-smrf-sp01).
+shelfmanager=shm-smrf-sp01
+crate_id=1
+
+# COMTEL max fan level is 100, ASIS is 15, ELMA is 15 # We're using an
+#ELMA crate on campus right now.
+max_fan_level=8
+# Badly named ; actually only sets the max fan level to the value
+# specified above by max_fan_level.
+set_crate_fans_to_full=true
+
+# If double_setup=true, runs pysmurf setup twice.  Only supported in
+# serial setup mode.  Added to help resolve the "double tap"
+# configuration issue we see on some systems, where we find we have to
+# run setup twice consecutively in order to get the JESD to properly
+# configure.
+double_setup=false
+# If attach_at_end=true, attaches to the smurf tmux session after done
+# configuring all slots in the same terminal that the user first ran
+# shawnhammer from.
+attach_at_end=true
+# Whether or not to run pysmurf.setup after instantiating a pysmurf
+# object.
+configure_pysmurf=true
+# If reboot=true, deactivates and re-activates the carriers in each
+# slot.
+reboot=true
+# If using_timing_master=true, checks if timing master docker is up
+# (looks for a docker named "tpg_ioc".  If none found, exits without
+# proceeding to configure.  Also displays tpg_ioc docker logs in a
+# split of the tmux smurf:utils panel.
+using_timing_master=false
+# If disable_streaming=true, runs pysmurf set_stream_enable(0) after
+# setup.  Only supported in serial setup mode.
+disable_streaming=false
+# If write_config=true, writes the rogue configuration file to
+# /data/smurf_data/${ctime}_slot${slot_number}.yml
+write_config=false
+# Whether or not to start atca_monitor docker.  Assumes atca_monitor
+# docker can be started by /home/cryo/docker/atca_monitor/run.sh
+# script.
+start_atca_monitor=false
+# If parallel_setup=true, will run setup on all slots simultaneously.
+# Otherwise, setup will be run on each slot serially.
+parallel_setup=false
+
+# Directory on server file system of pysmurf docker directory.  Will
+# use the run.sh script in this directory to instantiate pysmurf
+# dockers.
+pysmurf=/home/cryo/docker/pysmurf/dev/v4.1.0
+
+# only used if slot_cfgs is not provided.  Assumes
+# rogue directory is /home/cryo/docker/smurf/current
+# for every slot.
+#slots_in_configure_order=(5)
+
+# slot_cfgs first column is slot number (1-7)
+#           2nd column is rogue docker directory
+#(optional) 3rd column is pysmurf cfg.  If specified for any slot,
+#     	    must be explicitly specified for all slots.  If the
+#     	    pysmurf cfg file is in the pysmurf directory, can specify
+#     	    it relative to it ;
+#     	    e.g. cfg_files/stanford/experiment_fp30_cc02-03_lbOnlyBay0.cfg
+unset slot_cfgs
+read -r -d '' slot_cfgs << EOM
+2    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/b33/experiment_2xLB_testing_Feb2021.cfg
+EOM
+
+# can either specify a global pysmurf init script
+# for every slot, or specify the pysmurf cfg
+# to use for each slot in the 3rd column of
+# slot_cfgs above.  If pysmurf cfg is already
+# provided in 3rd column of slot_cfgs, it will
+# override the global pysmurf_init_script
+# variable.
+#pysmurf_init_script=scratch/shawn/scripts/init_stanford.py
+
+tmux_session_name=smurf
+
+#script_to_run=scratch/shawn/deterministic_latency.py

--- a/cfg_files/template/template.cfg
+++ b/cfg_files/template/template.cfg
@@ -1,0 +1,295 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"bandDelayUs" : 8.8,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"bandDelayUs" : 8.8,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"bandDelayUs" : 8.8,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"bandDelayUs" : 8.8,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask": {
+	"0": [5000, 5100],
+	"1": [5171.64, 5171.74]
+},
+
+"amplifier": {
+	     "hemt_Vg" : 0.28,
+	     "bit_to_V_hemt" : 1.93e-06,
+	     "hemt_Id_offset" : 0.2643,
+	     "LNA_Vg" : -0.79,
+	     "50k_Id_offset" : 0.0,
+	     # 32 if using a C02 cryostat card.  Some C01s were
+	     # kludged to provide a 50k gate voltage for ASU 50K LNAs
+	     # in early testing.  For those, use 2.
+	     "dac_num_50k" : 30,
+	     "bit_to_V_50k" : 3.38e-06,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 15800,
+"high_low_current_ratio" : 6.08,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [7],
+
+"tune_band" : {
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.489,
+	"reset_rate_khz": 4.0,
+	"delta_freq": {
+		    "0" : 0.02,
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02
+        },
+	"lms_freq": {
+		    "0" : 16500,
+		    "1" : 19945,
+		    "2" : 19986,
+		    "3" : 20218
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,
+		    "2" : 0.98,
+		    "3" : 0.98
+	},
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,
+		    "2" : 1e-4,
+		    "3" : 1e-4
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,
+		    "2" : 1,
+		    "3" : 1
+        },
+	"gradient_descent_converge_hz":{
+		    "0" : 500,
+		    "1" : 500,
+		    "2" : 500,
+		    "3" : 500
+	},
+	"gradient_descent_step_hz":{
+		    "0" : 1000,
+		    "1" : 1000,
+		    "2" : 1000,
+		    "3" : 1000
+	},
+	"gradient_descent_momentum":{
+		    "0" : 1,
+		    "1" : 1,
+		    "2" : 1,
+		    "3" : 1
+	},
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,
+		    "2" : 0,
+		    "3" : 0
+	},
+	"eta_scan_del_f": {
+		    "0": 5000,
+		    "1": 5000,
+		    "2": 5000,
+		    "3": 5000
+	},
+	"eta_scan_amplitude":{
+		    "0" : 12,
+		    "1" : 12,
+		    "2" : 12,
+		    "3" : 12
+	},
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,
+		    "2" : 1,
+		    "3" : 1
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "ext_ref"
+},
+
+"fs" : 200.0,
+
+# This section is for smurf_to_mce, the transmission from SMuRF to the
+# Keck GCP. This is mostly depracated.
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 4,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -876,7 +876,6 @@ class SmurfTuneMixin(SmurfBase):
         grad = np.convolve(angle, np.repeat([1,-1], grad_kernel_width),
             mode='same')
 
-
         amp = np.abs(resp)
 
         grad_loc = np.array(grad > grad_cut)

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3714,7 +3714,7 @@ class SmurfTuneMixin(SmurfBase):
             Whether to make a plot.
         save_plot : bool, optional, default True
             Whether to save the plot to self.plot_dir.
-        show_plot : bool, optional, defaullt False
+        show_plot : bool, optional, default False
             Whether to show the plot to screen.
         plotname_append : str, optional, default ''
             Appended to the default plot filename.

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -819,6 +819,8 @@ class SmurfTuneMixin(SmurfBase):
         flip_phase : bool, optional, default False
             Whether to flip the sign of phase before
             evaluating the gradient cut.
+        plot_phase : bool, optional, default False
+            Whether to generate a plot showing just the phase information
         amp_cut : float, optional, default 0.25
             The fractional distance from the median value to decide
             whether there is a resonance.
@@ -901,6 +903,7 @@ class SmurfTuneMixin(SmurfBase):
                 if 1-amp[idx]/med_amp[idx] > amp_cut:
                     peak = np.append(peak, idx)
 
+        # Plot the phase information
         if plot_phase:
             plt.figure()
             plt.plot(freq, angle)
@@ -3699,6 +3702,8 @@ class SmurfTuneMixin(SmurfBase):
         flip_phase : bool, optional, default False
             Whether to flip the sign of phase before
             evaluating the gradient cut.
+        plot_phase : bool, optional, default False
+            Whether to generate a plot showing just the phase information
         freq_min : float, optional, default -2.5e8
             The minimum frequency relative to the center of the band
             to look for resonances. Units of Hz.

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3673,10 +3673,9 @@ class SmurfTuneMixin(SmurfBase):
             window=500, grad_cut=0.05, amp_cut=0.25, freq_min=-2.5E8,
             flip_phase=False, grad_kernel_width=8,
             freq_max=2.5E8, make_plot=False, save_plot=True,
-            show_plot=False,
-            plotname_append='',
+            show_plot=False, plotname_append='',
             band=None, make_subband_plot=False, subband_plot_with_slow=False,
-                      timestamp=None, pad=2, min_gap=2, plot_phase=False):
+            timestamp=None, pad=2, min_gap=2, plot_phase=False):
         """
         find the peaks within each subband requested from a fullbandamplsweep
 

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -801,7 +801,7 @@ class SmurfTuneMixin(SmurfBase):
             band=None, subband=None, make_subband_plot=False,
             subband_plot_with_slow=False, timestamp=None, pad=50, min_gap=100,
             plot_title=None, grad_kernel_width=8, highlight_phase_slip=True,
-                  amp_ylim=None, flip_phase=False, plot_phase=False):
+            amp_ylim=None, flip_phase=False, plot_phase=False):
         """ Find the peaks within a given subband.
 
         Args
@@ -875,8 +875,8 @@ class SmurfTuneMixin(SmurfBase):
             angle *= -1
         grad = np.convolve(angle, np.repeat([1,-1], grad_kernel_width),
             mode='same')
-            
-        
+
+
         amp = np.abs(resp)
 
         grad_loc = np.array(grad > grad_cut)
@@ -909,7 +909,7 @@ class SmurfTuneMixin(SmurfBase):
                 plt.show()
             else:
                 plt.close()
-                    
+
         # Make summary plot
         if make_plot:
             if show_plot:
@@ -3404,7 +3404,7 @@ class SmurfTuneMixin(SmurfBase):
             tone_power=None, n_read=2, make_plot=False, save_plot=True,
             plotname_append='', window=50, rolling_med=True,
             make_subband_plot=False, show_plot=False, grad_cut=.05,
-                  flip_phase=False, grad_kernel_width=8,
+            flip_phase=False, grad_kernel_width=8,
             amp_cut=.25, pad=2, min_gap=2):
         '''
         Finds the resonances in a band (and specified subbands)
@@ -3440,6 +3440,9 @@ class SmurfTuneMixin(SmurfBase):
         grad_cut : float, optional, default 0.05
             The value of the gradient of phase to look for
             resonances.
+        flip_phase : bool, optional, default False
+            Whether to flip the sign of phase before
+            evaluating the gradient cut.
         amp_cut : float, optional, default 0.25
             The fractional distance from the median value to decide
             whether there is a resonance.
@@ -3695,6 +3698,9 @@ class SmurfTuneMixin(SmurfBase):
         amp_cut : float, optional, default 0.25
             The fractional distance from the median value to decide
             whether there is a resonance.
+        flip_phase : bool, optional, default False
+            Whether to flip the sign of phase before
+            evaluating the gradient cut.
         freq_min : float, optional, default -2.5e8
             The minimum frequency relative to the center of the band
             to look for resonances. Units of Hz.
@@ -3750,7 +3756,7 @@ class SmurfTuneMixin(SmurfBase):
             make_subband_plot=make_subband_plot,
             subband_plot_with_slow=subband_plot_with_slow, timestamp=timestamp,
             pad=pad, min_gap=min_gap, show_plot=show_plot, plot_phase=plot_phase,
-                               flip_phase=flip_phase)
+            flip_phase=flip_phase)
 
         return peaks
 

--- a/scratch/eyy/noise/princeton_phi0.py
+++ b/scratch/eyy/noise/princeton_phi0.py
@@ -1,0 +1,97 @@
+import pysmurf.client
+import numpy as np
+import scipy.signal as signal
+import os
+import glob
+import matplotlib.pyplot as plt
+
+# What to run
+preprocess = False
+psd = True
+
+# Data
+output_dir = '/data/smurf_data/princeton_srv15/20210219/1613776439/outputs'
+fs = 1000
+pA_per_phi0 = 9E6
+
+datafiles = np.load(os.path.join(output_dir, 'out_dict2.npy'),
+    allow_pickle=True).item()
+keys = list(datafiles.keys())
+
+S = pysmurf.client.SmurfControl(offline=True)
+
+# Preprocess all the data
+if preprocess:
+    for k in keys:
+        print(f'Working on {k}')
+        fn = os.path.basename(datafiles[k])
+
+        # Extract values
+        reset_rate = int(k[5])
+        nphi0 = int(k[-2:])
+
+        t, d, m = S.read_stream_data(os.path.join(output_dir, fn))
+
+        bands, channels = np.where(m != -1)
+
+        for b, ch in zip(bands, channels):
+            idx = m[b, ch]
+            np.save(os.path.join(output_dir,
+                f'b{b}ch{ch:03}_rr{reset_rate}_nphi{nphi0:02}'), d[idx])
+
+# Load the data, take PSD, then plot.
+# T his is currently hardcoded to only work for band 2. Need to update
+# code if we want to change.
+if psd:
+    datafiles = glob.glob(os.path.join(output_dir, 'b*ch*.npy'))
+    bands = np.zeros(len(datafiles), dtype=int)
+    channels = np.zeros_like(bands)
+    reset_rates = np.zeros_like(bands)
+    nphi0s = np.zeros_like(bands)
+
+    # Load the bands, channels
+    for i, d in enumerate(datafiles):
+        df = os.path.basename(d)
+        bands[i] = int(df[1])
+        channels[i] = int(df[4:7])
+        reset_rates[i] = int(df[10])
+        nphi0s[i] = int(df[16:18])
+
+    # Find the unique channels
+    unique_channels = np.unique(channels)
+
+    for ch in unique_channels:
+        fig, ax = plt.subplots(1, 2, figsize=(10,4), sharey=True)
+        idx = np.where(channels == ch)[0]
+
+        for i in idx:
+            d = np.load(os.path.join(output_dir, datafiles[i]))
+
+            # Convert to pA
+            d *= pA_per_phi0/(2*np.pi)
+            f, pxx = signal.welch(d, fs=fs, nperseg=2**15)
+            pxx = np.sqrt(pxx)
+
+            ax[0].loglog(f, pxx,
+                label=f'rr {reset_rates[i]}'+ r'$N \phi_0$' + f' {nphi0s[i]}')
+            phi0_rate = reset_rates[i] * nphi0s[i]
+
+            # Calculate the median in the signal band.
+            psd_idx = np.where(np.logical_and(f>.1, f<10))
+            med_pxx = np.median(pxx[psd_idx])
+
+            ax[1].plot(phi0_rate, med_pxx, '.')
+
+        ax[0].legend()
+        ax[0].set_ylim(100,5000)
+        ax[0].set_xlabel('Freq [Hz]')
+        ax[0].set_ylabel('Noise PSD [pA/rtHz]')
+        ax[1].set_xlabel(f'$\phi_0$ rate [kHz]')
+        plt.tight_layout()
+
+        fig.suptitle(f'b{bands[i]}ch{ch:03}')
+
+        # Save the data
+        plt.savefig(os.path.join(output_dir, f'b{2}ch{ch:03}.png'),
+            bbox_inches='tight')
+        plt.close()


### PR DESCRIPTION
## Issue
This PR resolves #649 and #654 .

## Description

This adds documentation for config_files. 
This adds an optional variable that flips the phase before taking a derivative in `find_freq`.

## Does this PR break any interface?
- [ ] Yes
- [x] No

### Which interface changed?
[Indicate here what is the interface that changed, preferable with a link to the code where the interface is defined]

### What was the interface before the change
[Describe here how was the original interface]

### What will be the new interface after the change
[Describe here how is the new interface, and what the difference with the original interface]
