### PR TITLE
Remove errant factor of 4 in `smurf_control.setup()` call to `set_lms_delay()`

### DIFF
--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -449,12 +449,12 @@ class SmurfConfig:
                 ## TODO remove lmsDelay
                 # lmsDelay is deprected use bandDelayUs instead
 
-                # Matches system latency for LMS feedback (9.6 MHz
-                # ticks, use multiples of 52).  For dspv3 to adjust to
-                # match refPhaseDelay*4 (ignore refPhaseDelayFine for
-                # this).  If not provided and lmsDelay=None, sets to
-                # lmsDelay = 4 x refPhaseDelay.
-                Optional('lmsDelay', default=None) : And(int, lambda n: 0 <= n < 2**5),
+                # Matches system latency for LMS feedback (2.4 MHz
+                # ticks).  For production SMuRF firmware, should set
+                # equal to refPhaseDelay.  (ignore refPhaseDelayFine
+                # for this).  If not provided and lmsDelay=None, sets
+                # to lmsDelay = refPhaseDelay.
+                Optional('lmsDelay', default=None) : And(int, lambda n: 0 <= n < 2**6),
 
                 # Adjust trigRstDly such that the ramp resets at the flux ramp
                 # glitch.  2.4 MHz ticks.

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -542,13 +542,30 @@ class SmurfControl(SmurfCommandMixin,
                         self._ref_phase_delay_fine[band],
                         write_log=write_log, **kwargs)
 
-                    # in DSPv3, lmsDelay should be 4*refPhaseDelay (says
-                    # Mitch).  If none provided in cfg, enforce that
-                    # constraint.  If provided in cfg, override with provided
-                    # value.
+                    # The lmsDelay register matches the system latency
+                    # for LMS feedback.  The readout has both actuator
+                    # and sensor delay, so this delay is needed to
+                    # compensate the feedback.
+                    #
+                    # actuator being the delay from DSP -> synthesis
+                    # filter bank -> JESD -> DAC -> RF tracked freq
+                    # out
+                    #
+                    # sensor delay being RF in resonator -> ADC input
+                    # -> JESD -> filter bank -> demod (edited)
+                    #
+                    # The delay is needed because we are playing out a
+                    # FM waveform on the RF DACs and it takes ~us to
+                    # get the results.
+                    #
+                    # In production SMuRF firmware, lmsDelay should be
+                    # set equal to refPhaseDelay, and both are
+                    # integers that count 2.4 MHz ticks.  If none
+                    # provided in cfg, enforce that constraint.  If
+                    # provided in cfg, override with provided value.
                     if self._lms_delay[band] is None:
                         self.set_lms_delay(
-                            band, int(4*self._ref_phase_delay[band]),
+                            band, int(self._ref_phase_delay[band]),
                             write_log=write_log, **kwargs)
                     else:
                         self.set_lms_delay(


### PR DESCRIPTION
Addresses issue https://github.com/slaclab/pysmurf/issues/789, which fixes SO issue https://github.com/simonsobs/sodetlib/discussions/423.  This is an edge case that only effects users who don't provide `lmsDelay` in their pysmurf cfg files and don't run the `smurf_util.estimate_phase_delay` routine, which triggers the low level rogue setBandDelay routine (https://github.com/slaclab/cryo-det/blob/797fa80aa0e43bc4c0939921702a053f3f69ed2b/firmware/python/CryoDet/DspCoreLib/CryoDetCmbHcd/_CryoFreqBand.py#L661) which properly sets the lmsDelay register.

The lmsDelay register matches the system latency for the tracking feedback.  The readout has both actuator and sensor delay, so this delay is needed to compensate the feedback.  Actuator delay is the delay from DSP -> synthesis filter bank -> JESD -> DAC -> RF tracked freq out.  Sensor delay is the delay from RF in resonator -> ADC input -> JESD -> filter bank -> demod (edited).  The delay is needed because we are playing out a FM waveform on the RF DACs and it takes microseconds to get the results.  In production SMuRF firmware, lmsDelay should be set equal to refPhaseDelay, and both are integers that count 2.4 MHz ticks.  If none provided in the pysmurf cfg, enforce that constraint.  If provided in cfg, override with provided value.

The bug is the factor of 4 here in https://github.com/slaclab/pysmurf/blob/e8db8010a6698beedae4e55928ab858f6c7cd0d6/python/pysmurf/client/base/smurf_control.py#L551 ; the history is that the SMuRF firmware used to process four tones in every polyphase filter bank (PFB) subband, but the production firmware we use now processes only one tone in every PFB subband. The 4* was only relevant for older versions of the firmware where there was more delay due to each subband needing to do four times more processing.

lmsDelay was also increased from a 5-bit to 6-bit register here - https://github.com/slaclab/cryo-det/commit/2aaedcbfe7ac08e39cf2d5db7a585b27e9627d17.  Adjusted pysmurf cfg schema entry to reflect this.

No interface changes in this PR.