### PR TITLE
Fix automated access to cryo-det

### DIFF
--- a/.github/workflows/test-or-deploy.yml
+++ b/.github/workflows/test-or-deploy.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Validate the server definitions
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.SLACLAB_TOKEN }}
+          AER7_TOKEN: ${{ secrets.AER7_TOKEN }}
         run: |
           cd docker/server/
           ./validate.sh
@@ -306,7 +306,7 @@ jobs:
         id: build
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.SLACLAB_TOKEN }}
+          AER7_TOKEN: ${{ secrets.AER7_TOKEN }}
         run: |
           cd docker/server/
           ./build.sh


### PR DESCRIPTION
Problem

The pysmurf repository itself needs access to the private cryo-det
repo in order to run tests and generate release images. For some
reason the current token broke.

Solution

The simple thing to do is make some access token in cryo-det and then
put that in pysmurf's private environment keys. But strangely this
isn't possible. Instead Github requires users make "Personal Access
Tokens" which are owned by specific users, and Github suggests we make
another machine user entirely. I don't want to juggle two Github
accounts, so just put it in my account for now.