### PR TITLE
Fix issue where AMC LMK doesn't lock to the FPGA clock

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,11 @@
-# If these files are modified, tag only those users.
+# @swh76 will be the default owners for everything. Unless
+# a later match takes precedence, they will be requested
+# for review when someone opens a pull request.
+* @aer7 @swh76
+
+# @aer7 and @slacrherbst owns the code related
+# to the core, dockers, and startup scripts.
+# Only them will be requested for review.
 /src/                   @aer7 @slacrherbst
 /include/               @aer7 @slacrherbst
 /python/pysmurf/core/   @aer7 @slacrherbst
@@ -7,7 +14,8 @@
 /tests/core             @aer7 @slacrherbst
 /releaseGen.py          @aer7 @slacrherbst
 /README.*.md            @aer7 @slacrherbst
-/.github/               @swh76 @aer7 @slacrherbst
 
-# If no match, tag these.
-* @aer7 @swh76
+# @swh76, @aer7 and @slacrherbst owns the
+# github related scripts. All of them will be requested
+# for review.
+/.github/               @swh76 @aer7 @slacrherbst

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,11 +1,12 @@
 #-----------------------------------------------------------------------------
-# Title      : test-or-deploy
+# Title      : PySMuRF CI/CD GitHub Action Workflow
 #-----------------------------------------------------------------------------
-# File       : test-or-deploy.yml
+# File       : ci-cd.yml
 # Created    : 2020-11-23
 #-----------------------------------------------------------------------------
 # Description:
-#    Test or deploy releases of pysmurf using GitHub Actions.
+#    GitHub Action Workflow for Continuous Integration and Continuous
+#    Deployment.
 #-----------------------------------------------------------------------------
 # This file is part of the smurf software platform. It is subject to
 # the license terms in the LICENSE.txt file found in the top-level directory
@@ -16,16 +17,17 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
-name: test-or-deploy
+name: CI/CD
 on: [push, pull_request]
 
 jobs:
 
-  # Tests
-
-  # Run flake8 on all .py files. Should block deploys to Read The Docs.
-  flake8:
-    name: Flake8 Tests
+  ###################
+  # Check Jobs      #
+  ###################
+  # Flake8 checks
+  checks:
+    name: Flake8 Checks
     runs-on: ubuntu-18.04
     steps:
       # Checkout the code
@@ -47,12 +49,12 @@ jobs:
             flake8-import-order
 
       # Run Flake 8 tests
-      - name: Flake8
+      - name: Flake8 Checks
         run: flake8 --count python/
 
   # Validate the server docker image definitions
   docker-definitions:
-    name: Docker Definition Tests
+    name: Docker Definition Validation
     runs-on: ubuntu-18.04
     steps:
       # Checkout the code.
@@ -76,11 +78,14 @@ jobs:
           ./validate.sh
           cd -
 
+  ###################
+  # Test jobs       #
+  ###################
   # Documentation automatic build tests
   test-docs:
     name: Documentation Build Tests
     runs-on: ubuntu-18.04
