### PR TITLE
Add control of the C04 Cryocard HEMT2 gate and drain

### DIFF
--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -565,7 +565,17 @@ class SmurfConfig:
             # Used by: set_50k2_drain_voltage, get_50k2_drain_voltage
             # See also: smurf_config_properties.py, smurf_command.py
             Optional("fiftyk2_drain_conversion_m", default=-0.224968): Use(float),
-            Optional("fiftyk2_drain_conversion_b", default=5.59815): Use(float)
+            Optional("fiftyk2_drain_conversion_b", default=5.59815): Use(float),
+
+            # HEMT2
+            Optional("hemt2_gate_dac_num", default=27) : Use(int),
+            Optional("hemt2_drain_dac_num", default=29) : Use(int),
+            Optional("hemt2_Id_offset", default=0) : Use(float),
+            Optional('hemt2_amp_Vd_series_resistor', default=50.0): And(float, lambda f: f > 0),
+            Optional('hemt2_opamp_gain', default = 3.874): Use(float),
+            Optional("hemt2_gate_bit_to_V", default=3.869e-6) : And(Use(float), lambda f: f > 0),
+            Optional("hemt2_drain_conversion_m", default=-0.259491): Use(float),
+            Optional("hemt2_drain_conversion_b", default=1.74185): Use(float)
         }
         #### Done specifiying amplifier
 

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -1107,12 +1107,12 @@ class SmurfConfigPropertiesMixin:
     def fiftyk2_drain_conversion_b(self, value):
         self._fiftyk2_drain_conversion_b = value
 
-
     # hemt2
 
     @property
     def hemt2_gate_dac_num(self):
