### PR TITLE
Add set/get for MaxFileSize to allow splitting long streaming acquisitions over multiple files based on file size.

### DIFF
--- a/cfg_files/rflab/experiment_rflab_2xLB_backplane.cfg
+++ b/cfg_files/rflab/experiment_rflab_2xLB_backplane.cfg
@@ -1,0 +1,488 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_4" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_5" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_6" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_7" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask" : {
+},
+
+"amplifier": {
+	     "hemt_Vg" : 0.490,
+	     "bit_to_V_hemt" : 1.92e-6,
+	     "hemt_Id_offset" : 0.12891,
+	     "LNA_Vg" : -0.75,
+	     # 32 if using a C02 cryostat card.  Some C01s were
+	     # kludged to provide a 50k gate voltage for ASU 50K LNAs
+	     # in early testing.  For those, use 2.	     
+	     "dac_num_50k" : 32,
+	     "50k_Id_offset" : 0,
+	     "bit_to_V_50k" : 3.88e-6,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24],
+        "12" : [25,26],
+        "13" : [27,28],
+        "14" : [29,30]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 25479,
+"high_low_current_ratio" : 12.50,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [3],
+
+"tune_band" : {
+	"reset_rate_khz" : 4.0,
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.495,
+	"delta_freq" : {
+		    "0" : 0.02,	
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02,
+		    "4" : 0.02,
+		    "5" : 0.02,
+		    "6" : 0.02,
+		    "7" : 0.02
+	},		
+	"lms_freq": {
+		    "0" : 16500,	
+		    "1" : 16500,
+		    "2" : 16500,
+		    "3" : 16500,
+		    "4" : 16500,
+		    "5" : 16500,
+		    "6" : 16500,
+		    "7" : 16500
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,	
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05,
+		    "4" : 0.05,
+		    "5" : 0.05,
+		    "6" : 0.05,
+		    "7" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,		    
+		    "2" : 0.98,
+		    "3" : 0.98,
+		    "4" : 0.98,
+		    "5" : 0.98,
+		    "6" : 0.98,
+		    "7" : 0.98		    
+	},	
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,		    
+		    "2" : 1e-4,
+		    "3" : 1e-4,
+		    "4" : 1e-4,
+		    "5" : 1e-4,
+		    "6" : 1e-4,
+		    "7" : 1e-4		    
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        },
+	"gradient_descent_converge_hz": {
+		    "0" : 500,
+		    "1" : 500,		    
+		    "2" : 500,
+		    "3" : 500,
+		    "4" : 500,
+		    "5" : 500,
+		    "6" : 500,
+		    "7" : 500		    
+        },
+	"gradient_descent_step_hz": {
+		    "0" : 1000,
+		    "1" : 1000,		    
+		    "2" : 1000,
+		    "3" : 1000,
+		    "4" : 1000,
+		    "5" : 1000,
+		    "6" : 1000,
+		    "7" : 1000		    
+        },
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,		    
+		    "2" : 0,
+		    "3" : 0,
+		    "4" : 0,
+		    "5" : 0,
+		    "6" : 0,
+		    "7" : 0
+        },
+	"gradient_descent_momentum": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1
+        },	
+	"eta_scan_del_f": {
+                    "0": 5000,
+                    "1": 5000,
+                    "2": 5000,
+                    "3": 5000,
+                    "4": 5000,
+                    "5": 5000,
+                    "6": 5000,
+                    "7": 5000		    
+        },
+        "eta_scan_amplitude":{
+                    "0" : 12,
+                    "1" : 12,
+                    "2" : 12,
+                    "3" : 12,
+                    "4" : 12,
+                    "5" : 12,
+                    "6" : 12,		    
+                    "7" : 12		    
+        },
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "backplane"
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 0,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+# For remote commanding
+#"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/cfg_files/rflab/experiment_rflab_2xLB_extref.cfg
+++ b/cfg_files/rflab/experiment_rflab_2xLB_extref.cfg
@@ -1,0 +1,488 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_4" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_5" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_6" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_7" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask" : {
+},
+
+"amplifier": {
+	     "hemt_Vg" : 0.490,
+	     "bit_to_V_hemt" : 1.92e-6,
+	     "hemt_Id_offset" : 0.12891,
+	     "LNA_Vg" : -0.75,
+	     # 32 if using a C02 cryostat card.  Some C01s were
+	     # kludged to provide a 50k gate voltage for ASU 50K LNAs
+	     # in early testing.  For those, use 2.	     
+	     "dac_num_50k" : 32,
+	     "50k_Id_offset" : 0,
+	     "bit_to_V_50k" : 3.88e-6,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24],
+        "12" : [25,26],
+        "13" : [27,28],
+        "14" : [29,30]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 25479,
+"high_low_current_ratio" : 12.50,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [3],
+
+"tune_band" : {
+	"reset_rate_khz" : 4.0,
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.495,
+	"delta_freq" : {
+		    "0" : 0.02,	
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02,
+		    "4" : 0.02,
+		    "5" : 0.02,
+		    "6" : 0.02,
+		    "7" : 0.02
+	},		
+	"lms_freq": {
+		    "0" : 16500,	
+		    "1" : 16500,
+		    "2" : 16500,
+		    "3" : 16500,
+		    "4" : 16500,
+		    "5" : 16500,
+		    "6" : 16500,
+		    "7" : 16500
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,	
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05,
+		    "4" : 0.05,
+		    "5" : 0.05,
+		    "6" : 0.05,
+		    "7" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,		    
+		    "2" : 0.98,
+		    "3" : 0.98,
+		    "4" : 0.98,
+		    "5" : 0.98,
+		    "6" : 0.98,
+		    "7" : 0.98		    
+	},	
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,		    
+		    "2" : 1e-4,
+		    "3" : 1e-4,
+		    "4" : 1e-4,
+		    "5" : 1e-4,
+		    "6" : 1e-4,
+		    "7" : 1e-4		    
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        },
+	"gradient_descent_converge_hz": {
+		    "0" : 500,
+		    "1" : 500,		    
+		    "2" : 500,
+		    "3" : 500,
+		    "4" : 500,
+		    "5" : 500,
+		    "6" : 500,
+		    "7" : 500		    
+        },
+	"gradient_descent_step_hz": {
+		    "0" : 1000,
+		    "1" : 1000,		    
+		    "2" : 1000,
+		    "3" : 1000,
+		    "4" : 1000,
+		    "5" : 1000,
+		    "6" : 1000,
+		    "7" : 1000		    
+        },
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,		    
+		    "2" : 0,
+		    "3" : 0,
+		    "4" : 0,
+		    "5" : 0,
+		    "6" : 0,
+		    "7" : 0
+        },
+	"gradient_descent_momentum": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1
+        },	
+	"eta_scan_del_f": {
+                    "0": 5000,
+                    "1": 5000,
+                    "2": 5000,
+                    "3": 5000,
+                    "4": 5000,
+                    "5": 5000,
+                    "6": 5000,
+                    "7": 5000		    
+        },
+        "eta_scan_amplitude":{
+                    "0" : 12,
+                    "1" : 12,
+                    "2" : 12,
+                    "3" : 12,
+                    "4" : 12,
+                    "5" : 12,
+                    "6" : 12,		    
+                    "7" : 12		    
+        },
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "ext_ref"
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 0,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+# For remote commanding
+#"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/cfg_files/rflab/experiment_rflab_2xLB_fiber.cfg
+++ b/cfg_files/rflab/experiment_rflab_2xLB_fiber.cfg
@@ -1,0 +1,488 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_4" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_5" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_6" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_7" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 256,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 7,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask" : {
+},
+
+"amplifier": {
+	     "hemt_Vg" : 0.490,
+	     "bit_to_V_hemt" : 1.92e-6,
+	     "hemt_Id_offset" : 0.12891,
+	     "LNA_Vg" : -0.75,
+	     # 32 if using a C02 cryostat card.  Some C01s were
+	     # kludged to provide a 50k gate voltage for ASU 50K LNAs
+	     # in early testing.  For those, use 2.	     
+	     "dac_num_50k" : 32,
+	     "50k_Id_offset" : 0,
+	     "bit_to_V_50k" : 3.88e-6,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24],
+        "12" : [25,26],
+        "13" : [27,28],
+        "14" : [29,30]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 25479,
+"high_low_current_ratio" : 12.50,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [3],
+
+"tune_band" : {
+	"reset_rate_khz" : 4.0,
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.495,
+	"delta_freq" : {
+		    "0" : 0.02,	
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02,
+		    "4" : 0.02,
+		    "5" : 0.02,
+		    "6" : 0.02,
+		    "7" : 0.02
+	},		
+	"lms_freq": {
+		    "0" : 16500,	
+		    "1" : 16500,
+		    "2" : 16500,
+		    "3" : 16500,
+		    "4" : 16500,
+		    "5" : 16500,
+		    "6" : 16500,
+		    "7" : 16500
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,	
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05,
+		    "4" : 0.05,
+		    "5" : 0.05,
+		    "6" : 0.05,
+		    "7" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,		    
+		    "2" : 0.98,
+		    "3" : 0.98,
+		    "4" : 0.98,
+		    "5" : 0.98,
+		    "6" : 0.98,
+		    "7" : 0.98		    
+	},	
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,		    
+		    "2" : 1e-4,
+		    "3" : 1e-4,
+		    "4" : 1e-4,
+		    "5" : 1e-4,
+		    "6" : 1e-4,
+		    "7" : 1e-4		    
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        },
+	"gradient_descent_converge_hz": {
+		    "0" : 500,
+		    "1" : 500,		    
+		    "2" : 500,
+		    "3" : 500,
+		    "4" : 500,
+		    "5" : 500,
+		    "6" : 500,
+		    "7" : 500		    
+        },
+	"gradient_descent_step_hz": {
+		    "0" : 1000,
+		    "1" : 1000,		    
+		    "2" : 1000,
+		    "3" : 1000,
+		    "4" : 1000,
+		    "5" : 1000,
+		    "6" : 1000,
+		    "7" : 1000		    
+        },
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,		    
+		    "2" : 0,
+		    "3" : 0,
+		    "4" : 0,
+		    "5" : 0,
+		    "6" : 0,
+		    "7" : 0
+        },
+	"gradient_descent_momentum": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1
+        },	
+	"eta_scan_del_f": {
+                    "0": 5000,
+                    "1": 5000,
+                    "2": 5000,
+                    "3": 5000,
+                    "4": 5000,
+                    "5": 5000,
+                    "6": 5000,
+                    "7": 5000		    
+        },
+        "eta_scan_amplitude":{
+                    "0" : 12,
+                    "1" : 12,
+                    "2" : 12,
+                    "3" : 12,
+                    "4" : 12,
+                    "5" : 12,
+                    "6" : 12,		    
+                    "7" : 12		    
+        },
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "fiber"
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 0,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+# For remote commanding
+#"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -6570,6 +6570,8 @@ class SmurfCommandMixin(SmurfBase):
         :func:`get_max_file_size` : Get maximum file size for streamed data.
 
         """
+        assert (isinstance(size,int)),f'size={size} should be type int, doing nothing'
+        assert (size>=0),f'size={size} must be greater than zero, doing nothing'
         self._caput(
             self.smurf_processor + self._max_file_size_reg,
             str(size), **kwargs)
@@ -6582,14 +6584,21 @@ class SmurfCommandMixin(SmurfBase):
         with an incrementing integer appended at the end, e.g. .dat.1,
         .dat.2, etc..
 
+
+        Returns
+        -------
+        int
+            Maximum file size for streamed data in bytes.  Returns
+            zero if there's no limit in place.
+
         See Also
         --------
         :func:`set_max_file_size` : Get maximum file size for streamed data.
 
         """
