### PR TITLE
Allow configuring systems in slots 3-7 for fiber timing.

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -38,7 +38,7 @@ class SmurfCommandMixin(SmurfBase):
     _pv_cache = {}
     _global_poll_enable_reg = ':AMCc:enable'
 
-    def _caput(self, cmd, val, write_log=False, execute=True,
+    def _caput(self, pvname, val, write_log=False, execute=True,
             wait_before=None, wait_after=None, wait_done=True,
             log_level=0, enable_poll=False, disable_poll=False,
             new_epics_root=None, **kwargs):
@@ -48,8 +48,8 @@ class SmurfCommandMixin(SmurfBase):
 
         Args
         ----
-        cmd : str
-            The pyrogue command to be executed.
+        pvname : str
+            The EPICs path of the PV to get.
         val: any
             The value to put into epics
         write_log : bool, optional, default False
@@ -80,10 +80,16 @@ class SmurfCommandMixin(SmurfBase):
             self.log(f'Temporarily using new epics root: {new_epics_root}')
             old_epics_root = self.epics_root
             self.epics_root = new_epics_root
-            cmd = cmd.replace(old_epics_root, self.epics_root)
+            pvname = pvname.replace(old_epics_root, self.epics_root)
+
+        if enable_poll or disable_poll:
+            global_poll_pv=self.epics_root+ self._global_poll_enable_reg
+            if global_poll_pv not in self._pv_cache.keys():
+                self._pv_cache[global_poll_pv] = epics.PV(global_poll_pv)
 
         if enable_poll:
-            epics.caput(self.epics_root + self._global_poll_enable_reg, True)
+            #epics.caput(self.epics_root + self._global_poll_enable_reg, True)
+            self._pv_cache[global_poll_pv].put(True)
 
         if wait_before is not None:
             if write_log:
@@ -92,13 +98,18 @@ class SmurfCommandMixin(SmurfBase):
             time.sleep(wait_before)
 
         if write_log:
-            log_str = 'caput ' + cmd + ' ' + str(val)
+            log_str = 'caput ' + pvname + ' ' + str(val)
             if self.offline:
                 log_str = 'OFFLINE - ' + log_str
             self.log(log_str, log_level)
 
         if execute and not self.offline:
-            epics.caput(cmd, val, wait=wait_done, **kwargs)
+            #epics.caput(pvname, val, wait=wait_done, **kwargs)
+            if pvname not in self._pv_cache.keys():
+                self._pv_cache[pvname] = epics.PV(pvname)
+            self._pv_cache[pvname].put(val,
+                                       wait=wait_done,
+                                       **kwargs)
 
         if wait_after is not None:
             if write_log:
@@ -109,7 +120,8 @@ class SmurfCommandMixin(SmurfBase):
                 self.log('Done waiting.', self.LOG_USER)
 
         if disable_poll:
-            epics.caput(self.epics_root + self._global_poll_enable_reg, False)
+            #epics.caput(self.epics_root + self._global_poll_enable_reg, False)
+            self._pv_cache[global_poll_pv].put(False)
 
         if new_epics_root is not None:
             self.epics_root = old_epics_root
@@ -169,12 +181,14 @@ class SmurfCommandMixin(SmurfBase):
             self.epics_root = new_epics_root
             pvname = pvname.replace(old_epics_root, self.epics_root)
 
+        if enable_poll or disable_poll:
+            global_poll_pv=self.epics_root+ self._global_poll_enable_reg
+            if global_poll_pv not in self._pv_cache.keys():
+                self._pv_cache[global_poll_pv] = epics.PV(global_poll_pv)
+
         if enable_poll:
             #epics.caput(self.epics_root+ self._global_poll_enable_reg, True)
-            pvname=self.epics_root+ self._global_poll_enable_reg
-            if pvname not in self._pv_cache.keys():
-                self._pv_cache[pvname] = epics.PV(pvname)
-            self._pv_cache[pvname].put(True)
+            self._pv_cache[global_poll_pv].put(True)
 
         if write_log:
             self.log('caget ' + pvname, log_level)
@@ -215,10 +229,7 @@ class SmurfCommandMixin(SmurfBase):
 
         if disable_poll:
             #epics.caput(self.epics_root+ self._global_poll_enable_reg, False)
-            pvname=self.epics_root+ self._global_poll_enable_reg
-            if pvname not in self._pv_cache.keys():
-                self._pv_cache[pvname] = epics.PV(pvname)
-            self._pv_cache[pvname].put(False)
+            self._pv_cache[global_poll_pv].put(False)
 
         if new_epics_root is not None:
             self.epics_root = old_epics_root

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -170,7 +170,7 @@ class SmurfCommandMixin(SmurfBase):
             pvname = pvname.replace(old_epics_root, self.epics_root)
 
         if enable_poll:
-            #epics.caput(self.epics_root+ self._global_poll_enable_reg, True)            
+            #epics.caput(self.epics_root+ self._global_poll_enable_reg, True)
             pvname=self.epics_root+ self._global_poll_enable_reg
             if pvname not in self._pv_cache.keys():
                 self._pv_cache[pvname] = epics.PV(pvname)
@@ -202,7 +202,7 @@ class SmurfCommandMixin(SmurfBase):
                     #ret = epics.caget(pvname, count=count, use_monitor=use_monitor, **kwargs)
                     ret = self._pv_cache[pvname].get(count=count,
                                                      use_monitor=use_monitor,
-                                                     **kwargs)             
+                                                     **kwargs)
                     n_retry += 1
 
             # After retries, raise error
