### PR TITLE
Remove set_enable_ramp

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -4477,28 +4477,6 @@ class SmurfCommandMixin(SmurfBase):
             self.rtm_cryo_det_root + self._select_ramp_reg,
             **kwargs)
 
-    _enable_ramp_reg = 'EnableRamp'
-
-    def set_enable_ramp(self, val, **kwargs):
-        """
-        Select Ramp to the CPLD
-        0x1 = Fast flux Ramp
-        0x0 = Slow flux ramp
-        """
-        self._caput(
-            self.rtm_cryo_det_root + self._enable_ramp_reg,
-            val, **kwargs)
-
-    def get_enable_ramp(self, **kwargs):
-        """
-        Select Ramp to the CPLD
-        0x1 = Fast flux Ramp
-        0x0 = Slow flux ramp
-        """
-        return self._caget(
-            self.rtm_cryo_det_root + self._enable_ramp_reg,
-            **kwargs)
-
     _ramp_start_mode_reg = 'RampStartMode'
 
     def set_ramp_start_mode(self, val, **kwargs):


### PR DESCRIPTION
Closes #688

set_enable_ramp times out when writing to its PV. It's not used when turning on the flux ramp. I couldn't find it in pysmurf, sodetlib, or cryo-det. However EnableRampTrigger is used. If EnableRamp isn't actually used anywhere and is not needed for backwards compatibility, we can delete this.

https://github.com/slaclab/pysmurf/blob/41e41c9c568aecd7e350ff2f050be58498c56af9/python/pysmurf/client/command/smurf_command.py#L4461

https://github.com/slaclab/pysmurf/blob/41e41c9c568aecd7e350ff2f050be58498c56af9/python/pysmurf/client/tune/smurf_tune.py#L3200

https://confluence.slac.stanford.edu/display/SMuRF/RTM+firmware?preview=/232089354/233309457/Cryo_RTM_setup_note_v2.pdf
