### PR TITLE
Add control of the Cryocard C04 HEMT1 and 50K1

### DIFF
--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -494,32 +494,21 @@ class SmurfConfig:
 
         #### Start specifiying amplifier
         schema_dict["amplifier"] = {
-            # 4K amplifier gate voltage, in volts.
-            "hemt_Vg" : Use(float),
 
-            # Conversion from bits (the digital value the RTM DAC is set to)
-            # to volts for the 4K amplifier gate.  Units are volts/bit.  An
-            # important dependency is the voltage division on the cryostat
-            # card, which can be different from cryostat card to cryostat card
+            # See smurf_config_properties.py.
+
+            # HEMT
+            "hemt_Vg" : Use(float),
             "bit_to_V_hemt" : And(Use(float), lambda f: f > 0),
-            # The 4K amplifier drain current is measured before a voltage
-            # regulator, which also draws current.  An accurate measurement of
-            # the 4K drain current requires subtracting the current drawn by
-            # that regulator.  This is the offset to subtract off the measured
-            # value, in mA.
             "hemt_Id_offset" : Use(float),
-            # The resistance, in Ohm, of the resistor that is inline
-            # with the 4K HEMT amplifier drain voltage source which is
-            # used to infer the 4K HEMT amplifier drain current.  The
-            # default value of 200 Ohm is the standard value in the
-            # BOM for cryostat card revision C02 (PC-248-103-02-C02).
-            # The resistor on that revision of the cryostat card is
-            # R44.
             Optional('hemt_Vd_series_resistor', default=200.0): And(float, lambda f: f > 0),
-            # Software limit on the minimum gate voltage that can be set for the 4K amplifier.
             "hemt_gate_min_voltage" : Use(float),
-            # Software limit on the maximum gate voltage that can be set for the 4K amplifier.
-            "hemt_gate_max_voltage" :  Use(float),
+            "hemt_gate_max_voltage" : Use(float),
+            Optional("hemt_gate_dac_num", default = 3): Use(int),
+            Optional("hemt_drain_dac_num", default = 31): Use(float),
+            Optional('hemt_opamp_gain', default = 3.874): Use(float),
+            Optional("hemt_drain_conversion_m", default=-0.259491): Use(float),
+            Optional("hemt_drain_conversion_b", default=1.74185): Use(float),
 
             # 50K
             # https://confluence.slac.stanford.edu/display/AIRTRACK/PC-248-103-02-CXX

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -213,15 +213,20 @@ class SmurfConfigPropertiesMixin:
         ## Cold amplifier biases
         amp_cfg = config.get('amplifier')
 
-        # 4K HEMT
+        # HEMT
         self.hemt_Vg = amp_cfg['hemt_Vg']
         self.hemt_bit_to_V = amp_cfg['bit_to_V_hemt']
         self.hemt_Vd_series_resistor = amp_cfg['hemt_Vd_series_resistor']
         self.hemt_Id_offset = amp_cfg['hemt_Id_offset']
         self.hemt_gate_min_voltage = amp_cfg['hemt_gate_min_voltage']
         self.hemt_gate_max_voltage = amp_cfg['hemt_gate_max_voltage']
+        self.hemt_gate_dac_num = amp_cfg['hemt_gate_dac_num']
+        self.hemt_drain_dac_num = amp_cfg['hemt_drain_dac_num']
+        self.hemt_opamp_gain = amp_cfg['hemt_opamp_gain']
+        self.hemt_drain_conversion_m = amp_cfg['hemt_drain_conversion_m']
+        self.hemt_drain_conversion_b = amp_cfg['hemt_drain_conversion_b']
 
-        # 50K HEMT
+        # 50K
         self.fiftyk_Vg = amp_cfg['LNA_Vg']
         self.fiftyk_dac_num = amp_cfg['dac_num_50k']
         self.fiftyk_bit_to_V = amp_cfg['bit_to_V_50k']
@@ -471,10 +476,9 @@ class SmurfConfigPropertiesMixin:
     def hemt_Vg(self):
         """4K HEMT gate voltage in volts.
 
-        Gets or sets the desired value for the 4K HEMT gate voltage at
-        the output of the cryostat card.  Units are Volts.
-
-        Specified in the pysmurf configuration file as
+        Used by set_amplifier_biases to set the desired value for
+        the 4K HEMT gate voltage at the output of the cryostat
+        card. Specified in the pysmurf configuration file as
         `amplifier:hemt_Vg`.
 
         Returns
@@ -703,6 +707,72 @@ class SmurfConfigPropertiesMixin:
 
     ## End hemt_gate_max_voltage property definition
     ###########################################################################
+
+    @property
+    def hemt_gate_dac_num(self):
+        """RTM DAC Number to the HEMT gate. Compatible with C02 and C04.
+        """
+        return self._hemt_gate_dac_num
+
+    @hemt_gate_dac_num.setter
+    def hemt_gate_dac_num(self, value):
+        self._hemt_gate_dac_num = value
+
+    @property
+    def hemt_drain_dac_num(self):
+        """RTM DAC Number to the HEMT drain. Compatible with C02 and C04.
+        """
+        return self._hemt_drain_dac_num
+
+    @hemt_drain_dac_num.setter
+    def hemt_drain_dac_num(self, value):
+        self._hemt_drain_dac_num = value
+
+    @property
+    def hemt_opamp_gain(self):
+        """Gain of the C02 HEMT opamp, equal to the C04 HEMT1 opamp. This is
+        used to estimate the current going out the cryocard HEMT drain.
+        """
+        return self._hemt_opamp_gain
+
+    @hemt_opamp_gain.setter
+    def hemt_opamp_gain(self, value):
+        self._hemt_opamp_gain = value
+
+    @property
+    def hemt_drain_conversion_m(self):
+        """On the C02, the HEMT drain is set manually, so this is not relevant
+        to the C02. On the C04, the user can specify the voltage going out of
+        the HEMT drain. However this can only be set indirectly by setting the
+        RTM DAC voltage. This converts the RTM DAC voltage to the HEMT voltage
+        going out the C04 cryocard. If you precision voltage going out of the
+        HEMT drain to order 0.0001 V, use set_rtm_slow_dac_volt and measure
+        HEMT_D_OUT touch point with multimeter.
+
+        To measure the converison factor, set HEMT_G to max with
+        set_rtm_slow_dac_volt(S.hemt_gate_dac_num, 10), turn on the power
+        supply with set_hemt_ps_en, then measure the HEMT_D_OUT touch point as
+        function of set_rtm_slow_dac_volt(S.hemt_drain_dac_num, ...) from -10
+        to 10 Volts. Fit with y=mx+b, plug in here, then the functions
+        set_hemt_drain_voltage and get_hemt_drain_voltage are calibrated.
+        """
+
+        return self._hemt_drain_conversion_m
+
+    @hemt_drain_conversion_m.setter
+    def hemt_drain_conversion_m(self, value):
+        self._hemt_drain_conversion_m = value
+
+    @property
+    def hemt_drain_conversion_b(self):
+        """See hemt_drain_conversion_m.
+        """
+
+        return self._hemt_drain_conversion_b
+
+    @hemt_drain_conversion_b.setter
+    def hemt_drain_conversion_b(self, value):
+        self._hemt_drain_conversion_b = value
 
     ###########################################################################
     ## Start fiftyk_Vg property definition


### PR DESCRIPTION
## Issue

[ESCRYODET-852](https://jira.slac.stanford.edu/browse/ESCRYODET-852)

## Description

This adds control of the Cryocard C04 HEMT Drain. The goal here is for "HEMT" to refer to the HEMT on the C02, or HEMT1 on the C04. This implies the commands get_hemt_gate_voltage and set_hemt_gate_voltage can operate over both the first C02 or C04 HEMT automatically. This can obviously get confusing. Advice appreciated. The relevant differences between the C02 HEMT and C04 HEMT are: the C02 HEMT Drain is controlled manually, the C04 HEMT Drain is controlled via DAC, the resistor used to calculate current is different (C02: R2: 200 Ohm, C04: R44: 1 Ohm).

The following optional configurations are added.

- smurf_config.py
  - hemt_gate_dac_num, default 3 (same on C02 and C04)
  - hemt_drain_dac_num, default 31 (not on C02)
  - hemt_opamp_gain, default 3.874 (not sure if same)
  - hemt_drain_conversion_m, default -0.259491 (not on C02)
  - hemt_drain_conversion_b, default 1.74185 (not on C02)

The following functions are added.

- smurf_command.py
  - get_hemt_drain_enable
  - set_hemt_drain_enable
  - get_hemt_drain_voltage
  - set_hemt_drain_voltage

The get_hemt_drain_voltage and set_hemt_drain voltage uses the same fit from calibrating the HEMT2.

<img width="300" alt="3" src="https://user-images.githubusercontent.com/89935000/154899652-c5096c3b-44b5-41ac-be24-90b2d07d8c45.png">

## Test log with C04

```
[ 2022-02-21 05:48:10 ]  Done with setup.

In [2]: S.hemt_Vg
Out[2]: 0.49

In [3]: S.hemt_bit_to_V
Out[3]: 1.92e-06

In [4]: S.hemt_Vd_series_resistor  
Out[4]: 200.0

In [5]: S.hemt_Id_offset  
Out[5]: 0.12891

In [6]: S.hemt_gate_min_voltage 
Out[6]: -1.0

In [7]: S.hemt_gate_max_voltage 
Out[7]: 1.0

In [8]: S.hemt_gate_dac_num  
Out[8]: 3

In [9]: S.hemt_drain_dac_num 
Out[9]: 31

In [10]: S.hemt_opamp_gain
Out[10]: 3.874

In [11]: S.hemt_drain_conversion_m 
Out[11]: -0.259491

In [12]: S.hemt_drain_conversion_b 
Out[12]: 1.74185

In [13]: S.get_cryo_card_hemt_ps_en() 
Out[13]: False

In [14]: S.set_cryo_card_hemt_ps_en(True)

In [15]: S.get_hemt_gate_voltage?? 
Signature: S.get_hemt_gate_voltage(**kwargs)
Source:
 def get_hemt_gate_voltage(self, **kwargs):
  """
  Returns the HEMT voltage in bits.
  """
  return self._hemt_bit_to_V*(self.get_hemt_bias(**kwargs))
File:/usr/local/src/pysmurf/python/pysmurf/client/command/smurf_command.py
Type:method

In [16]: S.get_hemt_gate_voltage() 
Out[16]: 0.48999935999999994

In [17]: S.get_rtm_slow_dac_volt(S.hemt_gate_dac_num)
Out[17]: 0.0

In [18]: # Measuring 0.14 V on HEMT Gate. None of these three commands agree.

In [19]: S.set_hemt_gate_voltage(0)  

In [22]: # Measuring 0 V on HEMT Gate. At least rtm_spi_max_root + hemt_v_reg controls the HEMT Gate. DAC number 3 on the schematic C04 does not.  

In [25]: S.set_hemt_gate_voltage(0.5) 

In [26]: # Measuring 0.14 on HEMT Gate. Needs calibration? 

In [27]: # Next test HEMT drain.

In [28]: S.get_hemt_drain_voltage()
Out[28]: 1.74185

In [29]: # Measuring 1.7338 on HEMT Drain.  

In [30]: S.set_hemt_drain_voltage(0)  

In [31]: # Measuring 0.0067 on HEMT Drain.  

In [32]: S.set_hemt_drain_voltage(0.5)

In [33]: # Measuring 0.4998 on HEMT Drain. Good enough for now.  

In [34]: S.get_hemt_drain_current()
Out[34]: 8.024410312499999

In [35]: S.set_hemt_drain_voltage(1.75)  

In [36]: S.get_hemt_drain_current()
Out[36]: 27.689058749999994

In [37]: # This should max out at 50 mA. Needs calibration?

In [38]: S.set_hemt_drain_voltage(0)  

In [39]: S.get_hemt_drain_current()
Out[39]: 0.2255821875

In [40]: # Conclusion: HEMT1 Gate control is weird. Drain control OK. Current has range 0.22 to 27 mA, disagrees with schematic 0 to 50 mA.
```
## Test log with C02

NA

## See Also

#707

## Postscript

This is based off #707's changes. Just change the branch to develop once #707 is merged. Add software limits for the HEMT drain and gate in another pull request that adds software limits to all the other 4 amplifiers.