### PR TITLE
Control flux ramp AC/DC coupling on the C02 and C04 Cryocard

### DIFF
--- a/python/pysmurf/client/command/cryo_card.py
+++ b/python/pysmurf/client/command/cryo_card.py
@@ -148,9 +148,9 @@ class CryoCard():
 
         self.set_relay_bit(16, value)
 
-    def get_ac_dc_relay(self):
+    def read_ac_dc_relay_status(self):
         """
-        Read the flux ramp coupling status, either AC mode or DC mode.
+        Read the relay for the flux ramp coupling mode, which is either AC or DC.
 
         Args
         ----


### PR DESCRIPTION
Problem

Pysmurf should be able to control the flux ramp coupling mode for the C02 and C04, either DC mode or AC mode. To do this, the C02 controls two relays, K1 and K2, while the C04 uses just one relay named K2.

Solution

The easiest solution is to set bit 16 on address 0x2 on the PIC. This controls both relays on the C02, and just the K2 on the C04, which is very convenient. To read back the AC/DC status, just read back the same bit. This deprecates the usage of address 0x08 on the C02 firmware. If we still want to use that address, the code gets more complicated. 

Functions added:
- cryo_card.py
  - get_relay_bit
  - set_relay_bit

Functions modified:
- cryo_card.py
  - read_ac_dc_relay_status

Problems

- Some parts of pysmurf expect a value of 3 instead of 1 from read_ac_dc_relay_status. 3 means 0b11, or both relays are set on the C02. The C04 doesn't have this functionality anymore, it can only return 0 or 1 as to whether the relays are on or off.

Tests

Tested using C04 firmware R4.0.7 and C02 firmware R1.1.0.

```
[ 2022-02-04 00:55:59 ]  Done with setup.

In [2]: S.C.get_ac_dc_relay()                                                                                                             
Out[2]: 1

In [3]: S.C.set_ac_dc_relay(0)                                                                                                            

In [4]: S.C.get_ac_dc_relay()                                                                                                             
Out[4]: 0

In [5]: # I measured OL on C3 and C4, C02.                                                                                                

In [6]: S.C.set_ac_dc_relay(1)                                                                                                            

In [7]: # Measured 2 Ohm each on C3 and C4, C02.                                                                                                                                                                                                              

In [9]: S.C.get_fw_version()                                                                                                              
Out[9]: 'R1.1.0'

In [10]: # Move to C04.                                                                                                                   

In [11]: S.C.get_fw_version()                                                                                                             
Out[11]: 'R4.0.7'

In [12]: S.C.get_ac_dc_relay()                                                                                                            
Out[12]: 0

In [13]: # Measure OL on C3 and C4.                                                                                                 

In [14]: S.C.set_ac_dc_relay(1)                                                                                                           

In [15]: # Measure 1.5 Ohm on C3 and C4.

Done, setting and reading back AC/DC coupling mode works on both the C02 and C04.
```