### PR TITLE
pyepics use_monitor=False override for all caget calls for forwards pyepics compatibility

### DIFF
--- a/python/pysmurf/client/command/cryo_card.py
+++ b/python/pysmurf/client/command/cryo_card.py
@@ -61,19 +61,19 @@ class CryoCard():
 
     def do_read(self, address, use_monitor=False):
         r"""Writes query to cryostat card PIC and reads reply.
-                                                                                
-        Args                                                                    
+
+        Args
         ----
         address : int
             Address of PIC register to read.
-        use_monitor : bool, optional, default False                             
-            Passed directly to the underlying pyepics `epics.caget`             
-            function call.  This was added to maintain default                  
-            behavior because this option was changed from default               
+        use_monitor : bool, optional, default False
+            Passed directly to the underlying pyepics `epics.caget`
+            function call.  This was added to maintain default
+            behavior because this option was changed from default
             `False` to default `True` in later versions of pyepics.
-        
-        Returns                                                                 
-        -------                                                                 
+
+        Returns
+        -------
         ret : int or 0
             The requested value.  Returns 0 if no reply (which
             typically means no cryostat card is connected).
@@ -85,8 +85,8 @@ class CryoCard():
             data = epics.caget(self.readpv, use_monitor=use_monitor)
             addrrb = cmd_address(data)
             if (addrrb == address):
-                return(data)
-        return(0)
+                return (data)
+        return (0)
 
         return (epics.caget(self.readpv, use_monitor=use_monitor))
 
@@ -110,9 +110,9 @@ class CryoCard():
         for self.busy_retry in range(0, self.max_retries):
             data = self.do_read(self.relay_address)
             if ~(data & 0x80000):  # check that not moving
-                return(data & 0x7FFFF)
+                return (data & 0x7FFFF)
                 time.sleep(0.1) # wait for relays to move
-        return(80000) # busy flag still set
+        return (80000) # busy flag still set
 
     def set_relay_bit(self, bit, value):
         """
@@ -204,11 +204,11 @@ class CryoCard():
     def read_temperature(self):
         data = self.do_read(self.temperature_address)
         volts = (data & 0xFFFFF) * self.adc_scale
-        return((volts - self.temperature_offset) * self.temperature_scale)
+        return ((volts - self.temperature_offset) * self.temperature_scale)
 
     def read_cycle_count(self):
         data = self.do_read(self.count_address)
-        return( cmd_data(data))  # do we have the right addres
+        return (cmd_data(data))  # do we have the right addres
 
     def write_ps_en(self, enables):
         """
@@ -246,7 +246,7 @@ class CryoCard():
            Bit set to 0 means the power supply is disabled.
         """
         data = self.do_read(self.ps_en_address)
