### PR TITLE
Fixes so PRs will pass automated checks again.

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && \
     python3-matplotlib \
  && rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install --upgrade pip
+
 RUN pip3 install \
     scipy==1.5.2 \
     pandas==1.1.0 \


### PR DESCRIPTION
## Description

Automated checks were failing for PRs due to two problems; 1) some of the required status checks seem to no longer be defined and 2) Client Tests were failing because pip3 failing to install jupyter. 

1) was fixed by changing repo settings.  2) by adding command to client Dockerfile to update pip3 before installing jupyter.

## Github / ESCRYODET Issue
https://github.com/slaclab/pysmurf/issues/727 but also [ESCRYODET-889](https://jira.slac.stanford.edu/browse/ESCRYODET-889)