### PR TITLE
ADC->DAC in y-axis label of `read_dac_data` plots.

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -1718,7 +1718,7 @@ class SmurfUtilMixin(SmurfBase):
             ax1.set_ylim((-2**15, 2**15))
             ax2 = plt.subplot(212)
             ax2.plot(f_plot, 10*np.log10(p_dac))
-            ax2.set_ylabel(f'ADC{band}')
+            ax2.set_ylabel(f'DAC{band}')
             ax2.set_xlabel('Frequency [MHz]')
             ax2.set_title(f'{timestamp} Spectrum')
             plt.grid(which='both')


### PR DESCRIPTION
## Description

Plots produced by `read_dac_data` have ADC in y-label of FFT ; this PR corrects that to read DAC instead.  This PR has no corresponding issue - just a quick fix.