### PR TITLE
Adding bay 0 LB + bay 1 HB C02 defaults.yml

### DIFF
--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -29,4 +29,4 @@ mcs_file_name=MicrowaveMuxBpEthGen2-0x01010000-20210928123941-ruckman-02ed52a.mc
 # Define the YML configuration version to use. This is were you define which
 # configuration version to include in the docker image.
 # - 'yml_repo_tag': Set this variable to the tag version you want to use.
-config_repo_tag=v1.4.0
+config_repo_tag=v2.0.0


### PR DESCRIPTION
Add config for SMuRF so the automatic hardware detection can use one C02 LB on the right (0), C02 HB on the left (1). Used for RF Thermal Testing.