### PR TITLE
Add commands for external timing functionality

### DIFF
--- a/cfg_files/slac/experiment_rflab_onlyBay0.cfg
+++ b/cfg_files/slac/experiment_rflab_onlyBay0.cfg
@@ -1,0 +1,336 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask" : {
+},
+
+"amplifier": {
+	     "hemt_Vg" : 0.490,
+	     "bit_to_V_hemt" : 1.92e-6,
+	     "hemt_Id_offset" : 0.12891,
+	     "LNA_Vg" : -0.75,
+	     # 32 if using a C02 cryostat card.  Some C01s were
+	     # kludged to provide a 50k gate voltage for ASU 50K LNAs
+	     # in early testing.  For those, use 2.	     
+	     "dac_num_50k" : 32,
+	     "50k_Id_offset" : 0,
+	     "bit_to_V_50k" : 3.88e-6,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24],
+        "12" : [25,26],
+        "13" : [27,28],
+        "14" : [29,30]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 25479,
+"high_low_current_ratio" : 12.50,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [3],
+
+"tune_band" : {
+	"reset_rate_khz" : 4.0,
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.495,
+	"delta_freq" : {
+		    "0" : 0.02,	
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02
+	},		
+	"lms_freq": {
+		    "0" : 16500,	
+		    "1" : 16500,
+		    "2" : 16500,
+		    "3" : 16500
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,	
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,		    
+		    "2" : 0.98,
+		    "3" : 0.98
+	},	
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,		    
+		    "2" : 1e-4,
+		    "3" : 1e-4
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1
+        },
+	"gradient_descent_converge_hz": {
+		    "0" : 500,
+		    "1" : 500,		    
+		    "2" : 500,
+		    "3" : 500
+        },
+	"gradient_descent_step_hz": {
+		    "0" : 1000,
+		    "1" : 1000,		    
+		    "2" : 1000,
+		    "3" : 1000
+        },
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,		    
+		    "2" : 0,
+		    "3" : 0
+        },
+	"gradient_descent_momentum": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1
+        },	
+	"eta_scan_del_f": {
+                    "0": 5000,
+                    "1": 5000,
+                    "2": 5000,
+                    "3": 5000
+        },
+        "eta_scan_amplitude":{
+                    "0" : 12,
+                    "1" : 12,
+                    "2" : 12,
+                    "3" : 12
+        },
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "ext_ref"
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 0,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 0,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+# For remote commanding
+#"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/cfg_files/slac/experiment_rflab_thermal_testing_201907.cfg
+++ b/cfg_files/slac/experiment_rflab_thermal_testing_201907.cfg
@@ -1,0 +1,488 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_4" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_5" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_6" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_7" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask" : {
+},
+
+"amplifier": {
+	     "hemt_Vg" : 0.490,
+	     "bit_to_V_hemt" : 1.92e-6,
+	     "hemt_Id_offset" : 0.12891,
+	     "LNA_Vg" : -0.75,
+	     # 32 if using a C02 cryostat card.  Some C01s were
+	     # kludged to provide a 50k gate voltage for ASU 50K LNAs
+	     # in early testing.  For those, use 2.	     
+	     "dac_num_50k" : 32,
+	     "50k_Id_offset" : 0,
+	     "bit_to_V_50k" : 3.88e-6,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24],
+        "12" : [25,26],
+        "13" : [27,28],
+        "14" : [29,30]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 25479,
+"high_low_current_ratio" : 12.50,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [3],
+
+"tune_band" : {
+	"reset_rate_khz" : 4.0,
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.495,
+	"delta_freq" : {
+		    "0" : 0.02,	
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02,
+		    "4" : 0.02,
+		    "5" : 0.02,
+		    "6" : 0.02,
+		    "7" : 0.02
+	},		
+	"lms_freq": {
+		    "0" : 16500,	
+		    "1" : 16500,
+		    "2" : 16500,
+		    "3" : 16500,
+		    "4" : 16500,
+		    "5" : 16500,
+		    "6" : 16500,
+		    "7" : 16500
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,	
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05,
+		    "4" : 0.05,
+		    "5" : 0.05,
+		    "6" : 0.05,
+		    "7" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,		    
+		    "2" : 0.98,
+		    "3" : 0.98,
+		    "4" : 0.98,
+		    "5" : 0.98,
+		    "6" : 0.98,
+		    "7" : 0.98		    
+	},	
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,		    
+		    "2" : 1e-4,
+		    "3" : 1e-4,
+		    "4" : 1e-4,
+		    "5" : 1e-4,
+		    "6" : 1e-4,
+		    "7" : 1e-4		    
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        },
+	"gradient_descent_converge_hz": {
+		    "0" : 500,
+		    "1" : 500,		    
+		    "2" : 500,
+		    "3" : 500,
+		    "4" : 500,
+		    "5" : 500,
+		    "6" : 500,
+		    "7" : 500		    
+        },
+	"gradient_descent_step_hz": {
+		    "0" : 1000,
+		    "1" : 1000,		    
+		    "2" : 1000,
+		    "3" : 1000,
+		    "4" : 1000,
+		    "5" : 1000,
+		    "6" : 1000,
+		    "7" : 1000		    
+        },
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,		    
+		    "2" : 0,
+		    "3" : 0,
+		    "4" : 0,
+		    "5" : 0,
+		    "6" : 0,
+		    "7" : 0
+        },
+	"gradient_descent_momentum": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1
+        },	
+	"eta_scan_del_f": {
+                    "0": 5000,
+                    "1": 5000,
+                    "2": 5000,
+                    "3": 5000,
+                    "4": 5000,
+                    "5": 5000,
+                    "6": 5000,
+                    "7": 5000		    
+        },
+        "eta_scan_amplitude":{
+                    "0" : 12,
+                    "1" : 12,
+                    "2" : 12,
+                    "3" : 12,
+                    "4" : 12,
+                    "5" : 12,
+                    "6" : 12,		    
+                    "7" : 12		    
+        },
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "ext_ref"
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 0,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+# For remote commanding
+#"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/cfg_files/slac/experiment_so_westpak_6carrier_14day_test.cfg
+++ b/cfg_files/slac/experiment_so_westpak_6carrier_14day_test.cfg
@@ -1,0 +1,488 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_4" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_5" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_6" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_7" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask" : {
+},
+
+"amplifier": {
+	     "hemt_Vg" : 0.490,
+	     "bit_to_V_hemt" : 1.92e-6,
+	     "hemt_Id_offset" : 0.12891,
+	     "LNA_Vg" : -0.75,
+	     # 32 if using a C02 cryostat card.  Some C01s were
+	     # kludged to provide a 50k gate voltage for ASU 50K LNAs
+	     # in early testing.  For those, use 2.	     
+	     "dac_num_50k" : 32,
+	     "50k_Id_offset" : 0,
+	     "bit_to_V_50k" : 3.88e-6,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24],
+        "12" : [25,26],
+        "13" : [27,28],
+        "14" : [29,30]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 25479,
+"high_low_current_ratio" : 12.50,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [3],
+
+"tune_band" : {
+	"reset_rate_khz" : 4.0,
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.495,
+	"delta_freq" : {
+		    "0" : 0.02,	
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02,
+		    "4" : 0.02,
+		    "5" : 0.02,
+		    "6" : 0.02,
+		    "7" : 0.02
+	},		
+	"lms_freq": {
+		    "0" : 16500,	
+		    "1" : 16500,
+		    "2" : 16500,
+		    "3" : 16500,
+		    "4" : 16500,
+		    "5" : 16500,
+		    "6" : 16500,
+		    "7" : 16500
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,	
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05,
+		    "4" : 0.05,
+		    "5" : 0.05,
+		    "6" : 0.05,
+		    "7" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,		    
+		    "2" : 0.98,
+		    "3" : 0.98,
+		    "4" : 0.98,
+		    "5" : 0.98,
+		    "6" : 0.98,
+		    "7" : 0.98		    
+	},	
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,		    
+		    "2" : 1e-4,
+		    "3" : 1e-4,
+		    "4" : 1e-4,
+		    "5" : 1e-4,
+		    "6" : 1e-4,
+		    "7" : 1e-4		    
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        },
+	"gradient_descent_converge_hz": {
+		    "0" : 500,
+		    "1" : 500,		    
+		    "2" : 500,
+		    "3" : 500,
+		    "4" : 500,
+		    "5" : 500,
+		    "6" : 500,
+		    "7" : 500		    
+        },
+	"gradient_descent_step_hz": {
+		    "0" : 1000,
+		    "1" : 1000,		    
+		    "2" : 1000,
+		    "3" : 1000,
+		    "4" : 1000,
+		    "5" : 1000,
+		    "6" : 1000,
+		    "7" : 1000		    
+        },
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,		    
+		    "2" : 0,
+		    "3" : 0,
+		    "4" : 0,
+		    "5" : 0,
+		    "6" : 0,
+		    "7" : 0
+        },
+	"gradient_descent_momentum": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1
+        },	
+	"eta_scan_del_f": {
+                    "0": 5000,
+                    "1": 5000,
+                    "2": 5000,
+                    "3": 5000,
+                    "4": 5000,
+                    "5": 5000,
+                    "6": 5000,
+                    "7": 5000		    
+        },
+        "eta_scan_amplitude":{
+                    "0" : 12,
+                    "1" : 12,
+                    "2" : 12,
+                    "3" : 12,
+                    "4" : 12,
+                    "5" : 12,
+                    "6" : 12,		    
+                    "7" : 12		    
+        },
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "ext_ref"
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 0,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+# For remote commanding
+#"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/cfg_files/slac/rflab_smurf_startup.cfg
+++ b/cfg_files/slac/rflab_smurf_startup.cfg
@@ -1,0 +1,44 @@
+shelfmanager=shm-smrf-sp01
+
+set_crate_fans_to_full=true
+# COMTEL max fan level is 100, ASIS is 15, ELMA is 15
+## COMTEL in RF lab
+max_fan_level=100
+
+# more often used
+attach_at_end=true
+configure_pysmurf=true
+reboot=true
+using_timing_master=false
+start_atca_monitor=true
+disable_streaming=true
+parallel_setup=false
+
+# Less often used
+# requires tmux-logging plugin
+enable_tmux_logging=false
+screenshot_signal_analyzer=false
+run_full_band_response=false
+run_half_band_test=false
+write_config=false
+save_state=false
+
+# go go go
+cpwd=$PWD
+
+pysmurf=/home/cryo/docker/pysmurf/dev/v5.0.2
+
+crate_id=1
+
+unset slot_cfgs
+read -r -d '' slot_cfgs << EOM
+6    /home/cryo/docker/smurf/stable/slotN/v5.0.2        cfg_files/rflab/experiment_rflab_thermal_testing_201907.cfg
+EOM
+#3    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0        cfg_files/rflab/experiment_rflab_onlyBay0.cfg
+
+#pysmurf_init_script=scratch/shawn/scripts/init_rflab.py
+
+tmux_session_name=smurf
+
+thermal_test_script=scratch/shawn/thermal_test.py
+run_thermal_test=false