-        return(cmd_data(data))
+        return (cmd_data(data))
 
     def get_fw_version(self):
         """
@@ -320,13 +320,13 @@ class CryoCard():
 # low level data conversion
 
 def cmd_read(data):  # checks for a read bit set in data
-    return( (data & 0x80000000) != 0)
+    return ((data & 0x80000000) != 0)
 
 def cmd_address(data): # returns address data
-    return((data & 0x7FFF0000) >> 20)
+    return ((data & 0x7FFF0000) >> 20)
 
 def cmd_data(data):  # returns data
-    return(data & 0xFFFFF)
+    return (data & 0xFFFFF)
 
 def cmd_make(read, address, data):
-    return((read << 31) | ((address << 20) & 0x7FFF00000) | (data & 0xFFFFF))
+    return ((read << 31) | ((address << 20) & 0x7FFF00000) | (data & 0xFFFFF))

--- a/python/pysmurf/client/command/cryo_card.py
+++ b/python/pysmurf/client/command/cryo_card.py
@@ -59,18 +59,36 @@ class CryoCard():
         self.list_of_c04_amps = ['50k1', '50k2', 'hemt1', 'hemt2']
         self.list_of_c02_and_c04_amps = self.list_of_c02_amps + self.list_of_c04_amps
 
-    def do_read(self, address):
+    def do_read(self, address, use_monitor=False):
+        r"""Writes query to cryostat card PIC and reads reply.
+                                                                                
+        Args                                                                    
+        ----
+        address : int
+            Address of PIC register to read.
+        use_monitor : bool, optional, default False                             
+            Passed directly to the underlying pyepics `epics.caget`             
+            function call.  This was added to maintain default                  
+            behavior because this option was changed from default               
+            `False` to default `True` in later versions of pyepics.
+        
+        Returns                                                                 
+        -------                                                                 
+        ret : int or 0
+            The requested value.  Returns 0 if no reply (which
+            typically means no cryostat card is connected).
+        """
         #need double write to make sure buffer is updated
         epics.caput(self.writepv, cmd_make(1, address, 0))
         for self.retry in range(0, self.max_retries):
             epics.caput(self.writepv, cmd_make(1, address, 0))
-            data = epics.caget(self.readpv)
+            data = epics.caget(self.readpv, use_monitor=use_monitor)
             addrrb = cmd_address(data)
             if (addrrb == address):
                 return(data)
         return(0)
 
-        return (epics.caget(self.readpv))
+        return (epics.caget(self.readpv, use_monitor=use_monitor))
 
     def do_write(self, address, value):
         """Write the given value directly to the address on the PIC. Make sure

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -113,6 +113,7 @@ class SmurfCommandMixin(SmurfBase):
     def _caget(self, cmd, write_log=False, execute=True, count=None,
                log_level=0, enable_poll=False, disable_poll=False,
                new_epics_root=None, yml=None, retry_on_fail=True,
+               use_monitor=False,
                max_retry=5, **kwargs):
         r"""Gets variables from epics.
 
@@ -140,6 +141,11 @@ class SmurfCommandMixin(SmurfBase):
             If not None, yaml file to parse for the result.
         retry_on_fail : bool
             Whether to retry the caget if it fails on first attempt
+        use_monitor : bool, optional, default False
+            Passed directly to the underlying pyepics `epics.caget`
+            function call.  This was added to maintain default
+            behavior because this option was changed from default
+            `False` to default `True` in later versions of pyepics.
         max_retry : int
             The number of times to retry if caget fails the first time.
         \**kwargs
@@ -170,7 +176,7 @@ class SmurfCommandMixin(SmurfBase):
             return tools.yaml_parse(yml, cmd)
         # Get the data
         elif execute and not self.offline:
-            ret = epics.caget(cmd, count=count, **kwargs)
+            ret = epics.caget(cmd, count=count, use_monitor=use_monitor, **kwargs)
 
             # If epics doesn't respond in time, epics.caget returns None.
             if ret is None and retry_on_fail:
@@ -178,7 +184,7 @@ class SmurfCommandMixin(SmurfBase):
                 n_retry = 0
                 while n_retry < max_retry and ret is None:
                     self.log(f'Retry attempt {n_retry+1} of {max_retry}')
-                    ret = epics.caget(cmd, count=count, **kwargs)
+                    ret = epics.caget(cmd, count=count, use_monitor=use_monitor, **kwargs)
                     n_retry += 1
 
             # After retries, raise error

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5336,13 +5336,13 @@ class SmurfCommandMixin(SmurfBase):
         # Both bit
         if status == 0x0:
             # When both readbacks are '0' we are in DC mode
-            return("DC")
+            return ("DC")
         elif status == 0x3:
             # When both readback are '1' we are in AC mode
-            return("AC")
+            return ("AC")
         else:
             # Anything else is an error
-            return("ERROR")
+            return ("ERROR")
 
 
     _smurf_to_gcp_stream_reg = 'userConfig[0]'  # bit for streaming

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -4712,7 +4712,7 @@ class SmurfTuneMixin(SmurfBase):
 
         fmod_array = []
         for n in range(0, num_channels):
-            if(result[n] > 0):
+            if (result[n] > 0):
                 fmod_array.append(result[n])
         mod_median = np.median(fmod_array)
         return mod_median

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -3081,7 +3081,7 @@ class SmurfUtilMixin(SmurfBase):
 
         aph = np.random.choice(aphorisms)
         self.log(aph)
-        return(aph)
+        return (aph)
 
     def make_channel_mask(self, band=None, smurf_chans=None):
         """

--- a/scratch/cyu/cryochannel.py
+++ b/scratch/cyu/cryochannel.py
@@ -32,9 +32,9 @@ def config_cryo_channel(smurfCfg, bandNo, channelNo, frequencyMhz, ampl, \
     epicsRoot = root + CryoChannels + 'CryoChannel[{0}]:'.format(channelNo)
 
     n_subband = epics.caget(root + SysgenCryo + bandStr +  \
-            'numberSubBands') # should be 128
+            'numberSubBands', use_monitor=False) # should be 128
     band = epics.caget(root + SysgenCryo + bandStr + \
-            'digitizerFrequencyMHz') # 614.4 MHz
+            'digitizerFrequencyMHz', use_monitor=False) # 614.4 MHz
     sub_band = band / (n_subband/2) # width of each subband
 
     ## some checks to make sure we put in values within the correct ranges