@@ -213,12 +213,12 @@ class SmurfCommandMixin(SmurfBase):
         else:
             ret = None
 
-        if disable_poll:            
+        if disable_poll:
             #epics.caput(self.epics_root+ self._global_poll_enable_reg, False)
             pvname=self.epics_root+ self._global_poll_enable_reg
             if pvname not in self._pv_cache.keys():
                 self._pv_cache[pvname] = epics.PV(pvname)
-            self._pv_cache[pvname].put(False) 
+            self._pv_cache[pvname].put(False)
 
         if new_epics_root is not None:
             self.epics_root = old_epics_root

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4592,12 +4592,9 @@ class SmurfUtilMixin(SmurfBase):
           carriers configured in "backplane" timing mode must be in
           slots 3 or higher.
         * "fiber" : locked to external timing input from the carrier's
-          RTM timing input and distributing timing over the crate
-          backplane.  Configuring a carrier in this mode assumes the
-          carrier is installed in slot 2 of a crate with a dual-start
-          backplane, as it configures the timing crossbar to
-          distribute external timing to all other carriers in the
-          crate over the backplane.
+          RTM timing input and if the carrier is in slot 2 of a crate
+          with a dual-start backplane, distributing the timing signals
+          to all other carriers in the crate's backplane.
 
         The timing mode configuration is determined by polling the
         configuration of the timing crossbar, LMKs,
@@ -4691,12 +4688,9 @@ class SmurfUtilMixin(SmurfBase):
           "fiber" timing mode.  Only carriers in slots 3 or higher can
           lock to backplane distributed timing.
         * "fiber" : lock to external timing input from the carrier's
-          RTM timing input and distribute the timing signals to all
-          other carriers in the crate's backplane.  Configuring a
-          carrier in this mode assumes the carrier is installed in
-          slot 2 of a crate with a dual-start backplane, as it
-          configures the timing crossbar to distribute external timing
-          to all other carriers in the crate over the backplane.
+          RTM timing input and if the carrier is in slot 2 of a crate
+          with a dual-start backplane, distribute the timing signals
+          to all other carriers in the crate's backplane.
 
         The timing mode configuration adjusts the configuration of the
         timing crossbar, LMKs, triggers, and RTM.
@@ -4712,12 +4706,9 @@ class SmurfUtilMixin(SmurfBase):
         message and does nothing.
 
         .. warning::
-           If "fiber" timing mode is requested for system that's not
-           in slot 2, `set_timing_mode` instead configures the system
-           for "backplane" timing.  Likewise, if "backplane" mode is
-           requested for a slot 2 system, `set_timing_mode` instead
-           configures the system for "fiber" timing.  This may or may
-           not be what was desired.
+           If "backplane" mode is requested for a slot 2 system,
+           `set_timing_mode` instead configures the system for "fiber"
+           timing.  This may or may not be what was desired.
 
         Args
         ----
@@ -4758,16 +4749,6 @@ class SmurfUtilMixin(SmurfBase):
             self.log('\033[91mSystem is in slot 2, which cannot be configured for backplane timing.  Will configure for fiber timing instead.\033[0m',
                      self.LOG_ERROR) # color red
             mode = 'fiber'
-
-        if mode == 'fiber' and self.slot_number != 2:
-            # Warn user if fiber timing mode is requested for a
-            # carrier not in slot 2.  In fiber timing mode, the system
-            # should be receiving timing through its RTM timing input,
-            # and fanning it out through the backplane to the other
-            # carriers in slots 3+.
-            self.log('\033[91mOnly systems in slot 2 can be configured for fiber timing.  Will configure for backplane timing instead.\033[0m',
-                     self.LOG_ERROR) # color red
-            mode = 'backplane'
 
         if mode == 'ext_ref':
             # Configure crossbar for ext_ref timing


### PR DESCRIPTION
In recent PR [#738](https://github.com/slaclab/pysmurf/pull/738) I added new `set_timing_mode` and `get_timing_mode` functions.  As I wrote it, `set_timing_mode` does not allow a non-slot 2 system to be configured for fiber timing, but that's too restrictive.  This PR fixes that and resolves [issue743](https://github.com/slaclab/pysmurf/issues/743).