### PR TITLE
Change PCIE Repo to known stable version

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -6,9 +6,8 @@ COPY local_files /tmp/fw/
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src
-RUN git clone https://github.com/slaclab/smurf-pcie.git -b v3.0.2
+RUN git clone https://github.com/slaclab/smurf-pcie.git -b v2.0.0.1
 WORKDIR smurf-pcie
-RUN sed -i -e 's|git@github.com:|https://github.com/|g' .gitmodules
 RUN git submodule sync && git submodule update --init --recursive
 ENV PYTHONPATH /usr/local/src/smurf-pcie/software/python:${PYTHONPATH}
 ENV PYTHONPATH /usr/local/src/smurf-pcie/firmware/submodules/axi-pcie-core/python:${PYTHONPATH}


### PR DESCRIPTION
This changes the PCIE repo back to a slightly modified version of the original repo used by pysmurf. 

Additional changes include using the https path for the submodules.

Changes to PCIE from the previously used repo can be seen here:

https://github.com/slaclab/smurf-pcie/compare/c63d76346356ee17f7af3891c6a5c0b35c77818b...v2.0.0.1

