### PR TITLE
Adding timeout as an option to the underlying `epics.PV.get call` with 5 sec as default

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -128,10 +128,12 @@ class SmurfCommandMixin(SmurfBase):
                log_level=0, enable_poll=False, disable_poll=False,
                new_epics_root=None, yml=None, retry_on_fail=True,
                use_monitor=False,
-               max_retry=5, **kwargs):
+               max_retry=5,
+               timeout=5,
+               **kwargs):
         r"""Gets variables from epics.
 
-        Wrapper around pyrogue lcaget. Gets variables from epics.
+        Wrapper around pyepics lcaget. Gets variables from epics.
 
         Args
         ----
@@ -156,15 +158,19 @@ class SmurfCommandMixin(SmurfBase):
         retry_on_fail : bool
             Whether to retry the caget if it fails on first attempt
         use_monitor : bool, optional, default False
-            Passed directly to the underlying pyepics `epics.caget`
+            Passed directly to the underlying pyepics `epics.PV.caget`
             function call.  This was added to maintain default
             behavior because this option was changed from default
             `False` to default `True` in later versions of pyepics.
         max_retry : int
-            The number of times to retry if caget fails the first time.
+            The number of times to retry if `epics.PV.caget` fails the
+            first time.
+        timeout : float or None
+            Maximum time to wait for each `epics.PV.get` call in
+            seconds.
         \**kwargs
             Arbitrary keyword arguments.  Passed directly to the
-            `epics.caget` call.
+            `epics.PV.caget` call.
 
         Returns
         -------
@@ -201,6 +207,7 @@ class SmurfCommandMixin(SmurfBase):
                 self._pv_cache[pvname] = epics.PV(pvname)
             ret = self._pv_cache[pvname].get(count=count,
                                              use_monitor=use_monitor,
+                                             timeout=timeout,
                                              **kwargs)
 
             # If epics doesn't respond in time, epics.caget returns None.
@@ -212,6 +219,7 @@ class SmurfCommandMixin(SmurfBase):
                     #ret = epics.caget(pvname, count=count, use_monitor=use_monitor, **kwargs)
                     ret = self._pv_cache[pvname].get(count=count,
                                                      use_monitor=use_monitor,
+                                                     timeout=timeout,
                                                      **kwargs)
                     n_retry += 1
 

--- a/scratch/shawn/check_crate_thermal_sensors.py
+++ b/scratch/shawn/check_crate_thermal_sensors.py
@@ -1,0 +1,67 @@
+import subprocess
+import re
+import sys
+
+result = subprocess.run(['ssh', 'root@shm-smrf-sp01','clia sensordata'], stdout=subprocess.PIPE)
+sensordata=result.stdout
+
+tsensors={}
+for sensor in sensordata.split(b'\n\n')[1:]:
+    sn=None
+    ipmbaddr=None
+    for idx,field in enumerate(sensor.split(b'\n')):
+        if len(field)==0:
+            continue
+        if idx==0:
+            x = re.search(b"\(\"([^\)]+)\"\)",field)
+            sn=x[1]
+            ipmbaddr=field.split(b':')[0]
+            if sn not in tsensors:
+                tsensors[sn]={}
+            ipmbaddr=field.split(b':')[0]
+            tsensors[sn][ipmbaddr]={}
+        if b'Type:' in field:
+            x = re.search(b"\"(.*?)\"",field)
+            tsensors[sn][ipmbaddr]['Type']=x[1]
+        if b'Processed data:' in field:
+            pd=field.split(b':')[-1:][0]
+            tsensors[sn][ipmbaddr]['Processed data']=pd.split()[0]
+            tsensors[sn][ipmbaddr]['Processed data units']=b' '.join(pd.split()[1:])
+
+# Get thresholds
+result = subprocess.run(['ssh', 'root@shm-smrf-sp01','clia getthreshold'], stdout=subprocess.PIPE)
+thresholds=result.stdout
+
+for threshold in thresholds.split(b'\n\n')[1:]:
+    sn=None
+    for idx,field in enumerate(threshold.split(b'\n')):        
+        if len(field)==0:
+            continue
+        if idx==0:
+            x = re.search(b"\(\"([^\)]+)\"\)",field)
+            sn=x[1]
+            ipmbaddr=field.split(b':')[0]
+        if sn is not None and sn not in tsensors.keys():
+            continue
+        if sn is not None and ipmbaddr not in tsensors[sn].keys():
+            continue
+        for t in [b'Upper Non-Critical Threshold']:
+            if t in field:
+                pd=field.split(b':')[-1:][0]
+                tsensors[sn][ipmbaddr][t]=pd.split()[0]
+                tsensors[sn][ipmbaddr][t+b' units']=b' '.join(pd.split()[1:])
+
+# Check vs thresholds!
+for sn in tsensors.keys():
+    for ipmbaddr in tsensors[sn].keys():
+        ts=tsensors[sn][ipmbaddr]
+        if ( ts['Type']==b'Temperature' and
+             b'Upper Non-Critical Threshold' in ts.keys() and
+             'Processed data' in ts.keys() ):
+            unct=ts[b'Upper Non-Critical Threshold']
+            pd=ts['Processed data']
+            if float(pd) < float(unct):
+                print(f'\033[92m{ipmbaddr.decode("utf-8")} : {sn.decode("utf-8")} : {float(pd):.3f} < {float(unct):.3f}\033[00m')
+            else:
+                print(f'\033[91m{ipmbaddr.decode("utf-8")} : {sn.decode("utf-8")} : {float(pd):.3f} > {float(unct):.3f}\033[00m')
+    


### PR DESCRIPTION
## Description

Exposes `epics.PV.get` timeout option to `smurf_command._caget` and sets default to 5 sec.  When we moved to PV caching in pysmurf release [v7.2.0](https://github.com/slaclab/pysmurf/releases/tag/v7.2.0), we switched to querying registers using the `epics.PV.get` function which has a default 2 sec timeout instead of the `epics.caget` function we had been using previously which has a longer default 5 sec timeout.  On some systems this resulted in timeouts.  Resolves issue #780.  Tested like this:

```
%timeit -r1 -n1 S._caget('xxx')
[ 2023-06-16 22:41:07 ]  Command failed: xxx
[ 2023-06-16 22:41:07 ]  Retry attempt 1 of 5
[ 2023-06-16 22:41:12 ]  Retry attempt 2 of 5
[ 2023-06-16 22:41:17 ]  Retry attempt 3 of 5
[ 2023-06-16 22:41:22 ]  Retry attempt 4 of 5
[ 2023-06-16 22:41:27 ]  Retry attempt 5 of 5
```