### PR TITLE
Update rogue version to 4.11.11

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.9.2
+FROM tidair/smurf-rogue:R2.9.3
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/


### PR DESCRIPTION

This updates the Rogue version to 4.11.11. This new version of Rogue is linked to the latest version of the KCU1500 driver which is not backwards compatible with Rogue 4.11.10. This new aes-stream-driver supports the latest kernel version of is aligned to the updated firmware distribution for the KCU1500 which fixes the receive crc errors. 