### PR TITLE
Upgrade Ubuntu in the base and rogue dockers from version 18.04 to 20.04.

### DIFF
--- a/.github/workflows/test-or-deploy.yml
+++ b/.github/workflows/test-or-deploy.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # Setup python 3.6
-      - name: setup python 3.6
+      # Setup python3
+      - name: setup python 3.8.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8.10
 
       # Install flake8 modules
       - name: Install dependencies
@@ -86,11 +86,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # Setup python 3.6
-      - name: Setup python 3.6
+      # Setup python 3.8.10
+      - name: Setup python 3.8.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8.10
 
       # Install requirements, pysmurf, and sphinx
       - name: Install dependencies
@@ -251,11 +251,11 @@ jobs:
         id: get_tag
         run: echo ::set-output name=tag::"${GITHUB_REF#refs/tags/}"
 
-      # Setup python 3.6
-      - name: Setup python 3.6
+      # Setup python3
+      - name: Setup python 3.8.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8.10
 
       # Install dependencies of the releaseGen.py script
       - name: Install dependencies

--- a/.github/workflows/test-or-deploy.yml
+++ b/.github/workflows/test-or-deploy.yml
@@ -26,7 +26,7 @@ jobs:
   # Run flake8 on all .py files. Should block deploys to Read The Docs.
   flake8:
     name: Flake8 Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # Checkout the code
       - name: Checkout code
@@ -53,7 +53,7 @@ jobs:
   # Validate the server docker image definitions
   docker-definitions:
     name: Docker Definition Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # Checkout the code.
       # We use ssh key authentication to be able to access other private
@@ -79,7 +79,7 @@ jobs:
   # Documentation automatic build tests
   test-docs:
     name: Documentation Build Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [flake8, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
@@ -108,7 +108,7 @@ jobs:
   # Server tests
   test-server:
     name: Server Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [flake8, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
@@ -182,7 +182,7 @@ jobs:
   # Client tests
   test-client:
     name: Client Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [flake8, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
@@ -235,7 +235,7 @@ jobs:
   # Deploy new release notes to GitHub
   deploy-release-notes:
     name: Generate Release Notes
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [test-docs, test-server, test-client]  # Run only if all tests passed
     if: startsWith(github.ref, 'refs/tags/')      # Run only on tagged releases
     steps:
@@ -275,7 +275,7 @@ jobs:
   # Server docker
   deploy-server:
     name: Build Server Docker Image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [test-docs, test-server, test-client]  # Run only if all tests passed
     if: startsWith(github.ref, 'refs/tags/')      # Run only on tagged releases
     steps:
@@ -315,7 +315,7 @@ jobs:
   # Client docker
   deploy-client:
     name: Build Client Docker Image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [test-docs, test-server, test-client]  # Run only if all tests passed
     if: startsWith(github.ref, 'refs/tags/')      # Run only on tagged releases
     steps:

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-base:R1.1.1
+FROM tidair/smurf-base:R2.0.0
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -6,7 +6,7 @@ COPY local_files /tmp/fw/
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src
-RUN git clone https://github.com/slaclab/smurf-pcie.git -b v2.1.0
+RUN git clone https://github.com/slaclab/smurf-pcie.git -b v2.3.0
 WORKDIR smurf-pcie
 RUN sed -i -e 's|git@github.com:|https://github.com/|g' .gitmodules
 RUN git submodule sync && git submodule update --init --recursive

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.8.8
+FROM tidair/smurf-rogue:R2.9.0
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/
@@ -6,7 +6,7 @@ COPY local_files /tmp/fw/
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src
-RUN git clone https://github.com/slaclab/smurf-pcie.git -b v2.0.0
+RUN git clone https://github.com/slaclab/smurf-pcie.git -b v2.1.0
 WORKDIR smurf-pcie
 RUN sed -i -e 's|git@github.com:|https://github.com/|g' .gitmodules
 RUN git submodule sync && git submodule update --init --recursive


### PR DESCRIPTION
## Description

Upgrading a lot of supporting software including:

- python 3.6.9 -> 3.8.10
- Ubuntu 18.04 -> 22.04 (including in smurf-base-docker and smurf-rogue-docker).  To do this, upgrading from smurf-base-docker release R1.1.1 to R2.0.0 and smurf-rogue-docker release R2.8.8 to R2.9.0.
- Upgrading smurf-pcie version checked out by server Dockerfile from v2.0.0 to latest v2.3.0.
- Updated python version sphinx docs gets built against from 3.6.9->3.8.10.

Closes issue https://github.com/slaclab/pysmurf/issues/764.  The Ubuntu 18.04->20.04 upgrade is needed because GitHub is no longer supporting version 18.04.

## Tests done on this branch

Still needs to be tested on hardware.

## Function interfaces that changed

No interface changes, but lots of low level software versions have changed, so should be prepared for unexpected behavior.