--- a/cfg_files/slac/rflab_smurf_startup_stephen_test.cfg
+++ b/cfg_files/slac/rflab_smurf_startup_stephen_test.cfg
@@ -1,0 +1,45 @@
+shelfmanager=shm-smrf-sp01
+
+set_crate_fans_to_full=true
+# COMTEL max fan level is 100, ASIS is 15, ELMA is 15
+## COMTEL in RF lab
+max_fan_level=100
+
+# more often used
+attach_at_end=true
+configure_pysmurf=true
+reboot=true
+using_timing_master=false
+start_atca_monitor=true
+disable_streaming=true
+parallel_setup=false
+
+# Less often used
+# requires tmux-logging plugin
+enable_tmux_logging=false
+screenshot_signal_analyzer=false
+run_full_band_response=false
+run_half_band_test=false
+write_config=false
+save_state=false
+
+# go go go
+cpwd=$PWD
+
+pysmurf=/home/cryo/docker/pysmurf/dev/v5.0.2
+
+crate_id=1
+
+unset slot_cfgs
+read -r -d '' slot_cfgs << EOM
+6    /home/cryo/docker/smurf/stable/slotN/v5.0.2	cfg_files/rflab/experiment_rflab_thermal_testing_201907.cfg
+EOM
+
+#pysmurf_init_script=scratch/shawn/scripts/init_rflab.py
+
+tmux_session_name=smurf
+
+#thermal_test_script=scratch/shawn/thermal_test.py
+#run_thermal_test=false
+
+script_to_run=scratch/stephen/full_band_response_AMCatten.py

