### PR TITLE
Fixing deprecated numpy.int call after numpy upgrade.

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2508,10 +2508,10 @@ class SmurfUtilMixin(SmurfBase):
 
         Returns
         -------
-        i : numpy.int
+        i : numpy.int64
            The 64 bit int.
         """
-        return np.int(''.join([chr(x) for x in s]),0)
+        return np.int64(int(''.join([chr(x) for x in s]),0))
 
 
     def int_to_hex_string(self, i):


### PR DESCRIPTION
## Description

After upgrading Ubuntu in the SMuRF dockers from 18.04->20.04, `numpy.int` is deprecated in the default version of numpy in the updated dockers.  This happened in numpy version 1.20.0 ; https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated.  But it turns out `numpy.int` was just an alias for the builtin `int` type.  Fixing by just using `int` instead (but typecasting to `numpy.int64` to match the docstring's return value).  Tested on a system in loopback by reading back adc data (via the `read_adc_data` function).  Closes https://github.com/slaclab/pysmurf/issues/770.  No interface changes.