### PR TITLE
Upgrade smurf-pcie to v3.0.2.

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -6,7 +6,7 @@ COPY local_files /tmp/fw/
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src
-RUN git clone https://github.com/slaclab/smurf-pcie.git -b v2.0.0
+RUN git clone https://github.com/slaclab/smurf-pcie.git -b v3.0.2
 WORKDIR smurf-pcie
 RUN sed -i -e 's|git@github.com:|https://github.com/|g' .gitmodules
 RUN git submodule sync && git submodule update --init --recursive


### PR DESCRIPTION
This updates the smurf-pcie version to [v3.0.2](https://github.com/slaclab/smurf-pcie/releases/tag/v3.0.2). This new version This back-applies all of the fixes that existed in the smurf-pcie-docker repo and adds EPICs scripts.