--- a/cfg_files/slac/smurf_startup_6carrier.cfg
+++ b/cfg_files/slac/smurf_startup_6carrier.cfg
@@ -1,0 +1,39 @@
+shelfmanager=shm-smrf-sp01
+
+set_crate_fans_to_full=true
+max_fan_level=50
+
+# more often used
+attach_at_end=true
+# don't configure pysmurf for thermal test because we want to run
+# setup for first time as a part of the thermal test.
+configure_pysmurf=true
+reboot=true
+using_timing_master=false
+start_atca_monitor=true
+disable_streaming=false
+parallel_setup=true
+
+# less often used
+screenshot_signal_analyzer=false
+run_half_band_test=false
+write_config=true
+
+# go go go
+cpwd=$PWD
+
+pysmurf=/home/cryo/docker/pysmurf/dev/v4.1.0
+
+crate_id=1
+
+unset slot_cfgs
+read -r -d '' slot_cfgs << EOM
+2    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/rflab/experiment_so_westpak_6carrier_14day_test.cfg
+3    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/rflab/experiment_so_westpak_6carrier_14day_test.cfg
+4    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/rflab/experiment_so_westpak_6carrier_14day_test.cfg
+5    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/rflab/experiment_so_westpak_6carrier_14day_test.cfg
+6    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/rflab/experiment_so_westpak_6carrier_14day_test.cfg
+7    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/rflab/experiment_so_westpak_6carrier_14day_test.cfg
+EOM
+
+tmux_session_name=smurf

