### PR TITLE
Downsample from either the internal downsampler counter, or external bits from timing system

### DIFF
--- a/include/smurf/core/common/SmurfHeader.h
+++ b/include/smurf/core/common/SmurfHeader.h
@@ -66,7 +66,7 @@ public:
     const uint32_t getCounter0()                  const;                   // Get 32 bit counter since last 1Hz marker
     const uint32_t getCounter1()                  const;                   // Get 32 bit counter since last external input
     const uint64_t getCounter2()                  const;                   // Get 64 bit timestamp
-    const uint32_t getAveragingResetBits()        const;                   // Get up to 32 bits of average reset from timing system
+    const uint32_t getTimingBits()                const;                   // Get 32 bits of the timing marker
     const uint32_t getFrameCounter()              const;                   // Get locally genreate frame counter 32 bit
     const uint32_t getTESRelaySetting()           const;                   // Get TES and flux ramp relays, 17bits in use now
     const uint64_t getExternalTimeClock()         const;                   // Get Syncword from mce for mce based systems (40 bit including header)
@@ -87,7 +87,15 @@ public:
     static const std::size_t SmurfHeaderSize                 = 128;
 
 protected:
-    // Header word offsets (in bytes)
+    // Header word offsets (in bytes). This is the number of bytes
+    // until the start of some portion of the header data. Compare
+    // this with AxisSysgenProcDataFramer.vhd to check that it is
+    // accurate. Example with headerCounter0Offset: Convert 64 bytes
+    // to bits, which is 512 bits. Divide 512 bits by 64, which is 8.
+    // v.header(8) is the start of the counter0, and its 32 bits
+    // large, so v.header(8)(31 downto 0) is the line in the firmware
+    // that determines the location of counter0 in the header.
+  
     static const std::size_t headerVersionOffset              = 0;
     static const std::size_t headerCrateIDOffset              = 1;
     static const std::size_t headerSlotNumberOffset           = 2;
@@ -100,7 +108,11 @@ protected:
     static const std::size_t headerCounter0Offset             = 64;
     static const std::size_t headerCounter1Offset             = 68;
     static const std::size_t headerCounter2Offset             = 72;
-    static const std::size_t headerAveragingResetBitsOffset   = 80;
+    static const std::size_t headerTimingBitsOffset           = 80;
+    // Data format for headerTimingBitsOffset:
+    // 9 downto 0: fixed rate markers: 1 2 3 4 5 6 8 10 12 15 kHz
+    // 27 downto 10: sequencer markers: sequencer number 0, 1, ... 18
+    // The easiest way to view the sequencer markers is with the TPG GUI
     static const std::size_t headerFrameCounterOffset         = 84;
     static const std::size_t headerTESRelaySettingOffset      = 88;
     static const std::size_t headerExternalTimeClockOffset    = 96;
@@ -163,7 +175,7 @@ public:
     void setCounter0(uint32_t value) const;                              // Set 32 bit counter since last 1Hz marker
     void setCounter1(uint32_t value) const;                              // Set 32 bit counter since last external input
     void setCounter2(uint64_t value) const;                              // Set 64 bit timestamp
-    void setAveragingResetBits(uint32_t value) const;                    // Set up to 32 bits of average reset from timing system
+    void setTimingBits(uint32_t value) const;                            // Set 32 bits of the timing markers
     void setFrameCounter(uint32_t value) const;                          // Set locally genreate frame counter 32 bit
     void setTESRelaySetting(uint32_t value) const;                       // Set TES and flux ramp relays, 17bits in use now
     void setExternalTimeClock(uint64_t value) const;                     // Set Syncword from mce for mce based systems (40 bit including header)

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5969,8 +5969,8 @@ class SmurfCommandMixin(SmurfBase):
             self.log("get_downsampler_internal_factor: offline is True, returning something anyway.")
             return 20
 
-        if self.get_downsampler_mode() != 'External':
-            self.log('get_downsampler_internal_factor: get_downsampler_mode is External, the factor is not used')
+        if self.get_downsampler_mode() == 'external':
+            self.log('get_downsampler_internal_factor: get_downsampler_mode is external, the factor is not used')
 
         return self._caget(self.smurf_processor + self._downsampler_internal_factor_reg, **kwargs)
 
