### PR TITLE
Add dependencies to setup.py as install_requires

### DIFF
--- a/.github/workflows/test-or-deploy.yml
+++ b/.github/workflows/test-or-deploy.yml
@@ -128,7 +128,7 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          echo ::set-output name=branch::"${BRANCH_NAME:-$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { $1=$2=""; sub("  ", ""); sub(" ","/"); print }')}"
+          echo ::set-output name=branch::"${BRANCH_NAME:-$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { $1=$2=""; sub("  ",""); gsub(" ","/"); print }')}"
 
       # Build docker image
       - name: Build docker image
@@ -202,7 +202,7 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          echo ::set-output name=branch::"${BRANCH_NAME:-$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { $1=$2=""; sub("  ", ""); sub(" ","/"); print }')}"
+          echo ::set-output name=branch::"${BRANCH_NAME:-$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { $1=$2=""; sub("  ",""); gsub(" ","/"); print }')}"
 
       # Build docker image
       - name: Build docker Image

--- a/.github/workflows/test-or-deploy.yml
+++ b/.github/workflows/test-or-deploy.yml
@@ -128,7 +128,7 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          echo ::set-output name=branch::"${BRANCH_NAME:-$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')}"
+          echo ::set-output name=branch::"${BRANCH_NAME:-$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { $1=$2=""; sub("  ", ""); sub(" ","/"); print }')}"
 
       # Build docker image
       - name: Build docker image
@@ -202,7 +202,7 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          echo ::set-output name=branch::"${BRANCH_NAME:-$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')}"
+          echo ::set-output name=branch::"${BRANCH_NAME:-$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { $1=$2=""; sub("  ", ""); sub(" ","/"); print }')}"
 
       # Build docker image
       - name: Build docker Image

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ To install pysmurf clone this repository and install using pip:
 ```
 git clone https://github.com/slaclab/pysmurf.git
 cd pysmurf/
-pip3 install -r requirements.txt
 pip3 install .
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,15 @@ setup(name='pysmurf',
       packages=find_packages(where='python'),
       package_dir={'': 'python'},
       version=versioneer.get_version(),
-      cmdclass=versioneer.get_cmdclass())
+      cmdclass=versioneer.get_cmdclass(),
+      install_requires=[
+          'matplotlib',
+          'numpy',
+          'packaging',
+          'pyepics',
+          'pyyaml',
+          'schema',
+          'scipy',
+          'seaborn',
+      ]
+)


### PR DESCRIPTION
## Description
This adds all the dependencies listed in the `requirements.txt` file to the `setup.py` file, allowing a one-step installation via pip. This is per the [python packaging guidelines](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#install-requires).

On my end in packaging work I'm doing for SO I want to be able to add pysmurf as a dependency like:
```
pysmurf @ git+https://github.com/slaclab/pysmurf.git@main
```
and get any dependencies required by pysmurf automatically. This change would enable that.

### install_requires vs requirements.txt
Naturally the question arises of whether you maintain the dependency list twice both in `setup.py` and in `requirements.txt`. Those files serve two different purposes (see the [python packaging docs](https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/)).

I'd advocate for dropping `requirements.txt` if you no longer think it's needed and want to maintain this list in just one place. Though I haven't done that here, just removed the need to install from the requirements file when installing pysmurf.

## Jira Issue

Not on Jira.

## Tests done on this branch

I've installed pysmurf locally using the updated instructions.

## Function interfaces that changed

No function interfaces changes.