--- a/cfg_files/slac/smurf_startup_dan.cfg
+++ b/cfg_files/slac/smurf_startup_dan.cfg
@@ -1,0 +1,43 @@
+shelfmanager=shm-smrf-sp01
+
+set_crate_fans_to_full=true
+# COMTEL max fan level is 100, ASIS is 15, ELMA is 15
+## COMTEL in RF lab
+#max_fan_level=50
+## ELMA in RF lab
+#max_fan_level=15
+## ASIS in RF lab
+max_fan_level=50
+
+# more often used
+attach_at_end=true
+configure_pysmurf=true
+reboot=true
+using_timing_master=false
+start_atca_monitor=true
+disable_streaming=true
+parallel_setup=false
+
+# less often used
+screenshot_signal_analyzer=false
+run_half_band_test=false
+write_config=false	
+
+# go go go
+cpwd=$PWD
+
+pysmurf=/home/cryo/docker/pysmurf/v4.0.0
+
+crate_id=3
+
+unset slot_cfgs
+read -r -d '' slot_cfgs << EOM
+3    /home/cryo/docker/smurf/dev_fw/slotN/v4.0.0	cfg_files/rflab/experiment_rflab_thermal_testing_201907.cfg
+EOM
+
+#pysmurf_init_script=scratch/shawn/scripts/init_rflab.py
+
+tmux_session_name=smurf
+
+thermal_test_script=scratch/shawn/thermal_test.py
+run_thermal_test=false

--- a/cfg_files/slac/smurf_startup_low_power_test.cfg
+++ b/cfg_files/slac/smurf_startup_low_power_test.cfg
@@ -1,0 +1,46 @@
+shelfmanager=shm-smrf-sp01
+
+set_crate_fans_to_full=true
+# COMTEL max fan level is 100, ASIS is 15, ELMA is 15
+## COMTEL in RF lab
+#max_fan_level=50
+## ELMA in RF lab
+#max_fan_level=15
+## ASIS in RF lab
+max_fan_level=100
+
+# more often used
+attach_at_end=true
+# don't configure pysmurf for the low power test because we want to
+# run setup for first time as a part of the test.
+configure_pysmurf=false
+reboot=true
+using_timing_master=false
+start_atca_monitor=true
+disable_streaming=true
+parallel_setup=false
+
+# less often used
+enable_tmux_logging=true
+screenshot_signal_analyzer=false
+run_half_band_test=false
+write_config=false	
+
+# go go go
+cpwd=$PWD
+
+pysmurf=/home/cryo/docker/pysmurf/v5.0.2
+
+crate_id=3
+
+unset slot_cfgs
+read -r -d '' slot_cfgs << EOM
+6    /home/cryo/docker/smurf/dev_fw/slotN/v5.0.2	cfg_files/rflab/experiment_rflab_thermal_testing_201907.cfg
+EOM
+
+#pysmurf_init_script=scratch/shawn/scripts/init_rflab.py
+
+tmux_session_name=smurf
+
+# this script will run at the end of the hammer.
+script_to_run=scratch/shawn/test_new_carrier.py

