### PR TITLE
feat(core.server_scripts.Common): Set log level and format.

### DIFF
--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -442,7 +442,7 @@ class SmurfConfig:
 
                 # data_out_mux
                 Optional("data_out_mux",
-                         default=default_data_out_mux_dict[band]) : \
+                         default=default_data_out_mux_dict[band]) :
                 And([Use(int)], list, lambda l: len(l) == 2 and
                     l[0] != l[1] and all(0 <= ll <= 9 for ll in l)),
 

--- a/python/pysmurf/core/server_scripts/Common.py
+++ b/python/pysmurf/core/server_scripts/Common.py
@@ -23,6 +23,7 @@ import socket
 import subprocess
 import sys
 import zipfile
+import logging
 
 import pyrogue
 
@@ -47,6 +48,16 @@ def process_args(args):
         args.config_file. Also set the server port to  a default values
         if it was not defined.
     """
+
+    # Setup logging
+    logger = logging.getLogger()
+    logger.setLevel(args.log_level)
+    # set up a handler with timestamps
+    handler = logging.StreamHandler()
+    handler.setLevel(args.log_level)
+    formatter = logging.Formatter("[%(asctime)s] %(levelname)s:%(name)s: %(msg)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
     # Verify if the zip file was specified
     if args.zip_file:
@@ -203,6 +214,10 @@ def make_parser(parser=None):
                        )
     group.add_argument('--use-qt', action='store_true', dest='use_qt',
                        default=False, help="Use the QT ."
+                       )
+    group.add_argument('--log-level', type=str.upper, help="Set the logging level.",
+                       choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+                       default="WARNING"
                        )
 
     return parser


### PR DESCRIPTION
## Description

Add a log handler with timestamps to capture the output of the rogue (and other) logs.

This works, but rogue is extremely verbose at the `INFO` level. It might be useful to set a more relaxed level for just the `cryo-det` modules.

## Jira Issue

ESCRYODET-

## Tests done on this branch

## Function interfaces that changed

[Indicate here what is the interface that changed, preferably with a link to the code where the interface is defined]

### What was the interface before the change
[Describe here how was the original interface]

### What will be the new interface after the change
[Describe here how is the new interface, and what the difference with the original interface]
