### PR TITLE
Include grad_kernel_width kwarg in find_peak call

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3829,7 +3829,7 @@ class SmurfTuneMixin(SmurfBase):
             make_subband_plot=make_subband_plot,
             subband_plot_with_slow=subband_plot_with_slow, timestamp=timestamp,
             pad=pad, min_gap=min_gap, show_plot=show_plot, plot_phase=plot_phase,
-            flip_phase=flip_phase)
+            flip_phase=flip_phase, grad_kernel_width=grad_kernel_width)
 
         return peaks
 


### PR DESCRIPTION
## Description

Passes `grad_kernel_width` keyword to `find_peak` in `smurf_tune` from `find_all_peak`.  `grad_kernel_width` was an allowed keyword of the `find_all_peak` function, but it wasn't actually being passed on to `find_peak`!