--- a/cfg_files/slac/smurf_startup_mitch.cfg
+++ b/cfg_files/slac/smurf_startup_mitch.cfg
@@ -1,0 +1,36 @@
+shelfmanager=shm-smrf-sp01
+
+set_crate_fans_to_full=true
+# COMTEL max fan level is 100, ASIS is 15, ELMA is 15
+## COMTEL in RF lab
+max_fan_level=100
+## ELMA in RF lab
+#max_fan_level=15
+## ASIS in RF lab
+#max_fan_level=15
+
+attach_at_end=true
+screenshot_signal_analyzer=false
+configure_pysmurf=true
+reboot=true
+using_timing_master=false
+run_half_band_test=false
+write_config=false	
+start_atca_monitor=true
+disable_streaming=true
+# still not completely parallel.  Also doesn't work.
+parallel_setup=true
+cpwd=$PWD
+
+pysmurf=/home/cryo/docker/pysmurf/dspv3
+
+crate_id=3
+
+unset slot_cfgs
+read -r -d '' slot_cfgs << EOM
+4   /home/cryo/docker/smurf/dev_fw/jesd-dev-dual-bay 
+EOM
+
+pysmurf_init_script=scratch/shawn/scripts/init_rflab.py
+
+tmux_session_name=smurf

--- a/cfg_files/slac/smurf_startup_so_westpak_6carrier_14day_test.cfg
+++ b/cfg_files/slac/smurf_startup_so_westpak_6carrier_14day_test.cfg
@@ -1,0 +1,42 @@
+shelfmanager=shm-smrf-sp01
+
+set_crate_fans_to_full=true
+max_fan_level=50
+
+# more often used
+attach_at_end=true
+# don't configure pysmurf for thermal test because we want to run
+# setup for first time as a part of the thermal test.
+configure_pysmurf=false
+reboot=true
+using_timing_master=false
+start_atca_monitor=true
+disable_streaming=true
+parallel_setup=true
+
+# less often used
+screenshot_signal_analyzer=false
+run_half_band_test=false
+write_config=false
+
+# go go go
+cpwd=$PWD
+
+pysmurf=/home/cryo/docker/pysmurf/dev/v4.1.0
+
+crate_id=1
+
+unset slot_cfgs
+read -r -d '' slot_cfgs << EOM
+2    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/rflab/experiment_so_westpak_6carrier_14day_test.cfg
+3    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/rflab/experiment_so_westpak_6carrier_14day_test.cfg
+4    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/rflab/experiment_so_westpak_6carrier_14day_test.cfg
+5    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/rflab/experiment_so_westpak_6carrier_14day_test.cfg
+6    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/rflab/experiment_so_westpak_6carrier_14day_test.cfg
+7    /home/cryo/docker/smurf/dev_fw/slotN/v4.1.0	cfg_files/rflab/experiment_so_westpak_6carrier_14day_test.cfg
+EOM
+
+tmux_session_name=smurf
+
+thermal_test_script=scratch/shawn/thermal_test.py
+#run_thermal_test=true