@@ -184,8 +184,8 @@ def get_subband_from_channel(root, bandNo, channelorderfile, channel):
     """
 
     base_root = root + ":" + SysgenCryo + "Base[{0}]:".format(bandNo)
-    n_subbands = epics.caget(base_root, 'numberSubBands')
-    n_channels = epics.caget(base_root, 'numberChannels')
+    n_subbands = epics.caget(base_root, 'numberSubBands', use_monitor=False)
+    n_channels = epics.caget(base_root, 'numberChannels', use_monitor=False)
     #n_subbands = 128 # just for testing while not hooked up to epics server
     #n_channels = 512
     n_chanpersubband = n_channels / n_subbands
@@ -214,9 +214,9 @@ def get_subband_centers(root, bandNo, asOffset = False):
     """
 
     base_root = root + ":" + SysgenCryo + "Base[{0}]:".format(bandNo)
-    digitizerFrequencyMHz = epics.caget(base_root + 'digitizerFrequencyMHz')
-    bandCenterMHz = epics.caget(base_root + 'bandCenterMHz')
-    n_subbands = epics.caget(base_root + 'numberSubBands')
+    digitizerFrequencyMHz = epics.caget(base_root + 'digitizerFrequencyMHz', use_monitor=False)
+    bandCenterMHz = epics.caget(base_root + 'bandCenterMHz', use_monitor=False)
+    n_subbands = epics.caget(base_root + 'numberSubBands', use_monitor=False)
 
     subband_width_MHz = 2 * digitizerFrequencyMHz / n_subbands
 