-        """RTM DAC number wired to the HEMT2 gate.
+        """
+        RTM DAC number wired to the HEMT2 gate.
         """
         return self._hemt2_gate_dac_num
 

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -239,6 +239,16 @@ class SmurfConfigPropertiesMixin:
         self.fiftyk2_drain_conversion_m = amp_cfg['fiftyk2_drain_conversion_m']
         self.fiftyk2_drain_conversion_b = amp_cfg['fiftyk2_drain_conversion_b']
 
+        # hemt2
+        self.hemt2_gate_dac_num = amp_cfg['hemt2_gate_dac_num']
+        self.hemt2_drain_dac_num = amp_cfg['hemt2_drain_dac_num']
+        self.hemt2_opamp_gain = amp_cfg['hemt2_opamp_gain']
+        self.hemt2_Id_offset = amp_cfg['hemt2_Id_offset']
+        self.hemt2_gate_bit_to_V = amp_cfg['hemt2_gate_bit_to_V']
+        self.hemt2_amp_Vd_series_resistor = amp_cfg['hemt2_amp_Vd_series_resistor']
+        self.hemt2_drain_conversion_m = amp_cfg['hemt2_drain_conversion_m']
+        self.hemt2_drain_conversion_b = amp_cfg['hemt2_drain_conversion_b']
+
         ## Tune parameters
         tune_band_cfg = config.get('tune_band')
         self.default_tune = tune_band_cfg['default_tune']
@@ -1096,6 +1106,101 @@ class SmurfConfigPropertiesMixin:
     @fiftyk2_drain_conversion_b.setter
     def fiftyk2_drain_conversion_b(self, value):
         self._fiftyk2_drain_conversion_b = value
+
+
+    # hemt2
+
+    @property
+    def hemt2_gate_dac_num(self):
+        """RTM DAC number wired to the HEMT2 gate.
+        """
+        return self._hemt2_gate_dac_num
+
+    @hemt2_gate_dac_num.setter
+    def hemt2_gate_dac_num(self, value):
+        self._hemt2_gate_dac_num = value
+
+    @property
+    def hemt2_drain_dac_num(self):
+        """RTM DAC number wired to the HEMT2 drain.
+        """
+        return self._hemt2_drain_dac_num
+
+    @hemt2_drain_dac_num.setter
+    def hemt2_drain_dac_num(self, value):
+        self._hemt2_drain_dac_num = value
+
+    @property
+    def hemt2_gate_bit_to_V(self):
+        """Given the bit measurement from the RTM HEMT2 Gate DAC, multiply it
+        by this number to get HEMT2_G_OUT Volts. This allows the user to set or
+        get the HEMT2 Gate Voltage going out of the cryocard.
+
+        HEMT2_G_OUT = 20 Volts * R19/(R19+R16) * 2^(-20) [Volt]
+        """
+        return self._hemt2_gate_bit_to_V
+
+    @hemt2_gate_bit_to_V.setter
+    def hemt2_gate_bit_to_V(self, value):
+        self._hemt2_gate_bit_to_V = value
+
+    @property
+    def hemt2_amp_Vd_series_resistor(self):
+        """The R54 resistor in the cryocard, Ohms. This is used to convert
+        HEMT2_I volts to HEMT2_I milliamps.
+        """
+        return self._hemt2_amp_Vd_series_resistor
+
+    @hemt2_amp_Vd_series_resistor.setter
+    def hemt2_amp_Vd_series_resistor(self, value):
+        self._hemt2_amp_Vd_series_resistor = value
+
+    @property
+    def hemt2_Id_offset(self):
+        """Analogous to 50k2_Id_offset, for the HEMT2 circuit.
+        """
+        return self._hemt2_Id_offset
+
+    @hemt2_Id_offset.setter
+    def hemt2_Id_offset(self, value):
+        self._hemt2_Id_offset = value
+
+    @property
+    def hemt2_opamp_gain(self):
+        """The gain of the HEMT2 opamp. Used to convert HEMT2_I volts to
+        HEMET2_I milliamps.
+        """
+        return self._hemt2_opamp_gain
+
+    @hemt2_opamp_gain.setter
+    def hemt2_opamp_gain(self, value):
+        self._hemt2_opamp_gain = value
+
+    @property
+    def hemt2_drain_conversion_m(self):
+        """The slope of the linear fit that converts HEMT2_D volts to
+        HEMT2_D_OUT volts.
+
+        See also: hemt2_drain_conversion_b
+        """
+        return self._hemt2_drain_conversion_m
+
+    @hemt2_drain_conversion_m.setter
+    def hemt2_drain_conversion_m(self, value):
+        self._hemt2_drain_conversion_m = value
+
+    @property
+    def hemt2_drain_conversion_b(self):
+        """The y-offset of the linear fit that converts HEMT2_D volts
+        to HEMT2_D_OUT volts.
+
+        See also: hemt2_drain_conversion_m
+        """
+        return self._hemt2_drain_conversion_b
+
+    @hemt2_drain_conversion_b.setter
+    def hemt2_drain_conversion_b(self, value):
+        self._hemt2_drain_conversion_b = value
 
     ## Start attenuator property definition
 

--- a/python/pysmurf/client/command/cryo_card.py
+++ b/python/pysmurf/client/command/cryo_card.py
@@ -46,6 +46,7 @@ class CryoCard():
         self.hemt_bias_address = 0x3
         self.a50K_bias_address = 0x4
         self.fiftyk2_drain_current_address = 0x0B
+        self.hemt2_i_address = 0x0A
         self.temperature_address = 0x5
         self.cycle_count_address = 0x6  # used for testing
         self.ps_en_address = 0x7 # PS enable (HEMT: bit 0, 50k: bit 1)
@@ -185,6 +186,17 @@ class CryoCard():
     def read_50k_bias(self):
         data = self.do_read(self.a50K_bias_address)
         return((data& 0xFFFFF) * self.bias_scale * self.adc_scale)
+
+    def get_hemt2_i_voltage(self):
+        """
+        Measure bits from HEMT2_I, convert those bits to voltage. This is
+        called the hemt2 "bias."
+
+        See also: get_hemt2_bias
+        """
+        data = self.do_read(self.hemt2_i_address)
+        volts = (data & 0xFFFFF) * self.bias_scale * self.adc_scale
+        return volts
 
     def get_50k2_bias(self):
         """


### PR DESCRIPTION
## Issue

