### PR TITLE
Don't start streaming after setting up pysmurf

### DIFF
--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -634,9 +634,6 @@ class SmurfControl(SmurfCommandMixin,
                                  self._fraction_full_scale,
                                  write_log=write_log)
 
-            # Turn on stream enable for all bands
-            self.set_stream_enable(1, write_log=write_log)
-
             # Set payload size and mask to a single channel
             self.set_payload_size(payload_size)
             self.set_channel_mask([0])


### PR DESCRIPTION
## Issue

#652 

## Description

Jack brought up the fact that pysmurf setup() turns on streaming with set_stream_enable(1). After poking around, I believe the correct way to start streaming data from pysmurf is with stream_data_on(), not set_stream_enable(1). So it feels like a bug that set_stream_enable(1) is in there. After poking through sodetlib and pysmurf it seems that everywhere disables streaming immediately, hinting that it isn't actually desired to start streaming after setup.

P.S. Why is there set_stream_enable(1) and stream_data_on and not just stream_data_on?

## Does this PR break any interface?
- [ ] Yes
- [x] No

### Which interface changed?
NA

### What was the interface before the change
NA

### What will be the new interface after the change
NA
