### PR TITLE
Adds wrapper functions in smurf_commands.py for setting/getting filter for streaming data. Adds convenience functions in smurf_utils.py for setting/getting filter and its gain

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -6100,7 +6100,7 @@ class SmurfCommandMixin(SmurfBase):
         -------
         band : int
             The band.
-        
+
         Returns
         -------
         coef_fixed : float
@@ -6131,7 +6131,7 @@ class SmurfCommandMixin(SmurfBase):
         -------
         band : int
             The band.
-        
+
         Returns
         -------
         val : int
@@ -6162,7 +6162,7 @@ class SmurfCommandMixin(SmurfBase):
         -------
         band : int
             The band.
-        
+
         Returns
         -------
         win_fixed : float array

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -6074,3 +6074,49 @@ class SmurfCommandMixin(SmurfBase):
         """
         return self._caget(self.stream_data_source + self._stream_data_period,
             **kwargs)
+
+    _boxcar_scale = "boxcarScale"
+
+    def set_boxcar_filter_coef_fixed(self, band, coef_fixed, **kwargs):
+        """
+        Sets the boxcar filter coefficient.
+        coef_fixed should be np.round(coef*2**15), where
+        coef is 1/length of the boxcar window (which is
+        2.4 MHz divided by the streaming rate).
+        We round our coefficient for Fix16_15 data type.
+        """
+        self._caput(self._band_root(band) + self._boxcar_scale, coef_fixed, **kwargs)
+
+    def get_boxcar_filter_coef_fixed(self, band, **kwargs):
+        """
+        Gets the boxcar filter coefficient.
+        """
+        return self._caget(self._band_root(band) + self._boxcar_scale, **kwargs)
+
+    _filt_select = "filtSel"
+
+    def set_filt_select(self, band, val, **kwargs):
+        """
+        Set programmable window.
+        """
+        self._caput(self._band_root(band) + self._filt_select, val, **kwargs)
+
+    def get_filt_select(self, band, **kwargs):
+        """
+        Get value for programmable window.
+        """
+        return self._caget(self._band_root(band) + self._filt_select, **kwargs)
+
+    _filt_select_array = "StreamingFilter:coefficientArray"
+
+    def set_filt_coefficient_array(self, band, win_fixed, **kwargs):
+        """
+        Program window.
+        """
+        self._caput(self._band_root(band) + self._filt_select_array, win_fixed, **kwargs)
+
+    def get_filt_coefficient_array(self, band, **kwargs):
+        """
+        Get window.
+        """
+        return self._caget(self._band_root(band) + self._filt_select_array, *kwargs)

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -6080,16 +6080,31 @@ class SmurfCommandMixin(SmurfBase):
     def set_boxcar_filter_coef_fixed(self, band, coef_fixed, **kwargs):
         """
         Sets the boxcar filter coefficient.
-        coef_fixed should be np.round(coef*2**15), where
-        coef is 1/length of the boxcar window (which is
-        2.4 MHz divided by the streaming rate).
-        We round our coefficient for Fix16_15 data type.
+
+        Args
+        -------
+        band : int
+            The band.
+        coef_fixed : float
+            The coefficient (rounded for Fix16_15 data type) for the boxcar filter.
+            This should be np.round(coef*2**15), where coef is 1/length of the boxcar window
+            (which is 2.4 MHz divided by the streaming rate).
         """
         self._caput(self._band_root(band) + self._boxcar_scale, coef_fixed, **kwargs)
 
     def get_boxcar_filter_coef_fixed(self, band, **kwargs):
         """
         Gets the boxcar filter coefficient.
+
+        Args
+        -------
+        band : int
+            The band.
+        
+        Returns
+        -------
+        coef_fixed : float
+            The coefficient (rounded for Fix16_15 data type) for the boxcar filter.
         """
         return self._caget(self._band_root(band) + self._boxcar_scale, **kwargs)
 
@@ -6098,12 +6113,29 @@ class SmurfCommandMixin(SmurfBase):
     def set_filt_select(self, band, val, **kwargs):
         """
         Set programmable window.
+
+        Args
+        -------
+        band : int
+            The band.
+        val : int
+            1 for selecting programmable window.
         """
         self._caput(self._band_root(band) + self._filt_select, val, **kwargs)
 
     def get_filt_select(self, band, **kwargs):
         """
         Get value for programmable window.
