### PR TITLE
Drops pydm from v1.18.2 to 1.17.0.

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.9.1
+FROM tidair/smurf-rogue:R2.9.2
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/


### PR DESCRIPTION
## Description

Trying to fix issue https://github.com/slaclab/pysmurf/issues/772 ; some critical routines like `read_adc_data` and `find_freqs` are not returning good data, suspect due to newer PyDM version used in recently upgraded dockers (post SMuRF software version 7.2.0).  SO dockers use same docker setup (so very similar software versions) and their last build didn't have this issue and used PyDM v1.17.0, so trying that by building a SMuRF release on https://github.com/slaclab/smurf-rogue-docker/releases/tag/R2.9.2 which requires PyDM v1.17.0.