### PR TITLE
New functions to get/set timing modes

### DIFF
--- a/cfg_files/lab1/experiment_lab1_2xLB_c04cc_extref.cfg
+++ b/cfg_files/lab1/experiment_lab1_2xLB_c04cc_extref.cfg
@@ -1,0 +1,483 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 16,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 19,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 19,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 16,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_4" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 16,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_5" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 16,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_6" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 16,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_7" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 16,
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 5,
+		"att_uc": 24,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask" : {
+},
+
+"amplifier" : {
+	     "hemt_Vg" : 0.265,
+	     "bit_to_V_hemt" : 1.93e-06,
+	     "hemt_Id_offset" : 0.9668,
+	     "LNA_Vg" : 0,
+	     "50k_Id_offset" : 0.3867,
+	     "dac_num_50k" : 32,
+	     "bit_to_V_50k" : 3.38e-06,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0,
+	     "hemt1" : {
+		     "drain_conversion_b": 1.74185,
+		     "drain_conversion_m": -0.259491,
+		     "drain_dac_num": 31,
+		     "drain_offset": 0.2662,
+		     "drain_opamp_gain": 3.874,
+		     "drain_pic_address": 3,
+		     "drain_resistor": 50.0,
+		     "drain_volt_default": 0.5,
+		     "drain_volt_min": 0,
+		     "drain_volt_max": 2,
+		     "gate_bit_to_volt": 3.86936e-6,
+		     "gate_volt_default": 0.265,
+		     "gate_volt_min": 0,
+		     "gate_volt_max": 2.03,
+		     "power_bitmask": 1
+		     },
+
+
+             "hemt2":{
+	      	     "drain_conversion_m":-0.259491,
+              	     "drain_conversion_b":1.74185,
+              	     "drain_dac_num":29,
+              	     "drain_offset":0.1797,
+              	     "drain_opamp_gain":3.874,
+              	     "drain_pic_address":10,
+              	     "drain_resistor":50.0,
+              	     "drain_volt_default":0.5,
+              	     "drain_volt_max":2,
+              	     "drain_volt_min":0,
+              	     "gate_bit_to_volt":3.86936e-6,
+              	     "gate_dac_num":27,
+              	     "gate_volt_default":0.0,
+              	     "gate_volt_max":2.03,
+              	     "gate_volt_min":0,
+              	     "power_bitmask":4
+              },
+
+             "50k1" : {
+               "drain_conversion_m": -0.224968,
+               "drain_conversion_b": 5.59815,
+               "drain_dac_num": 32,
+               "drain_offset": 1.1793,
+               "drain_opamp_gain": 9.929,
+               "drain_pic_address": 4,
+               "drain_resistor": 12.0,
+               "drain_volt_default": 5.0,
+               "drain_volt_max": 5.5,
+               "drain_volt_min": 3.5,
+               "gate_bit_to_volt": 3.86936e-6,
+               "gate_dac_num": 30,
+               "gate_volt_default": 0.0,
+               "gate_volt_max": 2.03,
+               "gate_volt_min": 0,
+               "power_bitmask": 2
+	    },		
+
+           "50k2" : {
+               "drain_conversion_m": -0.224968,
+               "drain_conversion_b": 5.59815,
+               "drain_dac_num": 28,
+               "drain_offset": 0,
+               "drain_opamp_gain": 9.929,
+               "drain_pic_address": 11,
+               "drain_resistor": 12.0,
+               "drain_volt_default": 5.0,
+               "drain_volt_max": 5.5,
+               "drain_volt_min": 3.5,
+               "gate_bit_to_volt": 3.86936e-6,
+               "gate_dac_num": 26,
+               "gate_volt_default": 0.0,
+               "gate_volt_max": 2.03,
+               "gate_volt_min": 0,
+               "power_bitmask": 8
+           }
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 15800,
+"high_low_current_ratio" : 6.08,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [7],
+
+"tune_band" : {
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	"fraction_full_scale": 0.489,
+	"reset_rate_khz": 4.0,
+	"delta_freq": {
+		    "0" : 0.02,	
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02,
+		    "4" : 0.02,
+		    "5" : 0.02,
+		    "6" : 0.02,
+		    "7" : 0.02
+        },		
+	"lms_freq": {
+		    "0" : 16500,	
+		    "1" : 19945,
+		    "2" : 19986,
+		    "3" : 20218,
+		    "4" : 20218,
+		    "5" : 20218,
+		    "6" : 20218,
+		    "7" : 20218		    
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,	
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05,
+		    "4" : 0.05,
+		    "5" : 0.05,
+		    "6" : 0.05,
+		    "7" : 0.05		    
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,		    
+		    "2" : 0.98,
+		    "3" : 0.98,
+		    "4" : 0.98,
+		    "5" : 0.98,
+		    "6" : 0.98,
+		    "7" : 0.98		    
+	},
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,		    
+		    "2" : 1e-4,
+		    "3" : 1e-4,
+		    "4" : 1e-4,
+		    "5" : 1e-4,
+		    "6" : 1e-4,
+		    "7" : 1e-4		    
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        },
+	"gradient_descent_converge_hz":{
+		    "0" : 500,
+		    "1" : 500,
+		    "2" : 500,
+		    "3" : 500,
+		    "4" : 500,
+		    "5" : 500,
+		    "6" : 500,
+		    "7" : 500		    
+	},
+	"gradient_descent_step_hz":{
+		    "0" : 1000,
+		    "1" : 1000,
+		    "2" : 1000,
+		    "3" : 1000,
+		    "4" : 1000,
+		    "5" : 1000,
+		    "6" : 1000,
+		    "7" : 1000		    
+	},
+	"gradient_descent_momentum":{
+		    "0" : 1,
+		    "1" : 1,
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+	},
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,
+		    "2" : 0,
+		    "3" : 0,
+		    "4" : 0,
+		    "5" : 0,
+		    "6" : 0,
+		    "7" : 0		    
+	},
+	"eta_scan_del_f": {
+		    "0": 5000,
+		    "1": 5000,
+		    "2": 5000,
+		    "3": 5000,
+		    "4": 5000,
+		    "5": 5000,
+		    "6": 5000,
+		    "7": 5000		    
+	},
+	"eta_scan_amplitude":{
+		    "0" : 12,
+		    "1" : 12,
+		    "2" : 12,
+		    "3" : 12,
+		    "4" : 12,
+		    "5" : 12,
+		    "6" : 12,
+		    "7" : 12		    
+	},
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "ext_ref"
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 4,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+# For remote commanding
+#"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -671,79 +671,8 @@ class SmurfControl(SmurfCommandMixin,
                     'Configuring the system to take timing ' +
                     f'from {timing_reference}')
 
