### PR TITLE
Update cryo-det firmware to v1.1.0 and Rogue to v4.11.10 (#682)

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.8.4
+FROM tidair/smurf-rogue:R2.8.8
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/

--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -21,8 +21,8 @@ config_repo=https://github.com/slaclab/smurf_cfg
 # define it here. On the other hand, the ZIP file follows this naming convention:
 # 'rogue_${fw_repo_tag}.zip', so you don't need to define it here.
 # The files will be downloaded from the release list of assets.
-fw_repo_tag=MicrowaveMuxBpEthGen2_v1.0.6
-mcs_file_name=MicrowaveMuxBpEthGen2-0x00000100-20210504090351-jvasquez-8ccb67e.mcs.gz
+fw_repo_tag=MicrowaveMuxBpEthGen2_v1.1.0
+mcs_file_name=MicrowaveMuxBpEthGen2-0x01010000-20210928123941-ruckman-02ed52a.mcs.gz
 
 # Define the configuration version:
 # =================================


### PR DESCRIPTION
## Issue
No issue

## Description

Update pysmurf to Rogue v4.11.10 and cryo-det v1.1.0. Major changes is the cryo-det U_timing messages were increased in size, the version number of cryo-det was incremented, and minor changes to Rogue.

## Does this PR break any interface?
- [ ] Yes
- [x] No

### Which interface changed?
NA

### What was the interface before the change
NA

### What will be the new interface after the change
NA
