### PR TITLE
Update to new smurf-rogue-docker release R2.9.1 which fixes server gui crash.

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.9.0
+FROM tidair/smurf-rogue:R2.9.1
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/


### PR DESCRIPTION
## Description

Update to new smurf-rogue-docker release R2.9.1 which fixes server gui crash.  R2.9.1 uses an earlier version of PyDM which doesn't cause the crash.  Closes issue #768.
No interface changes.