-        return self._caget(
+        return int(self._caget(
             self.smurf_processor + self._max_file_size_reg,
-            as_string=True, **kwargs)
+            as_string=True, **kwargs))
 
     _data_file_name_reg = 'FileWriter:DataFile'
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -6548,6 +6548,49 @@ class SmurfCommandMixin(SmurfBase):
             self.smurf_processor + self._filter_disable_reg,
             **kwargs)
 
+    _max_file_size_reg = 'FileWriter:MaxFileSize'
+
+    def set_max_file_size(self, size, **kwargs):
+        """Set maximum file size for streamed data.
+
+        If nonzero, when streaming data to disk, will split data over
+        files of this size, in bytes.  Files have the usual name but
+        with an incrementing integer appended at the end, e.g. .dat.1,
+        .dat.2, etc..
+
+        Args
+        ----
+        size : int
+            Number of bytes to limit the size of each file streamed to
+            disk to before rolling over into a new file.  If zero, no
+            limit.
+
+        See Also
+        --------
+        :func:`get_max_file_size` : Get maximum file size for streamed data.
+
+        """
+        self._caput(
+            self.smurf_processor + self._max_file_size_reg,
+            str(size), **kwargs)
+
+    def get_max_file_size(self, **kwargs):
+        """Get maximum file size for streamed data.
+
+        If nonzero, when streaming data to disk, will split data over
+        files of this size, in bytes.  Files have the usual name but
+        with an incrementing integer appended at the end, e.g. .dat.1,
+        .dat.2, etc..
+
+        See Also
+        --------
+        :func:`set_max_file_size` : Get maximum file size for streamed data.
+
+        """
+        return self._caget(
+            self.smurf_processor + self._max_file_size_reg,
+            as_string=True, **kwargs)            
+    
     _data_file_name_reg = 'FileWriter:DataFile'
 
     def set_data_file_name(self, name, **kwargs):

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -6589,8 +6589,8 @@ class SmurfCommandMixin(SmurfBase):
         """
         return self._caget(
             self.smurf_processor + self._max_file_size_reg,
-            as_string=True, **kwargs)            
-    
+            as_string=True, **kwargs)
+
     _data_file_name_reg = 'FileWriter:DataFile'
 
     def set_data_file_name(self, name, **kwargs):

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -18,6 +18,7 @@ import glob
 import os
 import threading
 import time
+import re
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -1049,10 +1050,13 @@ class SmurfUtilMixin(SmurfBase):
             return self.read_stream_data_gcp_save(datafile, channel=channel,
                 unwrap=True, downsample=1, nsamp=nsamp)
 
-        try:
-            datafile = glob.glob(datafile+'*')[-1]
-        except BaseException:
-            self.log(f'datafile={datafile}')
+        # Why were we globbing here?
+        #try:
+        #    datafile = glob.glob(datafile+'*')[-1]
+        #except BaseException:
+        #    self.log(f'datafile={datafile}')
+        if not os.path.isfile(datafile):
+            raise FileNotFoundError(f'datafile={datafile}')
 
         if write_log:
             self.log(f'Reading {datafile}')
@@ -1162,9 +1166,17 @@ class SmurfUtilMixin(SmurfBase):
                 " function again with gcp_mode=True")
 
         # make a mask from mask file
+        #  regexp pattern to match any filename which ends in a
+        #  . followed by a number, as occurs when MaxFileSize is
+        #  nonzero and rogue rolls over files by appending an
+        #  increasing number at the end after a .
+        extpattern=re.compile('(.+?).dat.([0-9]|[1-9][0-9]+)$')
+        extmatch=extpattern.match(datafile)
         if ".dat.part" in datafile:
             mask = self.make_mask_lookup(datafile.split(".dat.part")[0] +
                 "_mask.txt")
+        elif extmatch is not None:
+            mask = self.make_mask_lookup(extmatch[1]+"_mask.txt")
         else:
             mask = self.make_mask_lookup(datafile.replace('.dat', '_mask.txt'),
                                          make_freq_mask=make_freq_mask)

--- a/scratch/shawn/logtimingpackets.py
+++ b/scratch/shawn/logtimingpackets.py
@@ -2,7 +2,7 @@ from epics import PV
 import os
 import sys
 
-slots=[2,3]
+slots=[2,3,4]
 cadence_sec=5
 
 pvs = {}

--- a/scratch/shawn/meas_rf_phase.py
+++ b/scratch/shawn/meas_rf_phase.py
@@ -1,0 +1,30 @@
+band=0
+f,resp=S.find_freq(band,make_plot=True,show_plot=True)
+
+fs=[]
+resps=[]
+sbs,sbcs=S.get_subband_centers(band)
+bc=S.get_band_center_mhz(band)
+for sb,sbc in zip(sbs,sbcs):
+    if len(np.nonzero(f[sb])[0]):
+        fs.extend(f[sb]+bc)
+        resps.extend(resp[sb])
+
+rfphase=np.unwrap([np.math.atan2(np.imag(r),np.real(r))+np.pi for r in resps])
+
+fitskipids=10
+a,b = np.polyfit(fs[fitskipids:-fitskipids],rfphase[fitskipids:-fitskipids],1)
+
+plt.figure()
+
+plt.plot(fs,rfphase)
+plt.plot(fs,a*np.array(fs)+b,'r--')
+plt.xlabel('Frequency (GHz)')
+plt.ylabel('Unwrapped RF Phase (rad)')
+
+plt.figure()
+
+plt.plot(fs,rfphase-(a*np.array(fs)+b))
+#plt.xlabel('Frequency (GHz)')
+#plt.ylabel('Unwrapped RF Phase (rad)')
+    


### PR DESCRIPTION
## Description

Adds new `set_max_file_size` and `get_max_file_size` to restore support for splitting streamed data over multiple files of a fixed size.  If set to zero, streams to the same file indefinitely.  Otherwise if nonzero, streams to the set value in number of bytes.  E.g. `set_max_file_size(2000000)` will set the file partition size to 20MB per file.  Files are split by appending an incrementing integer on the end of the usual ctime taggedfile name ; e.g. .1, .2, .3, etc..  Addresses issue #759.

Also removes datafile glob in `read_stream_data` and added logic to find the mask for rolling data files (which only gets written to disk once for MaxFileSize!=0).