### PR TITLE
Rogue defaults fix for RTM precision slow DAC configuration to prevent railing fullscale negative for ~1 sec on configure.

### DIFF
--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -21,7 +21,7 @@ config_repo=https://github.com/slaclab/smurf_cfg
 # define it here. On the other hand, the ZIP file follows this naming convention:
 # 'rogue_${fw_repo_tag}.zip', so you don't need to define it here.
 # The files will be downloaded from the release list of assets.
-fw_repo_tag=MicrowaveMuxBpEthGen2_v1.1.0
+fw_repo_tag=MicrowaveMuxBpEthGen2_v1.1.1
 mcs_file_name=MicrowaveMuxBpEthGen2-0x01010000-20210928123941-ruckman-02ed52a.mcs.gz
 
 # Define the configuration version:


### PR DESCRIPTION
## Description

Also addresses pysmurf issue https://github.com/slaclab/pysmurf/issues/753.  Fixes subtle issue with Rogue zip file defaults which was causing the RTM precision slow DACs to rail fullscale negative for ~1 sec on pysmurf `setup`.  SO users report seeing significant heating in cryostats during setup, and this is the likely culprit.

## Jira Issue

[ESCRYODET-924](https://jira.slac.stanford.edu/browse/ESCRYODET-924)

## Tests done on this branch

Fix tested on the bench (see [ESCRYODET-924](https://jira.slac.stanford.edu/browse/ESCRYODET-924) for details).  Should retest in full release.

## Function interfaces that changed

No interface changes.