-                if timing_reference == 'ext_ref':
-                    for bay in self.bays:
-                        self.log(f'Select external reference for bay {bay}' +
-                                'or free running if there is no reference.')
-                        self.sel_ext_ref(bay)
-
-                    # Ramp on the internal clock.
-                    self.set_ramp_start_mode(0, write_log=write_log)
-
-                # The expected setup is that this slot is slot 2, and it
-                # should distribute its fiber timing to the carrier's
-                # backplane. Order does not matter.
-                if timing_reference == 'fiber':
-                    # FPGA_TIMING_OUT to RTM Timing In 0
-                    self.set_crossbar_output_config(1, 0x0)
-                    # Backplane DIST0 to RTM Timing In 0
-                    self.set_crossbar_output_config(2, 0x0)
-                    # Backplane Dist1 to RTM Timing In 0
-                    self.set_crossbar_output_config(3, 0x0)
-
-                    # EvrV2CoreTriggers EvrV2ChannelReg[0] EnableReg True
-                    self.set_evr_channel_reg_enable(0, True)
-
-                    # EvrV2CoreTriggers EvrV2ChannelReg[0] DestType All
-                    self.set_evr_trigger_dest_type(0, 0)
-
-                    # EvrV2CoreTriggers EVrV2TriggerReg[0] Enable Trig True
-                    self.set_trigger_enable(0, True)
-
-                    # RtmCryoDet RampStartMode 0x1
-                    self.set_ramp_start_mode(1, write_log=write_log)
-
-                    # MicrowaveMuxCore[0] LMK LmkReg_0x0147 0xA
-                    for bay in self.bays:
-                        self.set_lmk_enable(bay, 1)
-                        self.log(f'Setting Bay {bay} LMK 0x146 to 0x08')
-                        self.set_lmk_reg(bay, 0x146, 0x08)
-                        self.log(f'Setting Bay {bay} LMK 0x147 to 0x0A')
-                        self.set_lmk_reg(bay, 0x147, 0x0A)
-
-                # https://confluence.slac.stanford.edu/display/SMuRF/Timing+Carrier#TimingCarrier-Howtoconfiguretodistributeoverbackplanefromslot2
-
-                # Take timing from the backplane. The expected setup is
-                # that this carrier is not in slot 2, and slot 2 is
-                # distributing timing to the backplane. The order of these
-                # commands does not matter.
-                if timing_reference == 'backplane':
-                    self.log('The cfg file requests backplane timing.')
-                    # OutputConfig[1] = 0x2 configures the SMuRF carrier's
-                    # FPGA to take the timing signals from the backplane
-                    # (TO_FPGA = FROM_BACKPLANE)
-                    self.log('Setting crossbar OutputConfig[1]=0x2 (TO_FPGA=FROM_BACKPLANE)')
-                    self.set_crossbar_output_config(1, 2)
-
-                    # EvrV2CoreTriggers EvrV2ChannelReg[0] EnableReg True
-                    self.set_evr_channel_reg_enable(0, True)
-
-                    # EvrV2CoreTriggers EvrV2ChannelReg[0] DestType All
-                    self.set_evr_trigger_dest_type(0, 0)
-
-                    # EvrV2CoreTriggers EVrV2TriggerReg[0] Enable Trig True
-                    self.set_trigger_enable(0, True)
-
-                    # Set the bay AMC LMK to CLKin0
-                    for bay in self.bays:
-                        self.set_lmk_enable(bay, 1)
-                        self.log(f'Setting Bay {bay} LMK 0x146 to 0x08')
-                        self.set_lmk_reg(bay, 0x146, 0x08)
-                        self.log(f'Setting Bay {bay} LMK 0x147 to 0x0A')
-                        self.set_lmk_reg(bay, 0x147, 0x0A)
-
-                    # Configure RTM to trigger off of the timing system
-                    self.set_ramp_start_mode(1, write_log=write_log)
+                # Configure timing
+                self.set_timing_mode(timing_reference)
 
             self.log('Done with setup.', self.LOG_USER)
         else:

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5425,14 +5425,60 @@ class SmurfCommandMixin(SmurfBase):
     _trigger_enable_reg = 'EvrV2TriggerReg[{}]:EnableTrig'
 
     def set_trigger_enable(self, chan, val, **kwargs):