@@ -5982,15 +5982,15 @@ class SmurfCommandMixin(SmurfBase):
 
         Ref. https://confluence.slac.stanford.edu/display/SMuRF/SMuRF+Processor
         """
-        self._caput(self.smurf_processor + self.downsampler_external_bitmask_reg, bitmask)
+        self._caput(self.smurf_processor + self._downsampler_external_bitmask_reg, bitmask)
 
-    def get_downsampler_external_bitmask_reg(self):
+    def get_downsampler_external_bitmask(self):
         """
         Get the downsampler external bitmask.
 
         Ref. https://confluence.slac.stanford.edu/display/SMuRF/SMuRF+Processor
         """
-        self._caget(self.smurf_processor + self._downsampler_external_bitmask_reg)
+        return self._caget(self.smurf_processor + self._downsampler_external_bitmask_reg)
 
     _filter_disable_reg = "Filter:Disable"
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5905,9 +5905,45 @@ class SmurfCommandMixin(SmurfBase):
             self.smurf_processor + self._filter_gain_reg,
             **kwargs)
 
-    _downsampler_factor_reg = 'Downsampler:Factor'
+    _downsampler_mode_reg = 'Downsampler:DownsamplerMode'
 
-    def set_downsample_factor(self, factor, **kwargs):
+    def set_downsampler_mode(self, mode):
+        """
+        Set the downsampler mode. 0 is internal, 1 is external.
+
+        Ref. SmurfHeader.h, SmurfHeader.cpp, _SmurfProcessor.py
+        Ref. https://confluence.slac.stanford.edu/display/SMuRF/SMuRF+Processor
+        """
+        if mode == 'internal':
+            self._caput(self.smurf_processor + self._downsampler_mode_reg, 0)
+        if mode == 'external':
+            self._caput(self.smurf_processor + self._downsampler_mode_reg, 1)
+        else:
+            self.log(f'set_downsampler_mode: Unknown mode {mode}')
+
+    def get_downsampler_mode(self):
+        """
+        Get the downsampler mode. 0 is internal, 1 is external.
+
+        Ref. SmurfHeader.h, SmurfHeader.cpp, _SmurfProcessor.py
+        Ref. https://confluence.slac.stanford.edu/display/SMuRF/SMuRF+Processor
+        """
+        mode = self._caget(self.smurf_processor + self._downsampler_mode_reg)
+
+        ret = 'Unknown'
+
+        if mode == 0:
+            ret = 'internal'
+        elif mode == 1:
+            ret = 'external'
+        else:
+            self.log(f'get_downsampler_mode: Unknown mode {mode}')
+
+        return ret
+
+    _downsampler_internal_factor_reg = 'Downsampler:InternalFactor'
+
+    def set_downsampler_internal_factor(self, factor, **kwargs):
         """
         Set the smurf processor down-sampling factor.
 
@@ -5917,10 +5953,10 @@ class SmurfCommandMixin(SmurfBase):
             The down-sampling factor.
         """
         self._caput(
-            self.smurf_processor + self._downsampler_factor_reg,
+            self.smurf_processor + self._downsampler_internal_factor_reg,
             factor, **kwargs)
 
-    def get_downsample_factor(self, **kwargs):
+    def get_downsampler_internal_factor(self, **kwargs):
         """
         Get the smurf processor down-sampling factor.
 
@@ -5929,13 +5965,32 @@ class SmurfCommandMixin(SmurfBase):
         int
             The down-sampling factor.
         """
-        if self.offline:  # FIX ME - STUPID HARD CODE
+        if self.offline:
+            self.log("get_downsampler_internal_factor: offline is True, returning something anyway.")
             return 20
 
-        else:
-            return self._caget(
-                self.smurf_processor + self._downsampler_factor_reg,
-                **kwargs)
+        if self.get_downsampler_mode() != 'External':
+            self.log('get_downsampler_internal_factor: get_downsampler_mode is External, the factor is not used')
+
+        return self._caget(self.smurf_processor + self._downsampler_internal_factor_reg, **kwargs)
+
+    _downsampler_external_bitmask_reg = 'Downsampler:ExternalBitmask'
+
+    def set_downsampler_external_bitmask(self, bitmask):
+        """
+        Set the downsampler external bitmask.
+
+        Ref. https://confluence.slac.stanford.edu/display/SMuRF/SMuRF+Processor
+        """
+        self._caput(self.smurf_processor + self.downsampler_external_bitmask_reg, bitmask)
+
+    def get_downsampler_external_bitmask_reg(self):
+        """
+        Get the downsampler external bitmask.
+
+        Ref. https://confluence.slac.stanford.edu/display/SMuRF/SMuRF+Processor
+        """
+        self._caget(self.smurf_processor + self._downsampler_external_bitmask_reg)
 
     _filter_disable_reg = "Filter:Disable"
 

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -120,7 +120,7 @@ class SmurfNoiseMixin(SmurfBase):
 
         if fs is None:
             if downsample_factor is None:
-                downsample_factor = self.get_downsample_factor()
+                downsample_factor = self.get_downsampler_internal_factor()
             fs = flux_ramp_freq/downsample_factor
 
         # Generate downsample transfer function - downsampling is at

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -869,9 +869,9 @@ class SmurfUtilMixin(SmurfBase):
         bands = self._bands
 
         if downsample_factor is not None:
-            self.set_downsample_factor(downsample_factor)
+            self.set_downsampler_internal_factor(downsample_factor)
         else:
-            downsample_factor = self.get_downsample_factor()
+            downsample_factor = self.get_downsampler_internal_factor()
             if write_log:
                 self.log('Input downsample factor is None. Using '+
                      'value already in pyrogue:'+
@@ -3197,7 +3197,7 @@ class SmurfUtilMixin(SmurfBase):
         # Get filter order, gain, and averages
         filter_order = self.get_filter_order()
         filter_gain = self.get_filter_gain()
-        num_averages = self.get_downsample_factor()
+        num_averages = self.get_downsampler_internal_factor()
 
         # Get filter order, gain, and averages
 
@@ -3354,7 +3354,7 @@ class SmurfUtilMixin(SmurfBase):
 
         # Calculate sampling frequency
         # flux_ramp_freq = self.get_flux_ramp_freq() * 1.0E3
-        # fs = flux_ramp_freq * self.get_downsample_factor()
+        # fs = flux_ramp_freq * self.get_downsampler_internal_factor()
 
         # Cast the bias group as an array
         bias_group = np.ravel(np.array(bias_group))
@@ -4133,7 +4133,7 @@ class SmurfUtilMixin(SmurfBase):
             The data sample rate in Hz.
         """
         flux_ramp_freq = self.get_flux_ramp_freq() * 1.0E3
