### PR TITLE
Adds getAllData method

### DIFF
--- a/include/smurf/core/common/SmurfPacket.h
+++ b/include/smurf/core/common/SmurfPacket.h
@@ -123,6 +123,9 @@ public:
     // Get a data value
     const data_t getData(std::size_t index) const;
 
+    // Get all data as a vector
+    std::vector<data_t> getAllData() const;
+
 private:
     // Variables
     ris::FramePtr framePtr;  // Frame pointer

--- a/src/smurf/core/common/SmurfPacket.cpp
+++ b/src/smurf/core/common/SmurfPacket.cpp
@@ -120,6 +120,11 @@ const ZeroCopyCreator::data_t ZeroCopyCreator::getData(std::size_t index) const
     return data[index];
 }
 
+std::vector<ZeroCopyCreator::data_t> ZeroCopyCreator::getAllData() const
+{
+    return std::vector<data_t>(data, data+dataSize);
+}
+
 // Explicit template instantiations
 template class SmurfPacketManagerRO<CopyCreator>;
 template class SmurfPacketManagerRO<ZeroCopyCreator>;


### PR DESCRIPTION
## Issue
This PR resolves #676.
## Description
Adds a getAllData function to the SmurfPacket class that returns an array containing all detector data. This eliminates repeated function calls to the getData function.

Tested with the SO smurf-streamer, and greatly improves data processing speeds at high channel counts.

## Does this PR break any interface?
- [ ] Yes
- [X] No