--- a/cfg_files/slac/smurf_startup_thermal_test.cfg
+++ b/cfg_files/slac/smurf_startup_thermal_test.cfg
@@ -1,0 +1,45 @@
+shelfmanager=shm-smrf-sp01
+
+set_crate_fans_to_full=true
+# COMTEL max fan level is 100, ASIS is 15, ELMA is 15
+## COMTEL in RF lab
+#max_fan_level=50
+## ELMA in RF lab
+#max_fan_level=15
+## ASIS in RF lab
+max_fan_level=100
+
+# more often used
+attach_at_end=true
+# don't configure pysmurf for thermal test because we want to run
+# setup for first time as a part of the thermal test.
+configure_pysmurf=false
+reboot=true
+using_timing_master=false
+start_atca_monitor=true
+disable_streaming=true
+parallel_setup=false
+
+# less often used
+screenshot_signal_analyzer=false
+run_half_band_test=false
+write_config=false	
+
+# go go go
+cpwd=$PWD
+
+pysmurf=/home/cryo/docker/pysmurf/dev/v5.0.2
+
+crate_id=1
+
+unset slot_cfgs
+read -r -d '' slot_cfgs << EOM
+6    /home/cryo/docker/smurf/dev_sw/slotN/v5.0.2	cfg_files/rflab/experiment_rflab_thermal_testing_201907.cfg
+EOM
+
+#pysmurf_init_script=scratch/shawn/scripts/init_rflab.py
+
+tmux_session_name=smurf
+
+thermal_test_script=scratch/shawn/thermal_test.py
+run_thermal_test=true

--- a/cfg_files/slac/srv11.cfg
+++ b/cfg_files/slac/srv11.cfg
@@ -1,0 +1,303 @@
+# srv11.cfg
+
+# Cryocard: No
+# Bay 0 (right): C03
+# Bay 1 (left): No
+# Carrier: C03-04
+# Timing: Yes
+
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"bandDelayUs" : 8.8,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"bandDelayUs" : 8.8,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"bandDelayUs" : 8.8,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"bandDelayUs" : 8.8,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask": {
+	"0": [5000, 5100],
+	"1": [5171.64, 5171.74]
+},
+
+"amplifier": {
+	     "hemt_Vg" : 0.28,
+	     "bit_to_V_hemt" : 1.93e-06,
+	     "hemt_Id_offset" : 0.2643,
+	     "LNA_Vg" : -0.79,
+	     "50k_Id_offset" : 0.0,
+	     # 32 if using a C02 cryostat card.  Some C01s were
+	     # kludged to provide a 50k gate voltage for ASU 50K LNAs
+	     # in early testing.  For those, use 2.
+	     "dac_num_50k" : 32,
+	     "bit_to_V_50k" : 3.38e-06,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 15800,
+"high_low_current_ratio" : 6.08,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [7],
+
+"tune_band" : {
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.489,
+	"reset_rate_khz": 4.0,
+	"delta_freq": {
+		    "0" : 0.02,
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02
+        },
+	"lms_freq": {
+		    "0" : 16500,
+		    "1" : 19945,
+		    "2" : 19986,
+		    "3" : 20218
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,
+		    "2" : 0.98,
+		    "3" : 0.98
+	},
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,
+		    "2" : 1e-4,
+		    "3" : 1e-4
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,
+		    "2" : 1,
+		    "3" : 1
+        },
+	"gradient_descent_converge_hz":{
+		    "0" : 500,
+		    "1" : 500,
+		    "2" : 500,
+		    "3" : 500
+	},
+	"gradient_descent_step_hz":{
+		    "0" : 1000,
+		    "1" : 1000,
+		    "2" : 1000,
+		    "3" : 1000
+	},
+	"gradient_descent_momentum":{
+		    "0" : 1,
+		    "1" : 1,
+		    "2" : 1,
+		    "3" : 1
+	},
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,
+		    "2" : 0,
+		    "3" : 0
+	},
+	"eta_scan_del_f": {
+		    "0": 5000,
+		    "1": 5000,
+		    "2": 5000,
+		    "3": 5000
+	},
+	"eta_scan_amplitude":{
+		    "0" : 12,
+		    "1" : 12,
+		    "2" : 12,
+		    "3" : 12
+	},
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,
+		    "2" : 1,
+		    "3" : 1
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "backplane"
+},
+
+"fs" : 200.0,
+
+# This section is for smurf_to_mce, the transmission from SMuRF to the
+# Keck GCP. This is mostly depracated.
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 4,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/python/pysmurf/client/command/cryo_card.py
+++ b/python/pysmurf/client/command/cryo_card.py
@@ -213,7 +213,7 @@ class CryoCard():
     def write_ps_en(self, enables):
         """
         Write the bits that turn on the drain LDOs. Do not use this
-        directly. Instead, use set_amp_drain_voltage. 
+        directly. Instead, use set_amp_drain_voltage.
 
         Args
         ----

--- a/python/pysmurf/client/command/cryo_card.py
+++ b/python/pysmurf/client/command/cryo_card.py
@@ -194,7 +194,8 @@ class CryoCard():
 
     def write_ps_en(self, enables):
         """
