### PR TITLE
Reverting smurf-pcie version to from v2.3.0 back to v2.0.0.

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -6,7 +6,7 @@ COPY local_files /tmp/fw/
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src
-RUN git clone https://github.com/slaclab/smurf-pcie.git -b v2.3.0
+RUN git clone https://github.com/slaclab/smurf-pcie.git -b v2.0.0
 WORKDIR smurf-pcie
 RUN sed -i -e 's|git@github.com:|https://github.com/|g' .gitmodules
 RUN git submodule sync && git submodule update --init --recursive


### PR DESCRIPTION
## Description

Reverting smurf-pcie version to from v2.3.0 back to v2.0.0 in hopes of fixing issue https://github.com/slaclab/pysmurf/issues/766.