+
+        Args
+        -------
+        band : int
+            The band.
+        
+        Returns
+        -------
+        val : int
+            1 for selected programmable window.
         """
         return self._caget(self._band_root(band) + self._filt_select, **kwargs)
 
@@ -6112,11 +6144,28 @@ class SmurfCommandMixin(SmurfBase):
     def set_filt_coefficient_array(self, band, win_fixed, **kwargs):
         """
         Program window.
+
+        Args
+        -------
+        band : int
+            The band.
+        win_fixed : float array
+            The window function.
         """
         self._caput(self._band_root(band) + self._filt_select_array, win_fixed, **kwargs)
 
     def get_filt_coefficient_array(self, band, **kwargs):
         """
         Get window.
+
+        Args
+        -------
+        band : int
+            The band.
+        
+        Returns
+        -------
+        win_fixed : float array
+            The window function.
         """
         return self._caget(self._band_root(band) + self._filt_select_array, *kwargs)

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4704,7 +4704,7 @@ class SmurfUtilMixin(SmurfBase):
         The max length for the window is 2048 (1.2 kHz minimum streaming rate).
 
         Args
-        ------
+        -------
         band : int
             The band.
         win_len : int
@@ -4713,7 +4713,7 @@ class SmurfUtilMixin(SmurfBase):
             Window type.
 
         Returns
-        ------
+        -------
         win_fixed : float array
             Window for filtering, with the factor of 2**-15 put back.
         """

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4710,7 +4710,8 @@ class SmurfUtilMixin(SmurfBase):
         win_len : int
             Window length. This should be 2.4 MHz divided by the streaming rate.
         window_fn : function, optional, default Hamming
-            Window type.
+            Window type. See https://docs.scipy.org/doc/scipy-0.19.1/reference/signal.html#window-functions
+            for some common options.
 
         Returns
         -------

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4668,3 +4668,73 @@ class SmurfUtilMixin(SmurfBase):
                 plt.close()
 
         return gap_freq
+
+    def set_boxcar_window(self, band, win_len):
+        """
+        Sets boxcar window for streaming data.
+
+        Args
+        ------
+        band : int
+            The band.
+        win_len : int
+            Window length. This should be 2.4 MHz divided by the streaming rate.
+        """
+        coef = 1./win_len
+        coef_fixed = np.round(coef*2**15) # Round our coefficient for Fix16_15 data type
+        self.set_boxcar_filter_coef_fixed(band, coef_fixed)
+
+    def get_filt_gain_boxcar(self, band, win_len):
+        """
+        Calculates the gain in the streaming data introduced by the boxcar filter.
+
+        Args
+        ------
+        band : int
+            The band.
+        win_len : int
+            Window length. This should be 2.4 MHz divided by the streaming rate.
+        """
+        coef_fixed = self.get_boxcar_filter_coef_fixed(band)
+        return (coef_fixed * win_len * 2**-15)
+
+    def program_window(self, band, win_len, window_fn=signal.hamming):
+        """
+        Programs window for streaming data.
+        The max length for the window is 2048 (1.2 kHz minimum streaming rate).
+
+        Args
+        ------
+        band : int
+            The band.
+        win_len : int
+            Window length. This should be 2.4 MHz divided by the streaming rate.
+        window_fn : function, optional, default Hamming
+            Window type.
+
+        Returns
+        ------
+        win_fixed : float array
+            Window for filtering, with the factor of 2**-15 put back.
+        """
+        win = window_fn(win_len)
+        win = win/np.sum(win)
+        win_fixed = np.zeros(2048, dtype=np.int16)
+        win_fixed[:len(win)] = np.round(win*2**15) # For firmware Fix16_15 data type
+        # Select programmable window
+        self.set_filt_select(band, 1)
+        # Program window
+        self.set_filt_coefficient_array(band, win_fixed)
+        return win_fixed * 2**-15
+
+    def get_filt_gain_programmable_window(self, band):
+        """
+        Calculates the gain in the streaming data introduced by the programmable window filter.
+
+        Args
+        ------
+        band : int
+            The band.
+        """
+        win_fixed = self.get_filt_coefficient_array(band)
+        return np.sum(win_fixed * 2**-15)


### PR DESCRIPTION
## Issue
This PR resolves #656 

## Description

Adds wrapper functions in smurf_commands.py for setting/getting filter for streaming data. Adds convenience functions in smurf_utils.py for setting/getting filter and its gain.

## Does this PR break any interface?
- [ ] Yes
- [X] No

### Which interface changed?
[Indicate here what is the interface that changed, preferable with a link to the code where the interface is defined]

### What was the interface before the change
[Describe here how was the original interface]

### What will be the new interface after the change
[Describe here how is the new interface, and what the difference with the original interface]