-        Write the power supply enable signals.
+        Write the bits that turn on the drain LDOs. Do not use this
+        directly. Instead, use set_amp_drain_voltage. 
 
         Args
         ----

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5152,7 +5152,7 @@ class SmurfCommandMixin(SmurfBase):
         T = self.C.read_temperature()
 
         if T < 0:
-            self.log(f'get_cryo_card_temp: Temperature is below 0 C, is it connected?')
+            self.log('get_cryo_card_temp: Temperature is below 0 C, is it connected?')
 
         if disable_poll:
             epics.caput(

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5941,7 +5941,7 @@ class SmurfCommandMixin(SmurfBase):
 
     _downsampler_mode_reg = 'Downsampler:DownsamplerMode'
 
-    def set_downsampler_mode(self, mode):
+    def set_downsample_mode(self, mode):
         """
         Set the downsampler mode. 0 is internal, 1 is external.
 
@@ -5953,9 +5953,9 @@ class SmurfCommandMixin(SmurfBase):
         if mode == 'external':
             self._caput(self.smurf_processor + self._downsampler_mode_reg, 1)
         else:
-            self.log(f'set_downsampler_mode: Unknown mode {mode}')
+            self.log(f'set_downsample_mode: Unknown mode {mode}')
 
-    def get_downsampler_mode(self):
+    def get_downsample_mode(self):
         """
         Get the downsampler mode. 0 is internal, 1 is external.
 
@@ -5971,13 +5971,13 @@ class SmurfCommandMixin(SmurfBase):
         elif mode == 1:
             ret = 'external'
         else:
-            self.log(f'get_downsampler_mode: Unknown mode {mode}')
+            self.log(f'get_downsample_mode: Unknown mode {mode}')
 
         return ret
 
     _downsampler_factor_reg = 'Downsampler:InternalFactor'
 
-    def set_downsampler_factor(self, factor, **kwargs):
+    def set_downsample_factor(self, factor, **kwargs):
         """
         Set the smurf processor down-sampling factor.
 
@@ -6007,14 +6007,14 @@ class SmurfCommandMixin(SmurfBase):
             self.log("get_downsample_factor: offline is True, SmurfProcessor.cpp is not running..")
             return 20
 
-        if self.get_downsampler_mode() == 'external':
-            self.log('get_downsample_factor: get_downsampler_mode is external, the factor is not used')
+        if self.get_downsample_mode() == 'external':
+            self.log('get_downsample_factor: get_downsample_mode is external, the factor is not used')
 
         return self._caget(self.smurf_processor + self._downsampler_factor_reg, **kwargs)
 
     _downsampler_external_bitmask_reg = 'Downsampler:ExternalBitmask'
 
-    def set_downsampler_external_bitmask(self, bitmask):
+    def set_downsample_external_bitmask(self, bitmask):
         """
         Set the downsampler external bitmask.
 
@@ -6022,10 +6022,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         self._caput(self.smurf_processor + self._downsampler_external_bitmask_reg, bitmask)
 
-    def get_downsampler_external_bitmask(self):
+    def get_downsample_external_bitmask(self):
         """
         Get the downsampler external bitmask. This bitmask is only used
-        when get_downsampler_mode is external. For example, 0 means
+        when get_downsample_mode is external. For example, 0 means
         never trigger, 1 means trigger on the first bit, 2 will
         trigger on the second bit, 4 will trigger on the third bit. By
         bit, we mean when the bit flips in one direction, because the

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -120,7 +120,7 @@ class SmurfNoiseMixin(SmurfBase):
 
         if fs is None:
             if downsample_factor is None:
-                downsample_factor = self.get_downsampler_internal_factor()
+                downsample_factor = self.get_downsample_factor()
             fs = flux_ramp_freq/downsample_factor
 
         # Generate downsample transfer function - downsampling is at

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -869,9 +869,9 @@ class SmurfUtilMixin(SmurfBase):
         bands = self._bands
 
         if downsample_factor is not None:
-            self.set_downsampler_internal_factor(downsample_factor)
+            self.set_downsampler_factor(downsample_factor)
         else:
-            downsample_factor = self.get_downsampler_internal_factor()
+            downsample_factor = self.get_downsample_factor()
             if write_log:
                 self.log('Input downsample factor is None. Using '+
                      'value already in pyrogue:'+
@@ -3197,7 +3197,7 @@ class SmurfUtilMixin(SmurfBase):
         # Get filter order, gain, and averages
         filter_order = self.get_filter_order()
         filter_gain = self.get_filter_gain()
-        num_averages = self.get_downsampler_internal_factor()
+        num_averages = self.get_downsample_factor()
 
         # Get filter order, gain, and averages
 
@@ -3354,7 +3354,7 @@ class SmurfUtilMixin(SmurfBase):
 
         # Calculate sampling frequency
         # flux_ramp_freq = self.get_flux_ramp_freq() * 1.0E3
-        # fs = flux_ramp_freq * self.get_downsampler_internal_factor()
+        # fs = flux_ramp_freq * self.get_downsample_factor()
 
         # Cast the bias group as an array
         bias_group = np.ravel(np.array(bias_group))
@@ -4133,7 +4133,7 @@ class SmurfUtilMixin(SmurfBase):
             The data sample rate in Hz.
         """
         flux_ramp_freq = self.get_flux_ramp_freq() * 1.0E3
-        downsample_factor = self.get_downsampler_internal_factor()
+        downsample_factor = self.get_downsample_factor()
 
         return flux_ramp_freq / downsample_factor
 
@@ -4181,7 +4181,7 @@ class SmurfUtilMixin(SmurfBase):
         """
         # Check if probe frequency is too high
         flux_ramp_freq = self.get_flux_ramp_freq() * 1.0E3
-        fs = flux_ramp_freq * self.get_downsampler_internal_factor()
+        fs = flux_ramp_freq * self.get_downsample_factor()
 
         # Calculate downsample filter transfer function
         filter_params = self.get_filter_params()

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -869,7 +869,7 @@ class SmurfUtilMixin(SmurfBase):
         bands = self._bands
 
         if downsample_factor is not None:
-            self.set_downsampler_factor(downsample_factor)
+            self.set_downsample_factor(downsample_factor)
         else:
             downsample_factor = self.get_downsample_factor()
             if write_log:


### PR DESCRIPTION
## Issue
This PR improves docstrings and does some cleanup for [ESCRYODET-472](https://jira.slac.stanford.edu/browse/ESCRYODET-472), which is the SLAC JIRA issue for adding external triggering to the downsampler.  Also adds a convenience function `get_timing_fiber_status` for confirming a slot 2 carrier receiving timing over fiber and distributing it over the backplane is receiving timing data and has its crossbar configured properly, and reverts to our prior convention of using `downsample` instead of `downsampler` in the names of all functions related to downsampling. 

## Description

Backwards compatible changes in this PR include:
* Improved or added missing docstrings for the `write_ps_en`, `get_cryo_card_temp`, `get_crossbar_output_config`, `get_downsample_factor`, `get_downsampler_external_bitmask`, `set_filter_disable`, 
* Adds warning if `get_cryo_card_temp` returns a negative temperature (which usually only happens if no cryostat card is connected).
* Adds `get_timing_fiber_status` function which if run on a slot2 system distributing timing on the backplane to other SMuRF systems, checks if the slot2 system is receiving timing and properly configured to distribute those signals into the backplane via the crossbar configuration.
* Changes names of the `set_downsampler_internal_factor` and `get_downsampler_internal_factor` back to `set_downsample_factor` and `get_downsample_factor`.  Elsewhere any new functions relating to downsampler use downsample in their name instead of downsampler.
