### PR TITLE
Bug fix for setup_notches for unassigned channels, add SystemConfigured check.

### DIFF
--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -334,14 +334,14 @@ class SmurfControl(SmurfCommandMixin,
 
     def setup(self, write_log=True, payload_size=2048, force_configure=False, **kwargs):
         r"""Configures SMuRF system.
-        
+
         Sets up the SMuRF system by first loading hardware register
         defaults followed by overriding the hardware default register
         values with defaults from the pysmurf configuration file.
 
         Setup steps (in order of execution):
 
-        - Disables hardware logging if it’s active (to avoid register
+        - Disables hardware logging if it's active (to avoid register
           access collisions).
         - Sets FPGA OT limit (if one is specified in pysmurf cfg).
         - Resets the RF DACs on AMCs in use.

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -411,10 +411,10 @@ class SmurfControl(SmurfCommandMixin,
             if force_configure:
                 self.log(f'System already configured, but will configure again since force_configure={force_configure}.', self.LOG_USER)
             else:
-                self.log(f'\033[91mSystem already configured once while this Rogue server has been up.\033[00m', self.LOG_ERROR) # color red)
-                self.log(f'\033[91mIf you really want to configure again, run setup with force_configure=True.\033[00m', self.LOG_ERROR) # color red            
+                self.log('\033[91mSystem already configured once while this Rogue server has been up.\033[00m', self.LOG_ERROR) # color red
+                self.log('\033[91mIf you really want to configure again, run setup with force_configure=True.\033[00m', self.LOG_ERROR) # color red
                 return False
-        
+
         success=True
         self.log('Setting up...', (self.LOG_USER))
 

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -332,11 +332,9 @@ class SmurfControl(SmurfCommandMixin,
         # initialize outputs cfg
         self.config.update('outputs', {})
 
-    def setup(self, write_log=True, payload_size=2048, **kwargs):
+    def setup(self, write_log=True, payload_size=2048, force_configure=False, **kwargs):
         r"""Configures SMuRF system.
-
-        TODO: NEED TO BE MORE DETAILED, CLEARER.
-
+        
         Sets up the SMuRF system by first loading hardware register
         defaults followed by overriding the hardware default register
         values with defaults from the pysmurf configuration file.
@@ -382,6 +380,10 @@ class SmurfControl(SmurfCommandMixin,
             Whether to write to the log file.
         payload_size : int, optional, default 2048
             The starting size of the payload.
+        force_configure : bool, optional, default False
+            Whether or not to force configure if system has already
+            been configured once by the currently running Rogue
+            server.
         \**kwargs
             Arbitrary keyword arguments.  Passed to many, but not all,
             of the `_caput` calls.
@@ -390,14 +392,29 @@ class SmurfControl(SmurfCommandMixin,
         -------
         success : bool
            Returns `True` if system setup succeeded, otherwise
-           `False`.
+           `False`.  Also returns False if system has already been
+           configured by the currently running Rogue server and
+           force_configure=False.
 
         See Also
         --------
         :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_defaults_pv` :
               Loads the hardware defaults.
-
         """
+
+        # Check if system is already configured.  Be aware this checks
+        # a software register which does not persist on restart of the
+        # Rogue server, so it really only checks if the system has
+        # been successfully configured at any point while this Rogue
+        # server has been up.
+        if self.get_system_configured():
+            if force_configure:
+                self.log(f'System already configured, but will configure again since force_configure={force_configure}.', self.LOG_USER)
+            else:
+                self.log(f'\033[91mSystem already configured once while this Rogue server has been up.\033[00m', self.LOG_ERROR) # color red)
+                self.log(f'\033[91mIf you really want to configure again, run setup with force_configure=True.\033[00m', self.LOG_ERROR) # color red            
+                return False
+        
         success=True
         self.log('Setting up...', (self.LOG_USER))
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -372,6 +372,14 @@ class SmurfCommandMixin(SmurfBase):
         :func:`set_defaults_pv`) and all tests pass, this flag is set
         to `True` when the rogue `setDefaults` method exits.
 
+        .. warning::
+           The register used to check if the system has been
+           configured, AMCc:SmurfApplication:SystemConfigured, is a
+           software register, and does not persist if the Rogue server
+           is restarted.  So this function will only tell you if the
+           system has been successfully configured at any point during
+           the current Rogue server session.
+
         Args
         ----
         \**kwargs
@@ -4722,8 +4730,7 @@ class SmurfCommandMixin(SmurfBase):
            reports the flux ramp reset rate that will actually be
            programmed.
 
-        Warning
-        -------
+        .. warning::
            If `RampMaxCnt` is set too low, then it will invert and
            produce a train of pulses 1x or 2x 307.2 MHz ticks wide,
            but it will be mostly high.

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2246,10 +2246,10 @@ class SmurfTuneMixin(SmurfBase):
            This function uses a different convention for the real and
            imaginary quadratures than e.g. :func:`setup_notches`.  To
            convert data returned by this function to the convention
-           used by :func:`setup_notches, you can use the following
+           used by :func:`setup_notches`, you can use the following
            transformation to scale the returned rr and ii arrays from
            this function to match the convention used in
-           :func:`setup_notches`:
+           :func:`setup_notches` :
 
            ii - 1j*rr
 
@@ -2268,7 +2268,7 @@ class SmurfTuneMixin(SmurfBase):
 
         Returns
         -------
-        rr, ii : :py:class:`numpy.ndarray`,:py:class:`numpy.ndarray` 
+        rr, ii : :py:class:`numpy.ndarray`,:py:class:`numpy.ndarray`
             Real (=rr) and imaginary (=ii) response from the sweep.
             The real part is obtained from
             :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_eta_scan_results_real`,
@@ -2280,7 +2280,7 @@ class SmurfTuneMixin(SmurfBase):
         See Also
         --------
         :func:`setup_notches` : Faster eta scan on many channels.
-        
+
         """
         if len(self.which_on(band)):
             self.band_off(band, write_log=write_log)

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2249,22 +2249,7 @@ class SmurfTuneMixin(SmurfBase):
            used by :func:`setup_notches`, you can use the following
            transformation to scale the returned rr and ii arrays from
            this function to match the convention used in
-           :func:`setup_notches` :
-
-           ii - 1j*rr
-
-        .. warning::
-           For historical reasons, you should perform this scaling on the data returned by this function (which returns the results from :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_eta_scan_results_real` and :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_eta_scan_results_imag` before using it:
-
-           rr = np.asarray(rr)
-           idx = np.where( rr > 2**23 )
-           rr[idx] = rr[idx] - 2**24
-           rr /= 2**23
-
-           ii = np.asarray(ii)
-           idx = np.where( ii > 2**23 )
-           ii[idx] = ii[idx] - 2**24
-           ii /= 2**23
+           :func:`setup_notches`
 
         Returns
         -------

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2224,6 +2224,17 @@ class SmurfTuneMixin(SmurfBase):
         scan, sets the channel amplitude to zero.  Returns the real
         and imaginary components of the response.
 
+        .. warning::
+           This function uses a different convention for the real and
+           imaginary quadratures than e.g. :func:`setup_notches`.  To
+           convert data returned by this function to the convention
+           used by :func:`setup_notches`, you can use the following
+           transformation to scale the returned rr and ii arrays from
+           this function to match the convention used in
+           :func:`setup_notches`
+
+           ii - 1j*rr
+
         Args
         ----
         band : int
@@ -2241,15 +2252,6 @@ class SmurfTuneMixin(SmurfBase):
         sync_group : bool, optional, default True
             Whether not to wait for register change using
             :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.SyncGroup`.
-
-        .. warning::
-           This function uses a different convention for the real and
-           imaginary quadratures than e.g. :func:`setup_notches`.  To
-           convert data returned by this function to the convention
-           used by :func:`setup_notches`, you can use the following
-           transformation to scale the returned rr and ii arrays from
-           this function to match the convention used in
-           :func:`setup_notches`
 
         Returns
         -------

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2231,9 +2231,28 @@ class SmurfTuneMixin(SmurfBase):
            used by :func:`setup_notches`, you can use the following
            transformation to scale the returned rr and ii arrays from
            this function to match the convention used in
-           :func:`setup_notches`
+           :func:`setup_notches`:
 
            ii - 1j*rr
+
+        .. warning::
+           For historical reasons, you should perform this scaling on
+           the data returned by this function (which returns the
+           results from
+           :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_eta_scan_results_real`
+           and
+           :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_eta_scan_results_imag`
+           before using it:
+
+           rr = np.asarray(rr)
+           idx = np.where( rr > 2**23 )
+           rr[idx] = rr[idx] - 2**24
+           rr /= 2**23
+
+           ii = np.asarray(ii)
+           idx = np.where( ii > 2**23 )
+           ii[idx] = ii[idx] - 2**24
+           ii /= 2**23
 
         Args
         ----

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2233,7 +2233,7 @@ class SmurfTuneMixin(SmurfBase):
            this function to match the convention used in
            :func:`setup_notches`:
 
-           ii - 1j*rr
+           | ii - 1j*rr
 
         .. warning::
            For historical reasons, you should perform this scaling on
@@ -2244,15 +2244,15 @@ class SmurfTuneMixin(SmurfBase):
            :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.get_eta_scan_results_imag`
            before using it:
 
-           rr = np.asarray(rr)
-           idx = np.where( rr > 2**23 )
-           rr[idx] = rr[idx] - 2**24
-           rr /= 2**23
-
-           ii = np.asarray(ii)
-           idx = np.where( ii > 2**23 )
-           ii[idx] = ii[idx] - 2**24
-           ii /= 2**23
+           | rr = np.asarray(rr)
+           | idx = np.where( rr > 2**23 )
+           | rr[idx] = rr[idx] - 2**24
+           | rr /= 2**23
+           | 
+           | ii = np.asarray(ii)
+           | idx = np.where( ii > 2**23 )
+           | ii[idx] = ii[idx] - 2**24
+           | ii /= 2**23
 
         Args
         ----

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2248,7 +2248,7 @@ class SmurfTuneMixin(SmurfBase):
            | idx = np.where( rr > 2**23 )
            | rr[idx] = rr[idx] - 2**24
            | rr /= 2**23
-           | 
+           |
            | ii = np.asarray(ii)
            | idx = np.where( ii > 2**23 )
            | ii[idx] = ii[idx] - 2**24

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3931,7 +3931,7 @@ class SmurfTuneMixin(SmurfBase):
                 'freq' : f_min,
                 'eta' : eta,
                 'eta_scaled' : eta_scaled,
-                'eta_phase' : eta_phase_deg,                
+                'eta_phase' : eta_phase_deg,
                 'r2': 1, # This is BS
                 'eta_mag' : eta_mag,
                 'latency': 0,  # This is also BS
@@ -3986,12 +3986,12 @@ class SmurfTuneMixin(SmurfBase):
                 eta_phase_deg = np.angle(eta)*180/np.pi
                 eta_mag = np.abs(eta)
                 eta_scaled = eta_mag / subband_half_width
-                
+
                 abs_resp = np.abs(resp_s)
                 idx = np.ravel(np.where(abs_resp == np.min(abs_resp)))[0]
-                
+
                 f_min = freq_s[idx]
-                
+
                 resonances[i] = {
                     'freq' : f_min,
                     'eta' : eta,
@@ -4008,7 +4008,7 @@ class SmurfTuneMixin(SmurfBase):
             elif channel==-1 and scan_unassigned:
                 self.log(
                     f'scan_unassiged=True : Scanning unassigned frequency at {input_res[i]:.3f} MHz.',self.LOG_USER)
-                
+
                 # Unassigned channels aren't scanned in the time
                 # optimized assigned channel scans above.  This could
                 # be sped up.  For now, just inefficiently running
@@ -4026,7 +4026,7 @@ class SmurfTuneMixin(SmurfBase):
                 idx = np.where( Iu > 2**23 )
                 Iu[idx] = Iu[idx] - 2**24
                 Iu /= 2**23
-                
+
                 idx = np.where( Qu > 2**23 )
                 Qu[idx] = Qu[idx] - 2**24
                 Qu /= 2**23
@@ -4044,16 +4044,16 @@ class SmurfTuneMixin(SmurfBase):
                                                             respu,
                                                             delta_freq=delta_freq,
                                                             lock_max_derivative=lock_max_derivative)
-                
+
                 eta_phase_degu = np.angle(etau)*180/np.pi
                 eta_magu = np.abs(etau)
                 eta_scaledu = eta_magu / subband_half_width
-                
+
                 abs_respu = np.abs(respu_s)
                 idx = np.ravel(np.where(abs_respu == np.min(abs_respu)))[0]
-                
+
                 f_minu = frequ_s[idx]
-                
+
                 resonances[i] = {
                     'freq' : f_minu,
                     'eta' : etau,
@@ -4065,7 +4065,7 @@ class SmurfTuneMixin(SmurfBase):
                     'Q' : 1,  # This is also also BS
                     'freq_eta_scan' : frequ_s,
                     'resp_eta_scan' : respu_s
-                }                
+                }
 
         # Assign resonances to channels
         self.log('Assigning channels')

--- a/scratch/shawn/logtimingpackets.py
+++ b/scratch/shawn/logtimingpackets.py
@@ -1,0 +1,78 @@
+from epics import PV
+import os
+import sys
+
+slots=[2,3]
+cadence_sec=5
+
+def get_timing_packet_stats(slot,timeout=5):
+    sofCountPV=PV(f'smurf_server_s{slot}:AMCc:FpgaTopLevel:AmcCarrierCore:AmcCarrierTiming:TimingFrameRx:sofCount')
+    eofCountPV=PV(f'smurf_server_s{slot}:AMCc:FpgaTopLevel:AmcCarrierCore:AmcCarrierTiming:TimingFrameRx:eofCount')
+    fidCountPV=PV(f'smurf_server_s{slot}:AMCc:FpgaTopLevel:AmcCarrierCore:AmcCarrierTiming:TimingFrameRx:FidCount')
+    rxClkCountPV=PV(f'smurf_server_s{slot}:AMCc:FpgaTopLevel:AmcCarrierCore:AmcCarrierTiming:TimingFrameRx:RxClkCount')
+    rxRstCountPV=PV(f'smurf_server_s{slot}:AMCc:FpgaTopLevel:AmcCarrierCore:AmcCarrierTiming:TimingFrameRx:RxRstCount')            
+    crcErrCountPV=PV(f'smurf_server_s{slot}:AMCc:FpgaTopLevel:AmcCarrierCore:AmcCarrierTiming:TimingFrameRx:CrcErrCount')
+    rxDecErrCountPV=PV(f'smurf_server_s{slot}:AMCc:FpgaTopLevel:AmcCarrierCore:AmcCarrierTiming:TimingFrameRx:RxDecErrCount')
+    rxDspErrCountPV=PV(f'smurf_server_s{slot}:AMCc:FpgaTopLevel:AmcCarrierCore:AmcCarrierTiming:TimingFrameRx:RxDspErrCount')
+    rxLinkUpPV=PV(f'smurf_server_s{slot}:AMCc:FpgaTopLevel:AmcCarrierCore:AmcCarrierTiming:TimingFrameRx:RxLinkUp')    
+    return (sofCountPV.get(timeout=timeout,as_string=False),
+            eofCountPV.get(timeout=timeout,as_string=False),
+            fidCountPV.get(timeout=timeout,as_string=False),
+            rxClkCountPV.get(timeout=timeout,as_string=False),
+            rxRstCountPV.get(timeout=timeout,as_string=False),
+            crcErrCountPV.get(timeout=timeout,as_string=False),
+            rxDecErrCountPV.get(timeout=timeout,as_string=False),
+            rxDspErrCountPV.get(timeout=timeout,as_string=False),
+            rxLinkUpPV.get(timeout=timeout,as_string=False),)
+
+import time
+ctime0=int(time.time())
+
+fmt='{0[0]:<20}{0[1]:<20}{0[2]:<20}{0[3]:<20}{0[4]:<20}{0[5]:<20}{0[6]:<20}{0[7]:<20}{0[8]:<20}{0[9]:<20}{0[10]:<4}\n'
+
+hdr=fmt.format(['epics_root',
+                'ctime',
+                'CrcErrCount',
+                'RxDecErrCount',
+                'RxDspErrCount',
+                'sofCount',
+                'eofCount',
+                'FidCount',
+                'RxClkCount',
+                'RxRstCount',
+                'RxLinkUp'])
+
+filepath='/data/smurf_data/'
+filename=os.path.join(filepath,f'{ctime0}_timingpackets.log')
+
+print(f'-> Logging to {filename}')
+
+if not os.path.exists(filename):
+    with open(filename,'a') as logf:
+        logf.write(hdr)
+
+while True:
+    with open(filename,'a') as logf:
+        for slot in slots:
+            ctime=int(time.time())
+
+            (sofCount,eofCount,fidCount,rxClkCount,rxRstCount,crcErrCount,rxDecErrCount,rxDspErrCount,rxLinkUp)=(None,None,None,None,None,None,None,None,None)
+            try:
+                (sofCount,eofCount,fidCount,rxClkCount,rxRstCount,crcErrCount,rxDecErrCount,rxDspErrCount,rxLinkUp)=get_timing_packet_stats(slot)
+            except:
+                print("Cagets stalled!")
+                
+            entry=fmt.format([f'smurf_server_s{slot}',
+                              ctime,
+                              crcErrCount,
+                              rxDecErrCount,
+                              rxDspErrCount,
+                              sofCount,
+                              eofCount,
+                              fidCount,
+                              rxClkCount,
+                              rxRstCount,
+                              rxLinkUp])
+            print(entry)
+            logf.write(entry)
+        time.sleep(cadence_sec)


### PR DESCRIPTION
## Description

This PR implements a fix for [issue737](https://github.com/slaclab/pysmurf/issues/737) and [sodetlib issue300](https://github.com/simonsobs/sodetlib/issues/300) where users were seeing duplicate data for unassigned channels stored in the `freq_resp` dictionary populated by `setup_notches`.  The issue was that the method `setup_notches` uses to sweep channels can only run on assigned channels.  That method is used because it is faster than sweeping every resonator serially, but a bug was causing it to populate the resp data of the unassigned channels, which it wasn't sweeping, with data from other channels.  Here's where the bug was:

https://github.com/slaclab/pysmurf/blob/eb9f7be55e6e49446fc72621e21e85596f5962a6/python/pysmurf/client/tune/smurf_tune.py#L3974

Unassigned channels get assigned channel -1 by the `assign_channels` routine, which resulted in a misindexing here:

https://github.com/slaclab/pysmurf/blob/eb9f7be55e6e49446fc72621e21e85596f5962a6/python/pysmurf/client/tune/smurf_tune.py#L3975

resulting in a copy, although different for each band, of the wrong data being stored with every unassigned channel in the `S.freq_resp` dictionary.

I implemented the following fix : added a new optional keyword `scan_unassigned` to `setup_notches` which if `False`, just doesn't scan unassigned channels or if `True` it scans them serial after the time optimized sweep over the assigned channels.  I made it optional, and default disabled, because while this is useful for resonator lab characterization, it would slow down tuning in the field.  Here's what the entry to in the `freq_resp` dictionary for an unassigned channel looks like if it's not scanned:

```python
In [23]: S.freq_resp[2]['resonances'][0]
Out[23]: 
{'freq': 5250.0,
 'eta': 1,
 'eta_scaled': 1,
 'eta_phase': 0,
 'r2': 1,
 'eta_mag': 1,
 'latency': 0,
 'Q': 1,
 'freq_eta_scan': None,
 'resp_eta_scan': None,
 'subband': 255,
 'channel': -1,
 'offset': 0.0}
```
Some other fixes in this PR:
* Fixed `setup` function docstring which wasn't rendering in ipython due to a non-ascii character!
* Added check to `setup` for whether or not system has already been configured during the uptime of the rogue server to prevent users from running `setup` over and over again, which should only be run once per system, per power cycle.
* Added documentation for the `eta_scan` function I co-opted to implement the unassigned channel scans.
* Unrelated to this PR, added simple script for polling timing packets, scratch/shawn/logtimingpackets.py.