-    needs: [flake8, docker-definitions]   # Run only if all checks passed
+    needs: [checks, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
       - name: Checkout code
@@ -109,7 +114,7 @@ jobs:
   test-server:
     name: Server Tests
     runs-on: ubuntu-18.04
-    needs: [flake8, docker-definitions]   # Run only if all checks passed
+    needs: [checks, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
       - name: Checkout code
@@ -183,7 +188,7 @@ jobs:
   test-client:
     name: Client Tests
     runs-on: ubuntu-18.04
-    needs: [flake8, docker-definitions]   # Run only if all checks passed
+    needs: [checks, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
       - name: Checkout code
@@ -230,9 +235,10 @@ jobs:
             /bin/bash -c "python3 -c 'import matplotlib; matplotlib.use(\"Agg\"); import pysmurf.client'"
 
 
-  # Deploy
-
-  # Deploy new release notes to GitHub
+  ###################
+  # Deployment jobs #
+  ###################
+  # Generate release notes
   deploy-release-notes:
     name: Generate Release Notes
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -73,7 +73,9 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.SLACLAB_TOKEN }}
+        if: "${{ env.GITHUB_TOKEN != '' }}"
         run: |
+          echo "hello $GITHUB_TOKEN"
           cd docker/server/
           ./validate.sh
           cd -

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,30 @@
+#-----------------------------------------------------------------------------
+# Title      : PySMuRF Labeler GitHub Action Workflow
+#-----------------------------------------------------------------------------
+# File       : label.yml
+# Created    : 2020-03-18
+#-----------------------------------------------------------------------------
+# Description:
+#    GitHub Action Workflow for applying labels to pull requests based on the
+#    file path that are modified. For more information about the labeler
+#    action see: https://github.com/actions/labeler/blob/master/README.md
+#-----------------------------------------------------------------------------
+# This file is part of the smurf software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the smurf software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/verify-pr-labels.yml
+++ b/.github/workflows/verify-pr-labels.yml
@@ -1,0 +1,40 @@
+#-----------------------------------------------------------------------------
+# Title      : PySMuRF Verify Labels GitHub Action Workflow
+#-----------------------------------------------------------------------------
+# File       : verify-pr-labels.yml
+# Created    : 2020-03-20
+#-----------------------------------------------------------------------------
+# Description:
+#    GitHub Action Workflow for verifying that all pull requests have at
+#    least one of these labels: 'bug', 'enhancement', 'interface-change',
+#    before they can be merged. For more information about the
+#    verify-pr-label-action action see:
+#    https://github.com/jesusvasquez333/verify-pr-label-action/blob/master/README.md
+#-----------------------------------------------------------------------------
+# This file is part of the smurf software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the smurf software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+name: verify-pr-label-action
+
+on:
+  pull_request_target:
+   types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  verify_pr_labels:
+    runs-on: ubuntu-latest
+    name: Verify that the PR has a valid label
+    steps:
+    - name: Verify Pull Request Labels
+      uses: jesusvasquez333/verify-pr-label-action@v1.3.1
+      id: verify-pr-label
+      with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          valid-labels: 'bug, enhancement, interface-change'
+          pull-request-number: '${{ github.event.pull_request.number }}'

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -701,8 +701,10 @@ class SmurfControl(SmurfCommandMixin,
 
                     # MicrowaveMuxCore[0] LMK LmkReg_0x0147 0xA
                     for bay in self.bays:
-                        self.log(f'Configuring bay {bay} LMK to lock to the timing system')
-                        self.set_lmk_reg(bay, 0x147, 0xA)
+                        self.log(f'Setting Bay {bay} LMK 0x146 to 0x08')
+                        self.set_lmk_reg(bay, 0x146, 0x08)
+                        self.log(f'Setting Bay {bay} LMK 0x147 to 0x0A')
+                        self.set_lmk_reg(bay, 0x147, 0x0A)
 
                 # https://confluence.slac.stanford.edu/display/SMuRF/Timing+Carrier#TimingCarrier-Howtoconfiguretodistributeoverbackplanefromslot2
 
@@ -727,10 +729,12 @@ class SmurfControl(SmurfCommandMixin,
                     # EvrV2CoreTriggers EVrV2TriggerReg[0] Enable Trig True
                     self.set_trigger_enable(0, True)
 
-                    # Set LMK to use timing system as reference
+                    # Set the bay AMC LMK to CLKin0 or CLKin1.
                     for bay in self.bays:
-                        self.log(f'Configuring bay {bay} LMK to lock to the timing system')
-                        self.set_lmk_reg(bay, 0x147, 0xA)
+                        self.log(f'Setting Bay {bay} LMK 0x146 to 0x08')
+                        self.set_lmk_reg(bay, 0x146, 0x08)
+                        self.log(f'Setting Bay {bay} LMK 0x147 to 0x0A')
+                        self.set_lmk_reg(bay, 0x147, 0x0A)
 
                     # Configure RTM to trigger off of the timing system
                     self.set_ramp_start_mode(1, write_log=write_log)


### PR DESCRIPTION
Problem

The AMC LMK clock receives 122.88 MHz, cleans it up, then spits it
back out to the FPGA. To do this, it locks to one of two clocks,
CLKin0 or CLKin1. 0 is the FPGA's recovered timing clock, and 1 is the
front panel clock. Previously, with fiber timing, the LMK still tries
to lock to the front panel, fails, then free runs, preventing the
tones from locking to the fiber 122.88 MHz.

Solution

Set LMK 0x146 to 0x08 when taking timing from fiber. This also applies
to the backplane case, so set that as well.

Note this could be in the defaults .yml passed to Rogue, then just hit
Rogue with Init. But those defaults .yml files are hard to edit right
now, so edit them dynamically in pysmurf.