### PR TITLE
Adds data_path_id to the tune_dir

### DIFF
--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -242,7 +242,10 @@ class SmurfControl(SmurfCommandMixin,
                 self.output_dir = os.path.join(self.base_dir, self.date,
                                                data_path_id, name, 'outputs')
 
-            self.tune_dir = self._tune_dir
+            if data_path_id is None:
+                self.tune_dir = self._tune_dir
+            else:
+                self.tune_dir = os.path.join(self._tune_dir, data_path_id)
 
             if data_path_id is None:
                 self.plot_dir = os.path.join(self.base_dir, self.date, name,

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -4790,8 +4790,7 @@ class SmurfTuneMixin(SmurfBase):
         freq_dict : dict
             Resonance dictionary like the one that comes out of
             find_freqs You probably want to assign it to the right
-            place, as in S.freq_resp = S.fake_resonance_dict(freqs,
-            bands)
+            place, as in S.freq_resp = S.fake_resonance_dict(freqs).
         """
 
         bands = self._bands


### PR DESCRIPTION
Adds `data_path_id` to the tune_dir to make sure different slots have unique paths.

## Description
We just noticed tune data from different slots are all being saved to the same directory. This can be problematic when operating multiple slots simultaneously, as it's possible that different slots have the same timestamp associated with the tune, in which case the tune-files will be overwritten. Additionally, attempting to pull the latest tune_file using `S.load_tune()` will pull the most recent one out of all slots. 

We added `data_path_id` before to make sure `output` and `plot` directories don't conflict across slots, so it makes sense to extend this to the tune directory as well.

## Tests done on this branch
None yet but it seems straight-forward

## Function interfaces that changed
None
