### PR TITLE
speed up make_freq_mask

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -3303,13 +3303,14 @@ class SmurfUtilMixin(SmurfBase):
             An array with frequencies associated with the mask file.
         """
         freqs = np.zeros(len(mask), dtype=float)
-        channels_per_band = self.get_number_channels()
+        bands = mask // 512
+        chans = mask % 512
 
-        # iterate over mask channels and find their freq
-        for i, mask_ch in enumerate(mask):
-            b = mask_ch // channels_per_band
-            ch = mask_ch % channels_per_band
-            freqs[i] = self.channel_to_freq(b, ch)
+        for b in range(8):
+            m = bands == b
+            if not m.any():
+                continue
+            freqs[m] = self.channel_to_freq(b, chans[m])
 
         return freqs
 

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2270,7 +2270,7 @@ class SmurfUtilMixin(SmurfBase):
         ----
         band : int
             The band the channel is in.
-        channel : int, None, or array
+        channel : int, None, or array, optional, default None
             If None, will return the channel freqs of all enabled channels
 
         Returns

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2284,7 +2284,7 @@ class SmurfUtilMixin(SmurfBase):
             return None
 
         band_center_mhz = self.get_band_center_mhz(band)
-        subband_offset = self.get_tone_frequency_offset(band)
+        subband_offset = self.get_tone_frequency_offset_mhz(band)
         channel_offset = self.get_center_frequency_array(band)
         channel_freqs = band_center_mhz + subband_offset + channel_offset
 


### PR DESCRIPTION
## Issue
This PR should greatly speed up the creation of frequency mask by changing the required number of epics get requests from  being proportional to the number of channels to being proportional to the number of bands. This use to take ~minutes for a full UFM.  Resolves #662 .

This has not been tested yet, so I'll test when we have a cold system available (or someone else on SO can test before then) and then we can switch this from a draft to a full PR when it works.
## Description
The current implementation of this function makes a number of epics requests for each channel, which takes a very long time when there are a lot of channels. The new version uses the centerFrequencyArray registers etc. to get info for all channels in a given band at once, which should speed it up a lot.

## Does this PR break any interface?
- [ ] Yes
- [X] No
