### PR TITLE
Add TKID fw & zip file into releases, enhance server hardware detect to choose which fw & zip file to use based on which AMCs are installed in the SMuRF carrier.

### DIFF
--- a/docker/server/build.sh
+++ b/docker/server/build.sh
@@ -38,12 +38,14 @@ tag=`git describe --tags --always`
 rm -rf local_files && mkdir local_files
 
 # Get the  MCS file from the assets
-echo "Downloading MCS file..."
+echo "Downloading MCS files..."
 (cd local_files && get_private_asset ${fw_repo} ${fw_repo_tag} ${mcs_file_name}) || exit 1
+(cd local_files && get_private_asset ${tkid_fw_repo} ${tkid_fw_repo_tag} ${tkid_mcs_file_name}) || exit 1
 
 # Get the ZIP file from the assets
 echo "Downloading ZIP file..."
 (cd local_files && get_private_asset ${fw_repo} ${fw_repo_tag} ${zip_file_name}) || exit 1
+(cd local_files && get_private_asset ${tkid_fw_repo} ${tkid_fw_repo_tag} ${tkid_zip_file_name}) || exit 1
 
 #  Get the configuration files. We clone the whole repository
 echo "Downloading configuration files..."

--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -8,7 +8,12 @@
 #   MCS and the ZIP files.
 # - config_repo: points to the configuration repository, which contains the
 #   the YML files.
+
+# Firmware repo for uMUX systems
 fw_repo=https://github.com/slaclab/cryo-det
+# Firmware repo for TKID systems
+tkid_fw_repo=https://github.com/slaclab/cryo-det-kid
+# Repo for defaults.ymls
 config_repo=https://github.com/slaclab/smurf_cfg
 
 # Define the firmware version:
@@ -21,8 +26,14 @@ config_repo=https://github.com/slaclab/smurf_cfg
 # define it here. On the other hand, the ZIP file follows this naming convention:
 # 'rogue_${fw_repo_tag}.zip', so you don't need to define it here.
 # The files will be downloaded from the release list of assets.
+
+# Firmware version for uMUX systems
 fw_repo_tag=MicrowaveMuxBpEthGen2_v1.1.1
 mcs_file_name=MicrowaveMuxBpEthGen2-0x01010000-20210928123941-ruckman-02ed52a.mcs.gz
+
+# Firmware version for TKID systems
+tkid_fw_repo_tag=CryoDetKid_v2.0.0
+tkid_mcs_file_name=CryoDetKid-0x00000101-20230620224002-bareese-e3253bd.mcs.gz
 
 # Define the configuration version:
 # =================================

--- a/docker/server/scripts/server_common.sh
+++ b/docker/server/scripts/server_common.sh
@@ -356,8 +356,15 @@ checkFW()
     # Check if the firmware checking is disabled
     if [ -z ${no_check_fw+x} ]; then
 
+	fwstr=
+	if [ $1 = "umux" ]; then
+	    fwstr="MicrowaveMuxBpEthGen2"
+	elif [ $1 = "tkid" ]; then
+	    fwstr="CryoDetKid"
+	fi
+
         printf "Looking for mcs file...                           "
-        mcs_file=$(find ${fw_top_dir} -maxdepth 1 -name *mcs*)
+        mcs_file=$(find ${fw_top_dir} -maxdepth 1 -name *${fwstr}*mcs*)
         if [ ! -f "${mcs_file}" ]; then
             echo "MCS file not found!."
             exit 1
@@ -378,7 +385,7 @@ checkFW()
             echo "They match!."
         else
             echo "They don't match."
-            echo "Loading image..."
+            echo "Loading image..."	    
             ProgramFPGA.bash -s $shelfmanager -n $slot -m $mcs_file
 
             # Set a flag indicating a new MCS was loaded
@@ -431,9 +438,16 @@ hardBoot()
 # out python directories.
 findPyrogueFiles()
 {
+    fwstr=
+    if [ $1 = "umux" ]; then
+	fwstr="MicrowaveMuxBpEthGen2"
+    elif [ $1 = "tkid" ]; then
+	fwstr="CryoDetKid"
+    fi
+
     # Look for a pyrogue zip file
     printf "Looking for pyrogue zip file...                   "
-    pyrogue_file=$(find ${fw_top_dir} -maxdepth 1 -name *zip)
+    pyrogue_file=$(find ${fw_top_dir} -maxdepth 1 -name *${fwstr}*zip)
     if [ ! -f "$pyrogue_file" ]; then
         echo "Pyrogue zip file not found!."
 
@@ -558,6 +572,7 @@ detect_amc_board()
 
         # The first argument points to a variable name to store the resulting argument list
         local __result_args=$1
+	local -n system_type=$2
 
         # Definitions
         ## SMuRF AMC board part number
@@ -646,12 +661,15 @@ detect_amc_board()
             if [ ${type_str} == "A01" ]; then
                 echo "This is a LB board."
                 band_bay[$i]="lb"
+		system_type="umux"
             elif [ ${type_str} == "A02" ]; then
                 echo "This is a HB board."
                 band_bay[$i]="hb"
+		system_type="umux"
             elif [ ${type_str} == "A03" ]; then
                 echo "This is a TKID board."
-                band_bay[$i]="tkid"		
+                band_bay[$i]="tkid"
+		system_type="tkid"
             else
                 echo "Board type not supported."
                 echo
@@ -733,7 +751,6 @@ detect_amc_board()
             args+="-d ${defaults_file_name}"
         fi
 
-
         # Print the final list of auto-generated arguments
         echo "Final list of generated arguments:                '${args}'."
         echo "Done!."
@@ -765,20 +782,12 @@ initialize()
     # Get FPGA IP address
     getFpgaIpAddr
 
-    # Look for pyrogue files
-    findPyrogueFiles
-
-    # Firmware version checking
-    checkFW
-
-    # Do a hard boot, if requested
-    hardBoot
-
     # Auto-detect hardware type
     ## Detect type of AMCs, and get specific server startup arguments
     ## for each specific type and add them to the list of arguments
     local __extra_amcs_args
-    detect_amc_board __extra_amcs_args
+    local __system_type
+    detect_amc_board __extra_amcs_args __system_type
     __extra_args+=" ${__extra_amcs_args}"
 
     ## Detect type of carrier, and get specific server startup arguments
@@ -787,6 +796,15 @@ initialize()
     detect_carrier_board __extra_carrier_args
     __extra_args+=" ${__extra_carrier_args}"
 
+    # Look for pyrogue files
+    findPyrogueFiles ${__system_type}
+
+    # Firmware version checking
+    checkFW ${__system_type}
+
+    # Do a hard boot, if requested
+    hardBoot
+    
     # Write the result to the defined output variable
     eval $__result_args="'${__extra_args}'"
 }

