### PR TITLE
Add ability to powercycle slots from pysmurf

### DIFF
--- a/python/pysmurf/client/shelf/shelf.py
+++ b/python/pysmurf/client/shelf/shelf.py
@@ -1,0 +1,19 @@
+"""
+Interact with the SMuRF shelf manager, for example,
+shm-smrf-sp01. The SMuRF shelf manager is its own host, accessible
+from the SMuRF server only. Most common operation is deactivating and
+activating one of the shelf's slots.
+"""
+
+import subprocess
+
+def run_crate_command(command):
+    crate_hostname = 'shm-smrf-sp01'
+    subprocess.call(f'ssh {crate_hostname} {command}')
+
+def reactivate_slot(slot):
+    slot = str(slot)
+    run_crate_command(f'clia deactivate board {slot}')
+    time.sleep(5)
+    run_crate_command(f'clia activate board {slot}')
+

--- a/server_scripts/test_connection.py
+++ b/server_scripts/test_connection.py
@@ -1,0 +1,8 @@
+"""
+Sanity test for running scripts in pysmurf.
+"""
+
+import pysmurf.client
+
+if __name__ == '__main__':
+    print('I am main')


### PR DESCRIPTION
Because the SMuRF docker containers are networked, we can call SSH into the shelfmanagers directly and run clia commands. This opens the ability to powercycle slots, adjust fan levels, etc. I'm pretty sure sodetlib does something like this.