-        downsample_factor = self.get_downsample_factor()
+        downsample_factor = self.get_downsampler_internal_factor()
 
         return flux_ramp_freq / downsample_factor
 
@@ -4181,7 +4181,7 @@ class SmurfUtilMixin(SmurfBase):
         """
         # Check if probe frequency is too high
         flux_ramp_freq = self.get_flux_ramp_freq() * 1.0E3
-        fs = flux_ramp_freq * self.get_downsample_factor()
+        fs = flux_ramp_freq * self.get_downsampler_internal_factor()
 
         # Calculate downsample filter transfer function
         filter_params = self.get_filter_params()

--- a/src/smurf/core/common/SmurfHeader.cpp
+++ b/src/smurf/core/common/SmurfHeader.cpp
@@ -139,9 +139,9 @@ const uint64_t SmurfHeaderRO<T>::getCounter2() const
 }
 
 template<typename T>
-const uint32_t SmurfHeaderRO<T>::getAveragingResetBits() const
+const uint32_t SmurfHeaderRO<T>::getTimingBits() const
 {
-    return getU32Word(headerAveragingResetBitsOffset);
+    return getU32Word(headerTimingBitsOffset);
 }
 
 template<typename T>
@@ -409,9 +409,9 @@ void SmurfHeader<T>::setCounter2(uint64_t value) const
 }
 
 template<typename T>
-void SmurfHeader<T>::setAveragingResetBits(uint32_t value) const
+void SmurfHeader<T>::setTimingBits(uint32_t value) const
 {
-    setU32Word(this->headerAveragingResetBitsOffset, value);
+    setU32Word(this->headerTimingBitsOffset, value);
 }
 
 template<typename T>

--- a/src/smurf/core/emulators/StreamDataSource.cpp
+++ b/src/smurf/core/emulators/StreamDataSource.cpp
@@ -156,7 +156,7 @@ void sce::StreamDataSource::runThread() {
             header->setCounter0(0);                    // Set 32 bit counter since last 1Hz marker
             header->setCounter1(0);                    // Set 32 bit counter since last external input
             header->setCounter2(0);                    // Set 64 bit timestamp
-            header->setAveragingResetBits(0);          // Set up to 32 bits of average reset from timing system
+            header->setTimingBits(0);                  // Set 32 bits that represent the timing markers
             header->setFrameCounter(frameCounter_);    // Set locally genreate frame counter 32 bit
             header->setTESRelaySetting(0);             // Set TES and flux ramp relays, 17bits in use now
             header->setExternalTimeClock(0);           // Set Syncword from mce for mce based systems (40 bit including header)


### PR DESCRIPTION
Data for SMuRF is maximally available at the flux ramp frequency. Previously, SMuRF could only use its internal "downsampler counter" where it ignores some of the incoming data until the counter is reached. This code change adds the ability for SMuRF to look at external timing bits from the SMuRF timing hardware to decide when to save data. I note that there are two places where SMuRF data is downsampled: at the firmware layer, and here at the software layer. The firmware layer does averaging of its data, but here the data is not averaged. The software downsampling simply drops the unused frames.