--- a/docker/server/validate.sh
+++ b/docker/server/validate.sh
@@ -150,26 +150,36 @@ exit_on_success()
 
 # Extra definitions, generated from the user definitions
 zip_file_name=rogue_${fw_repo_tag}.zip
+tkid_zip_file_name=rogue_${tkid_fw_repo_tag}.zip
 
 # Validate if repositories were defined
 echo "======================================================================================"
 echo "Repository names validation"
 echo "======================================================================================"
 
-printf "Checking if firmware repository was defined...      "
+printf "Checking if uMUX firmware repository was defined...      "
 if [ -z ${fw_repo} ]; then
     echo "Failed!"
     echo
-    echo "Firmware repository not define! Please check that the variable 'fw_repo' is defined in the 'definitions.sh' file."
+    echo "Firmware repository not defined! Please check that the variable 'fw_repo' is defined in the 'definitions.sh' file."
     exit_on_error
 fi
 echo "${fw_repo}"
+
+printf "Checking if TKID firmware repository was defined...      "
+if [ -z ${tkid_fw_repo} ]; then
+    echo "Failed!"
+    echo
+    echo "TKID firmware repository not defined! Please check that the variable 'tkid_fw_repo' is defined in the 'definitions.sh' file."
+    exit_on_error
+fi
+echo "${tkid_fw_repo}"
 
 printf "Checking if configuration repository was defined... "
 if [ -z ${config_repo} ]; then
     echo "Failed!"
     echo
-    echo "Configuration repository not define! Please check that the variable 'config_repo' is defined in the 'definitions.sh' file."
+    echo "Configuration repository not defined! Please check that the variable 'config_repo' is defined in the 'definitions.sh' file."
     exit_on_error
 fi
 echo "${config_repo}"
@@ -180,7 +190,7 @@ echo
 
 # Validate the firmware version
 echo "======================================================================================"
-echo "Firmware version validation"
+echo "uMUX firmware version validation"
 echo "======================================================================================"
 
 printf "Checking if the tag version was defined...          "
@@ -226,6 +236,56 @@ echo "File exist!"
 # At this points all the definition of the firmware version are correct.
 echo "Done! A correct firmware version was defined"
 echo
+
+# Validate TKID firmware version
+echo "======================================================================================"
+echo "TKID firmware version validation"
+echo "======================================================================================"
+
+printf "Checking if the tag version was defined...          "
+if [ -z ${tkid_fw_repo_tag} ]; then
+    echo "Failed!"
+    echo
+    echo "Firmware tag version not defined! Please check that the variable 'tkid_fw_repo_tag' is defined in the 'definitions.sh' file."
+    exit_on_error
+fi
+echo "${tkid_fw_repo_tag}"
+
+printf "Checking if MCS file name was defined...            "
+if [ -z ${tkid_mcs_file_name} ]; then
+    echo "Failed!"
+    echo
+    echo "MCS file name not defined! Please check that the variable 'tkid_mcs_file_name' is defined in the 'definitions.sh' file."
+    exit_on_error
+fi
+echo "${tkid_mcs_file_name}"
+
+check_if_private_tag_exist ${tkid_fw_repo} ${tkid_fw_repo_tag}
+
+printf "Checking if MCS file is in the list of assets...    "
+check_if_private_asset_exist ${tkid_fw_repo} ${tkid_fw_repo_tag} ${tkid_mcs_file_name}
+if [ $? != 0 ]; then
+    echo "Failed!"
+    echo
+    echo "File '${tkid_mcs_file_name}' does not exist in the assets list of release '${tkid_fw_repo_tag}'!"
+    exit_on_error
+fi
+echo "File exists!"
+
+printf "Checking if ZIP file is in the list of assets...    "
+check_if_private_asset_exist ${tkid_fw_repo} ${tkid_fw_repo_tag} ${tkid_zip_file_name}
+if [ $? != 0 ]; then
+    echo "Failed!"
+    echo
+    echo "File '${tkid_zip_file_name}' does not exist in the assets list of release '${tkid_fw_repo_tag}'!"
+    exit_on_error
+fi
+echo "File exists!"
+
+# At this points all the definition of the firmware version are correct.
+echo "Done! A correct firmware version was defined"
+echo
+### Done validating TKID fw
 
 
 # Validate the configuration version


### PR DESCRIPTION
## Description

This PR adds the latest TKID fw and zip files into our releases and adjusts the SMuRF server's hardware detect to choose between TKID or uMUX fw & zip files based on which AMC(s) are plugged into the SMuRF carrier.

## Tests done on this branch

Started modified server on a carrier with one TKID AMC installed in bay 0, and on a carrier with two LB AMCs installed.

## Function interfaces that changed

No interface changes.