@@ -235,8 +235,8 @@ def get_channels_in_subband(root, bandNo, channelorderfile, subband):
     """
 
     base_root = root + ":" + SysgenCryo + "Base[{0}]:".format(bandNo)
-    n_subbands = epics.caget(base_root + 'numberSubBands')
-    n_channels = epics.caget(base_root + 'numberChannels')
+    n_subbands = epics.caget(base_root + 'numberSubBands', use_monitor=False)
+    n_channels = epics.caget(base_root + 'numberChannels', use_monitor=False)
     n_chanpersubband = n_channels / n_subbands
 
     if subband > n_subbands:
@@ -269,7 +269,7 @@ def parallel_scan(root, bandNo, scanchans, Adrive = 10, scanfreqs = None):
     base_root = root + ":" + SysgenCryo + "Base[{0}]:".format(bandNo)
     cryochannels_root = base_root + "CryoChannels:"
 
-    n_channels = epics.caget(base_root + 'numberChannels')
+    n_channels = epics.caget(base_root + 'numberChannels', use_monitor=False)
 
     if scanfreqs is None:
         # default to scanning -3 to 3 about channel center
@@ -294,7 +294,7 @@ def parallel_scan(root, bandNo, scanchans, Adrive = 10, scanfreqs = None):
             epics.caput(cryochannels_root + 'centerFrequencyArray', \
                     scanfreqs[freq, :])
             freq_error[freq, :] = freq_error[freq, :] + realImag[x] * \
-                    epics.caget(cryochannels_root + 'frequencyErrorArray')
+                    epics.caget(cryochannels_root + 'frequencyErrorArray', use_monitor=False)
 
     return freq_error
 

--- a/scratch/cyu/etascan.py
+++ b/scratch/cyu/etascan.py
@@ -42,8 +42,8 @@ def eta_scan(epics_path, subchan, freqs, drive):
     #epics.camonitor(epics_path + "etaScanResultsReal", writer=None, on_change)
     epics.caput(epics_path + "runEtaScan", 1)
 
-    I = epics.caget(epics_path + "etaScanResultsReal", count = len(freqs))
-    Q = epics.caget(epics_path + "etaScanResultsImag", count = len(freqs))
+    I = epics.caget(epics_path + "etaScanResultsReal", count = len(freqs), use_monitor=False)
+    Q = epics.caget(epics_path + "etaScanResultsImag", count = len(freqs), use_monitor=False)
 
     epics.camonitor_clear(epics_path + "etaScanResultsReal")
 
@@ -152,14 +152,14 @@ class etaParams(SmurfStage):
 
         off(self.bandNo)
 
-        bandCenterMHz = epics.caget(baseRootPath + 'bandCenterMHz')
-        n_channels = epics.caget(baseRootPath + 'numberChannels')
-        n_subbands = epics.caget(baseRootPath + 'numberSubBands')
+        bandCenterMHz = epics.caget(baseRootPath + 'bandCenterMHz', use_monitor=False)
+        n_channels = epics.caget(baseRootPath + 'numberChannels', use_monitor=False)
+        n_subbands = epics.caget(baseRootPath + 'numberSubBands', use_monitor=False)
 
         n_channelspersubband = n_channels // n_subbands
         max_channelspersubband = n_channelspersubband # not sure how long we need this constraint
 
-        digitizerFreqMHz = epics.caget(baseRootPath, 'digitizerFrequencyMHz')
+        digitizerFreqMHz = epics.caget(baseRootPath, 'digitizerFrequencyMHz', use_monitor=False)
         subBandHalfWidthMHz = digitizerFreqMHz / n_subbands
 
         subbandchans = np.zeros((1, n_subbands))
@@ -175,9 +175,9 @@ class etaParams(SmurfStage):
 
     def run_old(self):
         n_channels = epics.caget(self.epics_root + SysgenCryo \
-                + "numberChannels") # should be 512 for a 500MHz band
+                + "numberChannels", use_monitor=False) # should be 512 for a 500MHz band
         n_subbands = epics.caget(self.epics_root + SysgenCryo \
-                + "numberSubBands") # is 32 right now
+                + "numberSubBands", use_monitor=False) # is 32 right now
 
         n_subchannels = n_channels / n_subbands # 16
 
@@ -201,9 +201,9 @@ class etaParams(SmurfStage):
             sweep_df = 0.005 # default to 5 kHz
 
         band_center = epics.caget(self.epics_root + SysgenCryo \
-                + "bandCenterMHz") 
+                + "bandCenterMHz", use_monitor=False) 
         subband_order = epics.caget(self.epics_root + SysgenCryo \
-                + "subBandOrder")
+                + "subBandOrder", use_monitor=False)
 
         results = np.zeros((len(freqs), 7))
 

--- a/scratch/shawn/thermal_test.py
+++ b/scratch/shawn/thermal_test.py
@@ -9,7 +9,7 @@ shelfmanager='shm-smrf-sp01'
 
 def get_crate_mfr(shelfmanager,timeout=5):
     print(f'{shelfmanager}:Crate:Sensors:Crate:CrateInfo:manufacturer')
-    crate_mfr=epics.caget(f'{shelfmanager}:Crate:Sensors:Crate:CrateInfo:manufacturer',as_string=True,timeout=5)
+    crate_mfr=epics.caget(f'{shelfmanager}:Crate:Sensors:Crate:CrateInfo:manufacturer',as_string=True,timeout=5, use_monitor=False)
     return crate_mfr
 
 # atca_monitor not working right now, have to hardcode.
@@ -90,7 +90,7 @@ def tmux_cmd(slot_number,cmd,tmux_session_name='smurf'):
     os.system("""tmux send-keys -t {}:{} '{}' C-m""".format(tmux_session_name,slot_number,cmd))
 
 def get_eta_scan_in_progress(slot_number,band,tmux_session_name='smurf',timeout=5):
-    etaScanInProgress=int(epics.caget('smurf_server_s{}:AMCc:FpgaTopLevel:AppTop:AppCore:SysgenCryo:Base[{}]:CryoChannels:etaScanInProgress'.format(slot_number,band),timeout=timeout))
+    etaScanInProgress=int(epics.caget('smurf_server_s{}:AMCc:FpgaTopLevel:AppTop:AppCore:SysgenCryo:Base[{}]:CryoChannels:etaScanInProgress'.format(slot_number,band),timeout=timeout, use_monitor=False))
     return etaScanInProgress
     
 def start_hardware_logging(slot_number,filename=None):


### PR DESCRIPTION
## Description

This PR explicitly enforces `use_monitor=False` as the default in all pysmurf `caget` calls in pysmurf so we're compatible with newer versions of pyepics (e.g. 3.5.1+) where the default `use_monitor=False` was changed to `use_monitor=True` which at a minimum breaks pysmurf's ability to poll cryostat card registers (and who knows what else).  For more details see the github issue https://github.com/slaclab/pysmurf/issues/725.  This PR is part of work to try and upgrade some of the software (like Ubuntu and pyepics) in the pysmurf docker because some of the currently used versions are soon to be EOL'd.

## Github Issue

https://github.com/slaclab/pysmurf/issues/725

## Tests done on this branch

Booted a SMuRF system up using `jackhammer` into @jlashner's experimental dockers with newer software (including version 3.5.1 of pyepics) but with the --skip-setup option.  Then ran setup using this pysmurf branch and verified that setup completed successfully and that cryostat card commanding now works as expected with version 3.5.1 of pyepics.

## Function interfaces that changed

None - I added the `use_monitor` keyword to the cryocard `do_read` and smurf_command `_caget` functions with default value `False` so this change is backwards compatible and can be overriden if desired.