### PR TITLE
Attempted fix for `pysmurf.__version__`.

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -17,6 +17,7 @@ ENV PYTHONPATH /usr/local/src/smurf-pcie/firmware/submodules/axi-pcie-core/pytho
 ARG branch
 WORKDIR /usr/local/src
 RUN git clone https://github.com/slaclab/pysmurf.git -b ${branch}
+RUN git config --global --add safe.directory /usr/local/src/pysmurf
 WORKDIR pysmurf
 RUN mkdir build
 WORKDIR build


### PR DESCRIPTION
Core code lost the ability to ascertain the SMuRF software version in releases > v7.2.0.  Probably due to git upgrade in the dockers.  Trying adding a line to the server Dockerfile to fix.

Details in https://github.com/slaclab/pysmurf/issues/773.