[ESCRYODET-852](https://jira.slac.stanford.edu/browse/ESCRYODET-852)

## Description

This adds control of the C04 Cryocard's HEMT2 gate and drain. This should not change the operations of users on the C02 cryocard. No changes are made to the other three amplifiers, or TES biases.

The following optional configurations are added.

- smurf_config.py
  - hemt2_gate_dac_num, default 27
  - hemt2_drain_dac_num, default 29
  - hemt2_Id_offset, default 0
  - hemt2_amp_Vd_series_resistor, default 50.0
  - hemt2_opamp_gain, default 3.874
  - hemt2_gate_bit_to_V, default 3.869e-6
  - hemt2_drain_conversion_m, default -0.259491
  - hemt2_drain_conversion_b, default 1.74185

The following functions are added.

- smurf_command.py
  - get_hemt2_ps_en
  - set_hemt2_ps_en
  - get_hemt2_bias
  - get_hemt2_drain_milliamps
  - get_hemt2_gate_enable
  - set_hemt2_gate_enable
  - get_hemt2_gate_voltage
  - set_hemt2_gate_voltage
  - get_hemt2_drain_enable
  - set_hemt2_drain_enable
  - get_hemt2_drain_voltage
  - set_hemt2_drain_voltage
- cryo_card.py
  - get_hemt2_i_voltage

The get_hemt2_drain_voltage and set_hemt2_drain voltage is calculated with the following fit.

<img width="300" alt="Untitled" src="https://user-images.githubusercontent.com/89935000/154606889-2c6cbf16-c8d8-468c-bbc5-dc9288e5cf1b.png">

## Test log

```
[ 2022-02-18 01:37:34 ]  Done with setup.

In [5]: S.hemt2_gate_dac_num
Out[5]: 27

In [6]: S.hemt2_drain_dac_num
Out[6]: 29

In [7]: S.hemt2_gate_bit_to_V
Out[7]: 3.869e-06

In [8]: S.hemt2_drain_conversion_m
Out[8]: -0.259491

In [9]: S.hemt2_drain_conversion_b
Out[9]: 1.74185

In [10]: S.hemt2_Id_offset
Out[10]: 0

In [11]: S.hemt2_amp_Vd_series_resistor
Out[11]: 50.0

In [12]: S.hemt2_opamp_gain
Out[12]: 3.874

In [13]: S.C.read_ps_en()
Out[13]: 4

In [14]: S.set_hemt2_ps_en(False)

In [15]: # 0V on HEMT2 Drain

In [16]: S.get_hemt2_ps_en()
Out[16]: False

In [17]: S.set_hemt2_ps_en(True)

In [18]: S.get_hemt2_ps_en()
Out[18]: True

In [19]: # 1.7445V on HEMT2 Drain

In [20]: S.get_hemt2_gate_enable()
Out[20]: False

In [21]: S.set_hemt2_gate_enable(True)

In [22]: S.get_hemt2_gate_voltage()
Out[22]: 0.0

In [23]: # 0V HEMT2 Gate

In [26]: S.get_rtm_slow_dac_volt(S.hemt2_gate_dac_num)
Out[26]: 9.999980926513672

In [27]: S.set_hemt2_ps_en(True)

In [28]: S.get_hemt2_ps_en()
Out[28]: True

In [37]: S.set_hemt2_gate_voltage(2.03)

In [41]: # Measuring 2.0243 V on HEMT2 G

In [42]: S.set_hemt2_gate_voltage(1)

In [43]: # 0.9974 V on HEMT2 G

In [44]: S.set_hemt2_gate_voltage(0)

In [45]: # 0 V on HEMT2 G

In [46]: S.set_hemt2_gate_voltage(2.03)
[ 2022-02-18 01:58:21 ]  Bias too high. Must be <= than 2^19-1.  Setting to max value

In [47]: S.set_hemt2_drain_enable(True)

In [51]: S.set_hemt2_drain_voltage(1.7)

In [52]: # 1.6920 on HEMT2 Drain

In [53]: S.set_hemt2_drain_voltage(1.2)

In [54]: # 1.1938 V on HEMT2 Drain

In [55]: S.set_hemt2_drain_voltage(0.5)

In [56]: # 0.4963 V on HEMT2 Drain

In [58]: S.set_hemt2_drain_voltage(0)

In [59]: # 0.0066 on HEMT2 Drain

In [62]: S.set_hemt2_gate_voltage(1.5)

In [63]: S.get_hemt2_gate_voltage()
Out[63]: 1.499999693

In [64]: # Measuring 1.49 V on HEMT2 Gate

In [67]: S.get_hemt2_drain_milliamps()
Out[67]: 0.23292301239029423

In [68]: S.set_hemt2_drain_voltage(1.7)

In [69]: S.get_hemt2_drain_milliamps()
Out[69]: 0.3859867062467733

In [70]: S.set_hemt2_drain_voltage(0)

In [71]: S.get_hemt2_drain_milliamps()
Out[71]: 0.24623289881259677

In [65]: # Result: Controlling the HEMT2 gate and drain works, and get_ values agree with multimeter.
```

## See Also

#697 #699 