### PR TITLE
Enable hardware detection for systems running a single TKID AMC in bay 0

### DIFF
--- a/.github/workflows/test-or-deploy.yml
+++ b/.github/workflows/test-or-deploy.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Validate the server definitions
         shell: bash
         env:
-          AER7_TOKEN: ${{ secrets.AER7_TOKEN }}
+          SWH76_TOKEN: ${{ secrets.SWH76_TOKEN }}
         run: |
           cd docker/server/
           ./validate.sh
@@ -306,7 +306,7 @@ jobs:
         id: build
         shell: bash
         env:
-          AER7_TOKEN: ${{ secrets.AER7_TOKEN }}
+          SWH76_TOKEN: ${{ secrets.SWH76_TOKEN }}
         run: |
           cd docker/server/
           ./build.sh

--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -29,4 +29,4 @@ mcs_file_name=MicrowaveMuxBpEthGen2-0x01010000-20210928123941-ruckman-02ed52a.mc
 # Define the YML configuration version to use. This is were you define which
 # configuration version to include in the docker image.
 # - 'yml_repo_tag': Set this variable to the tag version you want to use.
-config_repo_tag=v2.0.0
+config_repo_tag=v2.1.0

--- a/docker/server/scripts/server_common.sh
+++ b/docker/server/scripts/server_common.sh
@@ -649,6 +649,9 @@ detect_amc_board()
             elif [ ${type_str} == "A02" ]; then
                 echo "This is a HB board."
                 band_bay[$i]="hb"
+            elif [ ${type_str} == "A03" ]; then
+                echo "This is a TKID board."
+                band_bay[$i]="tkid"		
             else
                 echo "Board type not supported."
                 echo

--- a/docker/server/validate.sh
+++ b/docker/server/validate.sh
@@ -54,7 +54,7 @@ check_if_private_tag_exist()
     # Big blob of JSON with the tags in it.
     local tags=$(curl \
       --url $api_url \
-      --header "Authorization: token ${AER7_TOKEN}" \
+      --header "Authorization: token ${SWH76_TOKEN}" \
       --fail)
 
     # e.g. 0 if no match
@@ -68,7 +68,7 @@ check_if_private_tag_exist()
 }
 
 # Check if a asset file exist on a tag version on a github private repository.
-# It requires the access token to be defined in $AER7_TOKEN.
+# It requires the access token to be defined in $SWH76_TOKEN.
 # Arguments:
 # - first: github private repository url (https),
 # - second: tag name,
@@ -80,7 +80,7 @@ check_if_private_asset_exist()
     local file=$3
 
     # Search the asset ID in the specified release
-    local r=$(curl --silent --header "Authorization: token ${AER7_TOKEN}" "${repo}/releases/tags/${tag}")
+    local r=$(curl --silent --header "Authorization: token ${SWH76_TOKEN}" "${repo}/releases/tags/${tag}")
     eval $(echo "${r}" | grep -C3 "name.:.\+${file}" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
 
     # return is the asset tag was found
@@ -88,7 +88,7 @@ check_if_private_asset_exist()
 }
 
 # Download the asset file on a tagged version on a github private repository.
-# It requires the access token to be defined in $AER7_TOKEN.
+# It requires the access token to be defined in $SWH76_TOKEN.
 # Arguments:
 # - first: github private repository url (https),
 # - second: tag name,
@@ -106,7 +106,7 @@ get_private_asset()
 
     # Try to download the asset
     curl --fail --location --remote-header-name --remote-name --progress-bar \
-         --header "Authorization: token ${AER7_TOKEN}" \
+         --header "Authorization: token ${SWH76_TOKEN}" \
          --header "Accept: application/octet-stream" \
          "${repo}/releases/assets/${id}"
 }


### PR DESCRIPTION
## Description

Extends hardware detection to include single-AMC TKID systems (with the TKID AMC in bay 0).  To work, the TKID AMC baseboard must have its FRU correctly programmed to reflect that it is a TKID AMC - this requires that the loading segment of its S/N be A03.  Many (maybe all) of the TKID AMCs were recycled from LB (=A01) and HB (=A02) AMCs, so using this new feature may require reprogramming your TKID AMC's FRU.  Instructions for how to do that are here - https://confluence.slac.stanford.edu/display/CMBS4SLAC/TKID+SMuRF+hardware#TKIDSMuRFhardware-TKIDAMCbasecardfrureprogramming.

This also bumps the smurf_cfg release from v2.0.0->v2.1.0 to pickup updated TKID defaults files.  See https://github.com/slaclab/smurf_cfg/releases/tag/v2.1.0 for more details.

There is no issue associated with this PR.

## Tests done on this branch

Ran with a TKID system on B33 cryostat.