-        """
+        r"""Set trigger pulse generation enable for requested channel.
+
+        The triggering firmware is broken into two parts: (1) the
+        event selection logic "Channel", and (2) the trigger pulse
+        generation "Trigger".  This enables or disables the "Trigger"
+        component for the requested channel.
+
+        Args
+        ----
+        chan : int
+            Which trigger pulse generator channel to enable or
+            disable.
+        val : int
+            1 to enable, 0 to disable.
+        \**kwargs
+            Arbitrary keyword arguments.  Passed directly to the
+            `_caput` call.
+
+        See Also
+        --------
+        :func:`get_trigger_enable` : Get trigger pulse generation
+        enable for requested channel.
         """
         self._caput(
             self.trigger_root + self._trigger_enable_reg.format(chan),
             val, **kwargs)
 
     def get_trigger_enable(self, chan, **kwargs):
-        """
+        r"""Get trigger pulse generation enable for requested channel.
+
+        The triggering firmware is broken into two parts: (1) the
+        event selection logic "Channel", and (2) the trigger pulse
+        generation "Trigger".  This returns whether or not the
+        "Trigger" component for the requested channel is enabled or
+        disabled.
+
+        Args
+        ----
+        chan : int
+            Return the enable for this trigger pulse generator
+            channel.
+        \**kwargs
+            Arbitrary keyword arguments.  Passed directly to the
+            `_caget` call.
+
+        Returns
+        -------
+        int
+            1 if trigger for this channel is enabled, 0 if disabled.
+
+        See Also
+        --------
+        :func:`set_trigger_enable` : Set trigger pulse generation
+        enable for requested channel.
         """
         return self._caget(
             self.trigger_root + self._trigger_enable_reg.format(chan),

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5436,7 +5436,7 @@ class SmurfCommandMixin(SmurfBase):
         """
         return self._caget(
             self.trigger_root + self._trigger_enable_reg.format(chan),
-            **kwargs)        
+            **kwargs)
 
     _trigger_channel_reg_enable_reg = 'EvrV2ChannelReg[{}]:EnableReg'
 
@@ -5454,7 +5454,7 @@ class SmurfCommandMixin(SmurfBase):
         return self._caget(
             self.trigger_root +
             self._trigger_channel_reg_enable_reg.format(chan),
-            **kwargs)        
+            **kwargs)
 
     # Crashing in rogue 4, and not clear it's ever needed.
     _trigger_reg_enable_reg = 'EvrV2TriggerReg[{}]:enable'
@@ -5499,7 +5499,7 @@ class SmurfCommandMixin(SmurfBase):
         return self._caget(
             self.trigger_root +
             self._evr_trigger_dest_type_reg.format(channel),
-            **kwargs)        
+            **kwargs)
 
     _trigger_channel_reg_dest_sel_reg = 'EvrV2ChannelReg[{}]:DestSel'
 
@@ -5658,7 +5658,7 @@ class SmurfCommandMixin(SmurfBase):
             **kwargs)
 
     def set_lmk_enable(self, bay, val, **kwargs):
-        """
+        r"""
         Enable the AMC LMK in bay 0. On boot, the LMK is enabled, however once
         the DACS are reset on SmurfControl.setup the LMK is disabled. If you
         need to modify LMK values, this value must be 1.
@@ -5675,8 +5675,8 @@ class SmurfCommandMixin(SmurfBase):
         """
         self._caput(self.lmk.format(bay) + 'enable', val, **kwargs)
 
-    def get_lmk_enable(self, bay):
-        """
+    def get_lmk_enable(self, bay, **kwargs):
+        r"""
         Set the LMK:Enable bit.
 
         Args

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5441,7 +5441,29 @@ class SmurfCommandMixin(SmurfBase):
     _trigger_channel_reg_enable_reg = 'EvrV2ChannelReg[{}]:EnableReg'
 
     def set_evr_channel_reg_enable(self, chan, val, **kwargs):
-        """
+        r"""Set trigger channel enable.
+
+        The triggering firmware is broken into two parts: (1) the
+        event selection logic "Channel", and (2) the trigger pulse
+        generation "Trigger".  Trigger pulse generation has several
+        required inputs including which "Channel" to listen to.
+        Setting this "Enable" register turns on the event selection
+        logic for the requested channel.
+
+        Args
+        ----
+        chan : int
+            Which trigger event selection logic channel to enable or
+            disable.
+        val : int
+            1 to enable, 0 to disable.
+        \**kwargs
+            Arbitrary keyword arguments.  Passed directly to the
+            `_caput` call.
+
+        See Also
+        --------
+        :func:`get_evr_channel_reg_enable` : Get trigger channel enable.
         """
         self._caput(
             self.trigger_root +
@@ -5449,14 +5471,38 @@ class SmurfCommandMixin(SmurfBase):
             val, **kwargs)
 
     def get_evr_channel_reg_enable(self, chan, **kwargs):
-        """
+        r"""Get trigger channel enable.
+
+        The triggering firmware is broken into two parts: (1) the
+        event selection logic "Channel", and (2) the trigger pulse
+        generation "Trigger".  Trigger pulse generation has several
+        required inputs including which "Channel" to listen to.  This
+        "Enable" register controls whether or not the event selection
+        logic for the requested channel is on.
+
+        Args
+        ----
+        chan : int
+            Which trigger event selection logic channel to enable or
+            disable.
+        \**kwargs
+            Arbitrary keyword arguments.  Passed directly to the
+            `_caget` call.
+
+        Returns
+        -------
+        int
+            1 if trigger channel is enabled, 0 if disabled.
+
+        See Also
+        --------
+        :func:`set_evr_channel_reg_enable` : Get trigger channel enable.
         """
         return self._caget(
             self.trigger_root +
             self._trigger_channel_reg_enable_reg.format(chan),
             **kwargs)
 
-    # Crashing in rogue 4, and not clear it's ever needed.
     _trigger_reg_enable_reg = 'EvrV2TriggerReg[{}]:enable'
 
     def set_evr_trigger_reg_enable(self, chan, val, **kwargs):
@@ -5479,26 +5525,84 @@ class SmurfCommandMixin(SmurfBase):
 
     _evr_trigger_dest_type_reg = 'EvrV2ChannelReg[{}]:DestType'
 
-    def set_evr_trigger_dest_type(self, channel, value, **kwargs):
-        """
-        Set the destination type of this trigger's channel. This is notably
-        used when turning on the flux ramps triggered by the fiber or
-        backplane.
+    def set_evr_trigger_dest_type(self, chan, value, **kwargs):
+        r"""Set trigger channel destination type.
+
+        The triggering firmware is broken into two parts: (1) the
+        event selection logic "Channel", and (2) the trigger pulse
+        generation "Trigger".  Trigger pulse generation has several
+        required inputs including which "Channel" to listen to.  The
+        channel destination type, or DestType, is an optional logic
+        selection (logical AND of) on the presence of a beam where
+        this logic is also used for LCLS-2 on the accelerator.  For
+        SMuRF we always use destination 0 (="All" if you're looking at
+        the SMuRF Rogue gui) which tells the trigger channel logic to
+        ignore all beam logic (a better name for "All" would be
+        "DontCare".
+
+        Args
+        ----
+        chan : int
+            Which trigger event selection logic channel's destination
+            type to set.
+        val : int
+            Destination type to set.  Although valid options are 0, 1,
+            2 or 3, for SMuRF we always use 0 corresponding to "All"
+            in the Rogue gui which instructs the channel to ignore any
+            selection on the presence of beam.
+        \**kwargs
+            Arbitrary keyword arguments.  Passed directly to the
+            `_caput` call.
+
+        See Also
+        --------
+        :func:`get_evr_trigger_dest_type` : Get trigger channel destination type.
         """
         self._caput(
             self.trigger_root +
-            self._evr_trigger_dest_type_reg.format(channel),
+            self._evr_trigger_dest_type_reg.format(chan),
             value, **kwargs)
 
-    def get_evr_trigger_dest_type(self, channel, **kwargs):
-        """
-        Get the destination type of this trigger's channel. This is notably
-        used when turning on the flux ramps triggered by the fiber or
-        backplane.
+    def get_evr_trigger_dest_type(self, chan, **kwargs):
+        r"""Get trigger channel destination type.
+
+        The triggering firmware is broken into two parts: (1) the
+        event selection logic "Channel", and (2) the trigger pulse
+        generation "Trigger".  Trigger pulse generation has several
+        required inputs including which "Channel" to listen to.  The
+        channel destination type, or DestType, is an optional logic
+        selection (logical AND of) on the presence of a beam where
+        this logic is also used for LCLS-2 on the accelerator.  For
+        SMuRF we always use destination 0 (="All" if you're looking at
+        the SMuRF Rogue gui) which tells the trigger channel logic to
+        ignore all beam logic (a better name for "All" would be
+        "DontCare".
+
+        Args
+        ----
+        chan : int
+            Which trigger event selection logic channel's destination
+            type to get.
+        \**kwargs
+            Arbitrary keyword arguments.  Passed directly to the
+            `_caget` call.
+
+        Returns
+        -------
+        int
+            Channel destination type of the requested channel.
+            Although valid options are 0, 1, 2, and 3, SMuRF should
+            always use 0 corresponding to "All" in the Rogue gui which
+            instructs the channel to ignore any selection on the
+            presence of beam for LCLS-2.
+
+        See Also
+        --------
+        :func:`set_evr_trigger_dest_type` : Set trigger channel destination type.
         """
         return self._caget(
             self.trigger_root +
-            self._evr_trigger_dest_type_reg.format(channel),
+            self._evr_trigger_dest_type_reg.format(chan),
             **kwargs)
 
     _trigger_channel_reg_dest_sel_reg = 'EvrV2ChannelReg[{}]:DestSel'
@@ -5647,11 +5751,23 @@ class SmurfCommandMixin(SmurfBase):
     _timing_link_up_reg = "RxLinkUp"
 
     def get_timing_link_up(self, **kwargs):
-        """
-        Return the value of RxLinkUp. This tells you if the FPGA recovered
-        clock is receiving timing from somewhere, either the backplane or
-        fiber. This doesn't directly tell you anything about the AMCs, JESDs,
-        or LMKs.
+        r"""Return external timing link status.
+
+        Return the value of RxLinkUp. This tells you if the FPGA
+        recovered clock is receiving timing from somewhere, either the
+        backplane or fiber. This doesn't directly tell you anything
+        about the AMCs, JESDs, or LMKs.
+
+        Args
+        ----
+        \**kwargs
+            Arbitrary keyword arguments.  Passed directly to the
+            `_caget` call.
+
+        Returns
+        -------
+        int
+            1 if link is up, 0 if link is down.
         """
         return self._caget(
             self.timing_status + self._timing_link_up_reg,

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4577,7 +4577,44 @@ class SmurfUtilMixin(SmurfBase):
         return results_dict
 
     def get_timing_mode(self):
-        """
+        r"""Determines current timing mode.
+
+        Returns the current timing mode configuration, or None if the
+        system is not in one of these three known configurations:
+
+        - "ext_ref" : locked to an external reference, or free running
+          if an external reference is absent.
+        - "backplane" : locked to external timing signals distributed
+          over the crate backplane by a carrier receiving timing on
+          its RTM's timing input.  Only carriers in slot 2 of typical
+          crates can distribute timing to other carriers through the
+          crate backplane, so carriers configured in "backplane"
+          timing mode must be in slots 3 or higher.
+        - "fiber" : locked to external timing input from the carrier's
+          RTM timing input.  Configuring a carrier in this mode
+          assumes the carrier is installed in slot 2 of a crate with a
+          dual-start backplane, as it configures the crossbar to
+          distribute external timing to all oter carriers in the crate
+          over the backplane.
+
+        The timing mode configuration is determined by polling the
+        configuration of the crossbar, LMKs, triggers, and RTM.
+
+        For systems configured in "fiber" or "backplane" modes, a
+        warning is printed if no external timing data is being
+        received.
+
+        Returns
+        -------
+        mode : str or None
+           Current timing mode configuration.  Returns None if system
+           not in one of the three recognized configurations :
+           ext_ref, backplane, or fiber.
+
+        See Also
+        --------
+        :func:`set_timing_mode` : Can be used to set the timing mode.
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_timing_link_up` : Is external timing data being received?
         """
         ## Poll all registers needed to determine which timing mode we're in.
 
@@ -4637,7 +4674,7 @@ class SmurfUtilMixin(SmurfBase):
         # Timing configuration not recognized, return None
         return None
 
-    def set_timing_mode(self,mode,write_log=False):
+    def set_timing_mode(self, mode, write_log=False):
         """
         """
         valid_timing_modes = ['ext_ref','backplane','fiber']

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4807,6 +4807,23 @@ class SmurfUtilMixin(SmurfBase):
                 self.set_crossbar_output_config(3, 0x0, write_log=write_log)
 
             # Configure triggering
+            #
+            # From Matt Weaver : The triggering firmware is broken
+            # into two parts: (1) the event selection logic "Channel",
+            # and (2) the trigger pulse generation "Trigger".  The
+            # event selection logic consists of two parts: (1)
+            # choosing either a rate marker or sequence bit, and (2)
+            # optionally including (logical AND of) a selection on the
+            # presence of beam (irrelevant for you).  The DestType is
+            # this optional selection on presence of beam (to a
+            # destination), and you are selecting "All" which is
+            # better described as "DontCare". [The other options
+            # should be "Inclusive" and "Exclusive"] The trigger pulse
+            # generation has configuration of which "Channel" to
+            # listen to, the delay, width, and polarity of the trigger
+            # to generate.  The "Enable" registers just turn on each
+            # of these two components.
+
             #  EvrV2CoreTriggers EvrV2ChannelReg[0] EnableReg True
             self.set_evr_channel_reg_enable(0, True, write_log=write_log)
             #  EvrV2CoreTriggers EvrV2ChannelReg[0] DestType All

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4723,6 +4723,17 @@ class SmurfUtilMixin(SmurfBase):
            configures the system for "fiber" timing.  This may or may
            not be what was desired.
 
+        Args
+        ----
+        mode : str
+            The timing mode to configure the system with.  Currently
+            valid options are "ext_ref", "backplane", or "fiber".
+        write_log : bool, optional, default False
+            Whether or not to print all EPICS calls, for logging or
+            debugging purposes.  Passed through all register set calls
+            to the underlying `epics.caput` calls.
+
+
         See Also
         --------
         :func:`get_timing_mode` : Can be used to set the timing mode.

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4582,23 +4582,24 @@ class SmurfUtilMixin(SmurfBase):
         Returns the current timing mode configuration, or None if the
         system is not in one of these three known configurations:
 
-        - "ext_ref" : locked to an external reference, or free running
+        * "ext_ref" : locked to an external reference, or free running
           if an external reference is absent.
-        - "backplane" : locked to external timing signals distributed
+        * "backplane" : locked to external timing signals distributed
           over the crate backplane by a carrier receiving timing on
           its RTM's timing input.  Only carriers in slot 2 of typical
           crates can distribute timing to other carriers through the
           crate backplane, so carriers configured in "backplane"
           timing mode must be in slots 3 or higher.
-        - "fiber" : locked to external timing input from the carrier's
+        * "fiber" : locked to external timing input from the carrier's
           RTM timing input.  Configuring a carrier in this mode
           assumes the carrier is installed in slot 2 of a crate with a
-          dual-start backplane, as it configures the crossbar to
+          dual-start backplane, as it configures the timing crossbar to
           distribute external timing to all oter carriers in the crate
           over the backplane.
 
         The timing mode configuration is determined by polling the
-        configuration of the crossbar [#crossbar]_, LMKs, triggers, and RTM.
+        configuration of the timing crossbar [#crossbar]_, LMKs,
+        triggers, and RTM.
 
         For systems configured in "fiber" or "backplane" modes, a
         warning is printed if no external timing data is being

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4711,7 +4711,7 @@ class SmurfUtilMixin(SmurfBase):
         the timing crossbar.
 
         Before changing the timing configuration, the current
-        configuration is polled via `get_timing_mode` and if the
+        configuration is polled via :func:`get_timing_mode` and if the
         system is already in the requested mode, the function prints a
         message and does nothing.
 

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4577,7 +4577,7 @@ class SmurfUtilMixin(SmurfBase):
         return results_dict
 
     def get_timing_mode(self):
-        r"""Determines current timing mode.
+        r"""Determines timing mode configuration.
 
         Returns the current timing mode configuration, or None if the
         system is not in one of these three known configurations:
@@ -4598,7 +4598,7 @@ class SmurfUtilMixin(SmurfBase):
           over the backplane.
 
         The timing mode configuration is determined by polling the
-        configuration of the crossbar, LMKs, triggers, and RTM.
+        configuration of the crossbar [#crossbar]_, LMKs, triggers, and RTM.
 
         For systems configured in "fiber" or "backplane" modes, a
         warning is printed if no external timing data is being
@@ -4609,12 +4609,16 @@ class SmurfUtilMixin(SmurfBase):
         mode : str or None
            Current timing mode configuration.  Returns None if system
            not in one of the three recognized configurations :
-           ext_ref, backplane, or fiber.
+           "ext_ref", "backplane", or "fiber".
 
         See Also
         --------
         :func:`set_timing_mode` : Can be used to set the timing mode.
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_timing_link_up` : Is external timing data being received?
+
+        References
+        ----------
+        .. [#crossbar] https://confluence.slac.stanford.edu/display/ppareg/How+to+configure+the+timing+crossbar
         """
         ## Poll all registers needed to determine which timing mode we're in.
 

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4740,7 +4740,7 @@ class SmurfUtilMixin(SmurfBase):
 
         current_timing_mode = self.get_timing_mode()
         if mode == current_timing_mode:
-            self.log(f'System already configure for {mode} timing, doing nothing.',self.LOG_USER)
+            self.log(f'System already configured for {mode} timing, doing nothing.',self.LOG_USER)
             return
 
         self.log(f'System configured for {current_timing_mode} timing.  Reconfiguring slot {self.slot_number} for {mode} timing.',self.LOG_USER)

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4600,7 +4600,7 @@ class SmurfUtilMixin(SmurfBase):
           crate over the backplane.
 
         The timing mode configuration is determined by polling the
-        configuration of the timing crossbar [#crossbar]_, LMKs,
+        configuration of the timing crossbar, LMKs,
         triggers, and RTM.
 
         For systems configured in "fiber" or "backplane" modes, a
@@ -4618,10 +4618,6 @@ class SmurfUtilMixin(SmurfBase):
         --------
         :func:`set_timing_mode` : Can be used to set the timing mode.
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_timing_link_up` : Is external timing data being received?
-
-        References
-        ----------
-        .. [#crossbar] https://confluence.slac.stanford.edu/display/ppareg/How+to+configure+the+timing+crossbar
         """
         ## Poll all registers needed to determine which timing mode we're in.
 
@@ -4703,7 +4699,7 @@ class SmurfUtilMixin(SmurfBase):
           to all other carriers in the crate over the backplane.
 
         The timing mode configuration adjusts the configuration of the
-        timing crossbar [#crossbar]_, LMKs, triggers, and RTM.
+        timing crossbar, LMKs, triggers, and RTM.
 
         For systems configured in "fiber" or "backplane" modes, after
         configuration a warning is printed if no external timing data
@@ -4738,10 +4734,6 @@ class SmurfUtilMixin(SmurfBase):
         --------
         :func:`get_timing_mode` : Can be used to set the timing mode.
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_timing_link_up` : Is external timing data being received?
-
-        References
-        ----------
-        .. [#crossbar] https://confluence.slac.stanford.edu/display/ppareg/How+to+configure+the+timing+crossbar
         """
         valid_timing_modes = ['ext_ref','backplane','fiber']
         assert (mode in valid_timing_modes), f'\033[91mRequested timing mode={mode} unknown.\033[0m'


### PR DESCRIPTION
## Description

This PR adds new functions to utils named `get_timing_mode` and `set_timing_mode` which allow you to check what timing mode a carrier is configured in (supported modes are our typical "ext_ref", "backplane", and "fiber" modes).   This closes out issue pysmurf github https://github.com/slaclab/pysmurf/issues/734.  No interface changes.  Some implementation details:

* Stripped all the timing stuff out of `setup` ; it now just uses the new `set_timing_mode` function.
* I tried to make the functions smart enough to catch some common errors like asking for an external timing mode (currently either "backplane" or "fiber") but no external timing data is coming in or e.g. trying to configure a slot 2 carrier for "backplane" timing or a slot 3-7 carrier for "fiber" timing.
* I added a lot more documentation for all the EvrV2 regs (that configure trigger pulse generation from external timing) and get functions for the regs that need to be set to configure for fiber and backplane timing modes.  The new get functions `get_evr_channel_reg_enable`, `get_evr_trigger_dest_type`, and `get_trigger_enable` are needed by the `get_timing_mode` function to figure out what timing mode a system is configured in.
* Eliminated the `get_timing_fiber_status` function which is now superceded by the `get_timing_mode` function.
* Improved docstrings for most of the functions used to get/set timing modes.

I tested that I was able to setup in all three modes from power on, that the new `get_timing_mode` function recognized the timing configurations the way we used to set them (by changing pysmurf cfg and hammering) and that I was able to switch between modes and still see external timing info making it into streamed data headers.  I also checked all of the warning conditions in both the new `set_timing_mode` and `get_timing_mode` functions (e.g. both throw a warning if configured in either "fiber" or "backplane" modes but no external timing data is being received).

Here's some commands and output for some typical usage cases for a slot 2 system in SLAC RF Lab1:

```python
In [10]: S.get_timing_mode()
Out[10]: 'fiber'

In [11]: S.set_timing_mode('ext_ref')
[ 2022-10-27 07:42:09 ]  System configured for fiber timing.  Reconfiguring slot 2 for ext_ref timing.
[ 2022-10-27 07:42:09 ]  Select external reference for bay 0 or free running if there is no reference.
[ 2022-10-27 07:42:09 ]  Select external reference for bay 1 or free running if there is no reference.

In [12]: S.get_timing_mode()
Out[12]: 'ext_ref'

In [13]: S.set_timing_mode('backplane')
[ 2022-10-27 07:42:18 ]  System configured for ext_ref timing.  Reconfiguring slot 2 for backplane timing.
[ 2022-10-27 07:42:18 ]  System is in slot 2, which cannot be configured for backplane timing.  Will configure for fiber timing instead.

In [14]: S.get_timing_mode()
Out[14]: 'fiber'

In [15]: S.set_timing_mode('fiber')
[ 2022-10-27 07:42:46 ]  System already configured for fiber timing, doing nothing.

In [16]: S.set_timing_mode('ext_ref',write_log=True)
[ 2022-10-27 07:43:01 ]  System configured for fiber timing.  Reconfiguring slot 2 for ext_ref timing.
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:LMK:enable 1
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[1]:LMK:enable 1
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AmcCarrierCore:AxiSy56040:OutputConfig[0] 0
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AmcCarrierCore:AxiSy56040:OutputConfig[1] 0
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AmcCarrierCore:AxiSy56040:OutputConfig[2] 1
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AmcCarrierCore:AxiSy56040:OutputConfig[3] 1
[ 2022-10-27 07:43:01 ]  Select external reference for bay 0 or free running if there is no reference.
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:LMK:LmkReg_0x0146 16
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:LMK:LmkReg_0x0147 26
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[1]:LMK:LmkReg_0x0146 16
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[1]:LMK:LmkReg_0x0147 26
[ 2022-10-27 07:43:01 ]  Select external reference for bay 1 or free running if there is no reference.
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:LMK:LmkReg_0x0146 16
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:LMK:LmkReg_0x0147 26
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[1]:LMK:LmkReg_0x0146 16
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[1]:LMK:LmkReg_0x0147 26
[ 2022-10-27 07:43:01 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:RtmCryoDet:RampStartMode 0

In [17]: S.set_timing_mode('fiber',write_log=True)
[ 2022-10-27 07:44:07 ]  System configured for ext_ref timing.  Reconfiguring slot 2 for fiber timing.
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:LMK:enable 1
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[1]:LMK:enable 1
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AmcCarrierCore:AxiSy56040:OutputConfig[0] 0
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AmcCarrierCore:AxiSy56040:OutputConfig[1] 0
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AmcCarrierCore:AxiSy56040:OutputConfig[2] 0
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AmcCarrierCore:AxiSy56040:OutputConfig[3] 0
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AmcCarrierCore:AmcCarrierTiming:EvrV2CoreTriggers:EvrV2ChannelReg[0]:EnableReg True
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AmcCarrierCore:AmcCarrierTiming:EvrV2CoreTriggers:EvrV2ChannelReg[0]:DestType 0
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AmcCarrierCore:AmcCarrierTiming:EvrV2CoreTriggers:EvrV2TriggerReg[0]:EnableTrig True
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:RtmCryoDet:RampStartMode 1
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:LMK:LmkReg_0x0146 8
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:LMK:LmkReg_0x0147 10
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[1]:LMK:LmkReg_0x0146 8
[ 2022-10-27 07:44:07 ]  caput smurf_server_s2:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[1]:LMK:LmkReg_0x0147 10

# After deactivating timing carrier
In [18]: S.get_timing_mode()
[ 2022-10-27 07:45:18 ]  Configured for fiber timing but not receiving external timing data.
Out[18]: 'fiber'

In [19]: S.set_timing_mode('ext_ref')
[ 2022-10-27 07:45:25 ]  Configured for fiber timing but not receiving external timing data.
[ 2022-10-27 07:45:25 ]  System configured for fiber timing.  Reconfiguring slot 2 for ext_ref timing.
[ 2022-10-27 07:45:25 ]  Select external reference for bay 0 or free running if there is no reference.
[ 2022-10-27 07:45:25 ]  Select external reference for bay 1 or free running if there is no reference.

In [20]: S.set_timing_mode('fiber')
[ 2022-10-27 07:45:42 ]  System configured for ext_ref timing.  Reconfiguring slot 2 for fiber timing.
[ 2022-10-27 07:45:43 ]  Configured for fiber timing but not receiving external timing data after waiting 1 second.
```

## Github Issue

https://github.com/slaclab/pysmurf/issues/734