### PR TITLE
Updates for rogue v6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if (DEFINED ENV{CONDA_PREFIX})
 endif()
 
 # Check cmake version
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 include(InstallRequiredSystemLibraries)
 
 # Project name
@@ -28,7 +28,7 @@ project (smurf)
 
 # C/C++
 enable_language(CXX)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wno-deprecated")
 
 #####################################
 # Find Rogue & Support Libraries
@@ -38,7 +38,7 @@ if (DEFINED ENV{ROGUE_DIR})
 else()
    set(Rogue_DIR ${CMAKE_PREFIX_PATH}/lib)
 endif()
-find_package(Rogue)
+find_package(Rogue REQUIRED)
 
 #####################################
 # Setup build
@@ -49,15 +49,16 @@ include_directories(${PROJECT_SOURCE_DIR}/include/)
 include_directories(/usr/local/include/)
 
 # Create rogue python library
-AUX_SOURCE_DIRECTORY(src SRC_FILES)
-add_library(smurf SHARED ${SRC_FILES})
+add_library(ucsc_hn_lib SHARED "")
+
+add_subdirectory(src)
 
 # Set output to TOP/lib, remove lib prefix
+set_target_properties(smurf PROPERTIES PREFIX "" SUFFIX ".so")
 set_target_properties(smurf PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
-set_target_properties(smurf PROPERTIES PREFIX "")
 
 # Link to rogue core
-TARGET_LINK_LIBRARIES(smurf LINK_PUBLIC ${ROGUE_LIBRARIES})
+TARGET_LINK_LIBRARIES(smurf PUBLIC ${ROGUE_LIBRARIES})
 
 # Setup configuration file
 set(CONF_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,16 +49,15 @@ include_directories(${PROJECT_SOURCE_DIR}/include/)
 include_directories(/usr/local/include/)
 
 # Create rogue python library
-add_library(ucsc_hn_lib SHARED "")
-
-add_subdirectory(src)
+AUX_SOURCE_DIRECTORY(src SRC_FILES)
+add_library(smurf SHARED ${SRC_FILES})
 
 # Set output to TOP/lib, remove lib prefix
-set_target_properties(smurf PROPERTIES PREFIX "" SUFFIX ".so")
 set_target_properties(smurf PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
+set_target_properties(smurf PROPERTIES PREFIX "")
 
 # Link to rogue core
-TARGET_LINK_LIBRARIES(smurf PUBLIC ${ROGUE_LIBRARIES})
+TARGET_LINK_LIBRARIES(smurf LINK_PUBLIC ${ROGUE_LIBRARIES})
 
 # Setup configuration file
 set(CONF_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,4 +67,3 @@ set(CONF_LIBRARIES    ${PROJECT_SOURCE_DIR}/lib/smurf.so)
 # Create the config file
 configure_file(smurfConfig.cmake.in ${PROJECT_SOURCE_DIR}/lib/smurfConfig.cmake @ONLY)
 
-add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ set_target_properties(smurf PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE
 set_target_properties(smurf PROPERTIES PREFIX "")
 
 # Link to rogue core
-TARGET_LINK_LIBRARIES(smurf LINK_PUBLIC ${ROGUE_LIBRARIES})
+TARGET_LINK_LIBRARIES(smurf PUBLIC ${ROGUE_LIBRARIES})
 
 # Setup configuration file
 set(CONF_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,3 +66,4 @@ set(CONF_LIBRARIES    ${PROJECT_SOURCE_DIR}/lib/smurf.so)
 # Create the config file
 configure_file(smurfConfig.cmake.in ${PROJECT_SOURCE_DIR}/lib/smurfConfig.cmake @ONLY)
 
+add_subdirectory(src)

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-roguev6:R3.0.2
+FROM tidair/smurf-roguev6:R3.0.10
 
 # RTH: Allowing ubuntu to update generates an error related to the git-lfs repo.
 

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-base:R2.0.0
+FROM tidair/smurf-roguev6:R3.0.0
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
@@ -33,15 +33,6 @@ ENV PYSMURF_TOP /usr/local/src/pysmurf
 RUN mkdir -p /usr/local/src/pysmurf_utilities
 ADD scripts/* /usr/local/src/pysmurf_utilities/
 ENV PATH /usr/local/src/pysmurf_utilities:${PATH}
-
-# By default EPICS is configured with 'EPICS_CA_AUTO_ADDR_LIST=YES'
-# which will cause problems is we have multiple NIC, so let's set it
-# to use localhost only for now
-ENV EPICS_CA_AUTO_ADDR_LIST NO
-ENV EPICS_CA_ADDR_LIST localhost
-
-# Default EPICS prefix value
-ENV EPICS_PREFIX "smurf_server"
 
 # Set GTK3Agg as the matplotlib backend
 ENV MPLBACKEND GTK3Agg

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,8 +1,10 @@
-FROM tidair/smurf-roguev6:R3.0.1
+FROM tidair/smurf-roguev6:R3.0.2
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y \
+# RTH: Allowing ubuntu to update generates an error related to the git-lfs repo.
+
+#RUN apt-get update && \
+#    DEBIAN_FRONTEND=noninteractive \
+RUN apt-get install -y \
     python3-gi \
     python3-gi-cairo \
     python3-cairocffi \
@@ -12,16 +14,27 @@ RUN apt-get update && \
 
 RUN pip3 install --upgrade pip
 
+#RUN pip3 install \
+#    scipy==1.5.2 \
+#    pandas==1.1.0 \
+#    PyYAML==5.3.1 \
+#    pillow==6.2.2 \
+#    seaborn==0.11.2 \
+#    jupyter==1.0.0 \
+#    pytest==6.0.1 \
+#    GitPython==3.1.7 \
+#    schema==0.7.1
+
 RUN pip3 install \
-    scipy==1.5.2 \
-    pandas==1.1.0 \
-    PyYAML==5.3.1 \
-    pillow==6.2.2 \
-    seaborn==0.11.2 \
-    jupyter==1.0.0 \
-    pytest==6.0.1 \
-    GitPython==3.1.7 \
-    schema==0.7.1
+    scipy \
+    pandas \
+    PyYAML \
+    pillow \
+    seaborn \
+    jupyter \
+    pytest \
+    GitPython \
+    schema
 
 # Install pysmurf
 ARG branch

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-roguev6:R3.0.0
+FROM tidair/smurf-roguev6:R3.0.1
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \

--- a/docker/client/build.sh
+++ b/docker/client/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker image build --build-arg branch=rogue_v6 -t roguev6_docker_client .

--- a/docker/client/scripts/start_client.sh
+++ b/docker/client/scripts/start_client.sh
@@ -74,5 +74,7 @@ if [ ! -z ${config_file+x} ]; then
     fi
 fi
 
-echo "Starting the ipython session"
-ipython3 -i /usr/local/src/pysmurf_utilities/pysmurf_startup.py
+#echo "Starting the ipython session"
+#ipython3 -i /usr/local/src/pysmurf_utilities/pysmurf_startup.py
+echo "Starting the jupyter notebook"
+jupyter notebook --ip 0.0.0.0 --port 8888 --no-browser --notebook-dir /data/notebooks/

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-roguev6:R3.0.11
+FROM tidair/smurf-roguev6:R3.0.12
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-roguev6:R3.0.1
+FROM tidair/smurf-roguev6:R3.0.2
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/
@@ -6,7 +6,7 @@ COPY local_files /tmp/fw/
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src
-RUN git clone https://github.com/slaclab/smurf-pcie.git -b v2.0.0
+RUN git clone https://github.com/slaclab/smurf-pcie.git -b v3.1.0
 WORKDIR smurf-pcie
 RUN sed -i -e 's|git@github.com:|https://github.com/|g' .gitmodules
 RUN git submodule sync && git submodule update --init --recursive

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-roguev6:R3.0.2
+FROM tidair/smurf-roguev6:R3.0.10
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.9.2
+FROM tidair/smurf-roguev6:R3.0.0
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -25,7 +25,7 @@ USER root
 WORKDIR pysmurf
 RUN mkdir build
 WORKDIR build
-RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .. && make -j4
+RUN cmake -DCMAKE_PREFIX_PATH=/usr/local/lib .. && make -j4
 ENV PYTHONPATH /usr/local/src/pysmurf/lib:${PYTHONPATH}
 ENV PYTHONPATH /usr/local/src/pysmurf/python:${PYTHONPATH}
 ENV SMURF_DIR /usr/local/src/pysmurf

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR smurf-pcie
 RUN sed -i -e 's|git@github.com:|https://github.com/|g' .gitmodules
 RUN git submodule sync && git submodule update --init --recursive
 ENV PYTHONPATH /usr/local/src/smurf-pcie/software/python:${PYTHONPATH}
+ENV PYTHONPATH /usr/local/src/smurf-pcie/firmware/python:${PYTHONPATH}
 ENV PYTHONPATH /usr/local/src/smurf-pcie/firmware/submodules/axi-pcie-core/python:${PYTHONPATH}
 
 # Install pysmurf

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-roguev6:R3.0.0
+FROM tidair/smurf-roguev6:R3.0.1
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-roguev6:R3.0.10
+FROM tidair/smurf-roguev6:R3.0.11
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-roguev6:R3.0.12
+FROM tidair/smurf-roguev6:R3.0.13
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/

--- a/docker/server/build.sh
+++ b/docker/server/build.sh
@@ -31,7 +31,8 @@ dockerhub_repo_base='pysmurf-server-base'
 
 # Get the git tag, which will be used to tag the docker image.
 # At the moment, this script runs only on tagged releases.
-tag=`git describe --tags --always`
+#tag=`git describe --tags --always`
+tag='rogue_v6'
 
 # Create temporal local file directory to hold firmware and configuration
 # files which will later be copied to the docker image

--- a/docker/server/build.sh
+++ b/docker/server/build.sh
@@ -56,11 +56,11 @@ echo "Building docker image..."
 docker image build --build-arg branch=${tag} -t docker_image . || exit 1
 
 # Tag and push the image to the stable dockerhub repository
-docker image tag docker_image ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}
-docker image push ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}
-echo "Docker image '${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}' pushed"
+#docker image tag docker_image ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}
+#docker image push ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}
+#echo "Docker image '${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}' pushed"
 
 # Tag and push the image to the stable dockerhub repository
-docker image tag docker_image ${dockerhub_org_name}/${dockerhub_repo_base}:${tag}
-docker image push ${dockerhub_org_name}/${dockerhub_repo_base}:${tag}
-echo "Docker image '${dockerhub_org_name}/${dockerhub_repo_base}:${tag}' pushed"
+#docker image tag docker_image ${dockerhub_org_name}/${dockerhub_repo_base}:${tag}
+#docker image push ${dockerhub_org_name}/${dockerhub_repo_base}:${tag}
+#echo "Docker image '${dockerhub_org_name}/${dockerhub_repo_base}:${tag}' pushed"

--- a/docker/server/build.sh
+++ b/docker/server/build.sh
@@ -31,6 +31,7 @@ dockerhub_repo_base='pysmurf-server-base'
 
 # Get the git tag, which will be used to tag the docker image.
 # At the moment, this script runs only on tagged releases.
+# RTH: For local offline testing
 #tag=`git describe --tags --always`
 tag='rogue_v6'
 
@@ -52,8 +53,9 @@ git -C local_files clone -c advice.detachedHead=false ${config_repo} -b ${config
 
 # Build the docker image. This same image will be pushed to both the stable
 # and the base dockerhub repositories.
+# RTH: Changed the name for now
 echo "Building docker image..."
-docker image build --build-arg branch=${tag} -t docker_image . || exit 1
+docker image build --build-arg branch=${tag} -t smurf_docker_server . || exit 1
 
 # Tag and push the image to the stable dockerhub repository
 #docker image tag docker_image ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}

--- a/docker/server/build.sh
+++ b/docker/server/build.sh
@@ -55,7 +55,7 @@ git -C local_files clone -c advice.detachedHead=false ${config_repo} -b ${config
 # and the base dockerhub repositories.
 # RTH: Changed the name for now
 echo "Building docker image..."
-docker image build --build-arg branch=${tag} -t smurf_docker_server . || exit 1
+docker image build --build-arg branch=${tag} -t roguev6_docker_server . || exit 1
 
 # Tag and push the image to the stable dockerhub repository
 #docker image tag docker_image ${dockerhub_org_name}/${dockerhub_repo_stable}:${tag}

--- a/docker/server/scripts/server_common.sh
+++ b/docker/server/scripts/server_common.sh
@@ -399,7 +399,7 @@ validateCommType()
         comm_type='eth'
     else
         # Check if the communication type is invalid
-        if [ ${comm_type} != 'eth' ] && [ ${comm_type} != 'pcie' ]; then
+        if [ ${comm_type} != 'eth' ] && [ ${comm_type} != 'pcie' ] && [ ${comm_type} != 'emu' ]; then
             echo "Invalid communication type!."
             usage
         fi
@@ -649,6 +649,9 @@ detect_amc_board()
             elif [ ${type_str} == "A02" ]; then
                 echo "This is a HB board."
                 band_bay[$i]="hb"
+            elif [ ${type_str} == "A03" ]; then
+                echo "This is a TKID board."
+                band_bay[$i]="tkid"
             else
                 echo "Board type not supported."
                 echo

--- a/docker/server/scripts/start_server.sh
+++ b/docker/server/scripts/start_server.sh
@@ -30,6 +30,9 @@ echo
 if [ ${comm_type} == 'eth' ]; then
     echo "Staring the server using Ethernet communication..."
     cmd="/usr/local/src/pysmurf/server_scripts/cmb_eth.py  ${args}"
+elif [ ${comm_type} == 'emu' ]; then
+    echo "Staring the server using Emulation..."
+    cmd="/usr/local/src/pysmurf/server_scripts/emulate.py  ${args}"
 else
     echo "Staring the server using PCIe communication..."
     cmd="/usr/local/src/pysmurf/server_scripts/cmb_pcie.py ${args}"

--- a/docker/server/validate.sh
+++ b/docker/server/validate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Validate definitions.sh
+# RTH: Replaced AER7_TOKEN with GITHUB_TOKEN
 
 #############
 # FUNCTIONS #
@@ -54,7 +55,7 @@ check_if_private_tag_exist()
     # Big blob of JSON with the tags in it.
     local tags=$(curl \
       --url $api_url \
-      --header "Authorization: token ${AER7_TOKEN}" \
+      --header "Authorization: token ${GITHUB_TOKEN}" \
       --fail)
 
     # e.g. 0 if no match
@@ -80,7 +81,7 @@ check_if_private_asset_exist()
     local file=$3
 
     # Search the asset ID in the specified release
-    local r=$(curl --silent --header "Authorization: token ${AER7_TOKEN}" "${repo}/releases/tags/${tag}")
+    local r=$(curl --silent --header "Authorization: token ${GITHUB_TOKEN}" "${repo}/releases/tags/${tag}")
     eval $(echo "${r}" | grep -C3 "name.:.\+${file}" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
 
     # return is the asset tag was found
@@ -106,7 +107,7 @@ get_private_asset()
 
     # Try to download the asset
     curl --fail --location --remote-header-name --remote-name --progress-bar \
-         --header "Authorization: token ${AER7_TOKEN}" \
+         --header "Authorization: token ${GITHUB_TOKEN}" \
          --header "Accept: application/octet-stream" \
          "${repo}/releases/assets/${id}"
 }

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -162,7 +162,7 @@ class SmurfBase:
         # Tx -> DAC , Rx <- ADC
         self.axi_version = self.amccc + 'AxiVersion.'
         self.waveform_engine_buffers_root = self.amccc + \
-            'AmcCarrierBsa:BsaWaveformEngine[{}].' + \
+            'AmcCarrierBsa.BsaWaveformEngine[{}].' + \
             'WaveformEngineBuffers.'
         self.stream_data_writer_root = self.amcc + 'streamDataWriter.'
         self.jesd_tx_root = self.apptop + 'AppTopJesd[{}].JesdTx.'

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -87,100 +87,97 @@ class SmurfBase:
         # do this than just hardcoding paths? This needs to be cleaned
         # up somehow
 
-        if epics_root is not None:
-            self.epics_root = epics_root
+        self.amcc = 'AMCc.'
 
-        self.amcc = self.epics_root + ':AMCc:'
+        self.smurf_application = self.amcc + 'SmurfApplication.'
 
-        self.smurf_application = self.amcc + 'SmurfApplication:'
+        self.smurf_processor = self.amcc + 'SmurfProcessor.'
+        self._predata_emulator = self.smurf_processor + 'PreDataEmulator.'
+        self._postdata_emulator = self.smurf_processor + 'PostDataEmulator.'
+        self.stream_data_source = self.amcc + 'StreamDataSource.'
+        self.channel_mapper = self.smurf_processor + 'ChannelMapper.'
+        self.frame_rx_stats = self.smurf_processor + 'FrameRxStats.'
 
-        self.smurf_processor = self.amcc + 'SmurfProcessor:'
-        self._predata_emulator = self.smurf_processor + 'PreDataEmulator:'
-        self._postdata_emulator = self.smurf_processor + 'PostDataEmulator:'
-        self.stream_data_source = self.amcc + 'StreamDataSource:'
-        self.channel_mapper = self.smurf_processor + 'ChannelMapper:'
-        self.frame_rx_stats = self.smurf_processor + 'FrameRxStats:'
-
-        self.fpga_top_level = self.amcc + 'FpgaTopLevel:'
-        self.app_top = self.fpga_top_level + 'AppTop:'
-        self.app_core = self.app_top + 'AppCore:'
+        self.fpga_top_level = self.amcc + 'FpgaTopLevel.'
+        self.app_top = self.fpga_top_level + 'AppTop.'
+        self.app_core = self.app_top + 'AppCore.'
 
         # AppTop
-        self.dac_sig_gen = self.app_top + 'DacSigGen[{}]:'
+        self.dac_sig_gen = self.app_top + 'DacSigGen[{}].'
 
         # AppCore
-        self.microwave_mux_core = self.app_core + 'MicrowaveMuxCore[{}]:'
-        self.sysgencryo = self.app_core + 'SysgenCryo:'
-        self.timing_header = self.app_core + 'TimingHeader:'
+        self.microwave_mux_core = self.app_core + 'MicrowaveMuxCore[{}].'
+        self.sysgencryo = self.app_core + 'SysgenCryo.'
+        self.timing_header = self.app_core + 'TimingHeader.'
 
         # MicrowaveMuxCore[#]
-        self.DBG = self.microwave_mux_core + 'DBG:'
-        self.dac_root = self.microwave_mux_core + 'DAC[{}]:'
-        self.att_root = self.microwave_mux_core + 'ATT:'
+        self.DBG = self.microwave_mux_core + 'DBG.'
+        self.dac_root = self.microwave_mux_core + 'DAC[{}].'
+        self.att_root = self.microwave_mux_core + 'ATT.'
 
         # LMK
-        self.lmk = self.microwave_mux_core + 'LMK:'
+        self.lmk = self.microwave_mux_core + 'LMK.'
 
         # SysgenCryo
-        self.band_root = self.sysgencryo + 'Base[{}]:'
-        self.adc_root = self.sysgencryo + 'CryoAdcMux:'
+        self.band_root = self.sysgencryo + 'Base[{}].'
+        self.adc_root = self.sysgencryo + 'CryoAdcMux.'
 
-        self.cryo_root = self.band_root + 'CryoChannels:'
-        self.channel_root = self.cryo_root + 'CryoChannel[{}]:'
+        self.cryo_root = self.band_root + 'CryoChannels.'
+        self.channel_root = self.cryo_root + 'CryoChannel[{}].'
 
-        self.streaming_root = self.amcc + 'streamingInterface:'
+        self.streaming_root = self.amcc + 'streamingInterface.'
 
         # FpgaTopLevel
-        self.fpgatl = self.amcc + 'FpgaTopLevel:'
+        self.fpgatl = self.amcc + 'FpgaTopLevel.'
 
         # AppTop
-        self.apptop = self.fpgatl + 'AppTop:'
+        self.apptop = self.fpgatl + 'AppTop.'
 
         # AppCore
-        self.appcore = self.apptop + 'AppCore:'
+        self.appcore = self.apptop + 'AppCore.'
 
         # AmcCarrierCore
-        self.amccc = self.fpgatl + 'AmcCarrierCore:'
+        self.amccc = self.fpgatl + 'AmcCarrierCore.'
 
         # Crossbar
-        self.crossbar = self.amccc + 'AxiSy56040:'
+        self.crossbar = self.amccc + 'AxiSy56040.'
 
         # Regulator
-        self.regulator = self.amccc + 'EM22xx:'
+        self.regulator = self.amccc + 'EM22xx.'
 
         # CarrierBsi
-        self.amc_carrier_bsi = self.amccc + 'AmcCarrierBsi:'
+        self.amc_carrier_bsi = self.amccc + 'AmcCarrierBsi.'
 
         # FPGA
-        self.ultrascale = self.amccc + 'AxiSysMonUltraScale:'
+        self.ultrascale = self.amccc + 'AxiSysMonUltraScale.'
 
         # Tx -> DAC , Rx <- ADC
-        self.axi_version = self.amccc + 'AxiVersion:'
+        self.axi_version = self.amccc + 'AxiVersion.'
         self.waveform_engine_buffers_root = self.amccc + \
-            'AmcCarrierBsa:BsaWaveformEngine[{}]:' + \
-            'WaveformEngineBuffers:'
-        self.stream_data_writer_root = self.amcc + 'streamDataWriter:'
-        self.jesd_tx_root = self.apptop + 'AppTopJesd[{}]:JesdTx:'
-        self.jesd_rx_root = self.apptop + 'AppTopJesd[{}]:JesdRx:'
-        self.daq_mux_root = self.apptop + 'DaqMuxV2[{}]:'
+            'AmcCarrierBsa:BsaWaveformEngine[{}].' + \
+            'WaveformEngineBuffers.'
+        self.stream_data_writer_root = self.amcc + 'streamDataWriter.'
+        self.jesd_tx_root = self.apptop + 'AppTopJesd[{}].JesdTx.'
+        self.jesd_rx_root = self.apptop + 'AppTopJesd[{}].JesdRx.'
+        self.daq_mux_root = self.apptop + 'DaqMuxV2[{}].'
 
         # RTM paths
-        self.rtm_cryo_det_root = self.appcore + 'RtmCryoDet:'
+        self.rtm_cryo_det_root = self.appcore + 'RtmCryoDet.'
         self.rtm_spi_root = self.rtm_cryo_det_root + \
-            'RtmSpiSr:'
+            'RtmSpiSr.'
         self.rtm_spi_max_root = self.rtm_cryo_det_root + \
-            'RtmSpiMax:'
+            'RtmSpiMax.'
         self.rtm_spi_cryo_root = self.rtm_cryo_det_root + \
-            'SpiCryo:'
+            'SpiCryo.'
         self.rtm_lut_ctrl_root = self.rtm_cryo_det_root + \
-            'LutCtrl:'
+            'LutCtrl.'
         self.rtm_lut_ctrl = self.rtm_lut_ctrl_root + \
-            'Ctrl:'
+            'Ctrl.'
 
         # Timing paths
-        self.amctiming = self.amccc + 'AmcCarrierTiming:'
-        self.trigger_root = self.amctiming + 'EvrV2CoreTriggers:'
-        self.timing_status = self.amctiming + 'TimingFrameRx:'
+        self.amctiming = self.amccc + 'AmcCarrierTiming.'
+        self.trigger_root = self.amctiming + 'EvrV2CoreTriggers.'
+        self.timing_status = self.amctiming + 'TimingFrameRx.'
 
         self.C = CryoCard(self.rtm_spi_cryo_root + 'read',
                           self.rtm_spi_cryo_root + 'write')

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -25,10 +25,10 @@ class SmurfBase:
     ----
     log : log file or None, optional, default None
         The log file to write to. If None, creates a new log file.
-    server_port: int or None, optional, default 9099
+    server_addr: str or None
+        The server address
+    server_port: int, optional, default 9000
         The server port on the server to connect to
-    epics_root : str or None, optional, default None
-        The name of the epics root. For example "test_epics".
     offline : bool, optional, default False
         Whether to run in offline mode (no rogue) or not. This
         will break many things. Default is False.
@@ -60,10 +60,17 @@ class SmurfBase:
     Overall progress on a task
     """
 
-    def __init__(self, log=None, server_port=9099, epics_root=None, offline=False,
-                 pub_root=None, script_id=None, **kwargs):
+    def __init__(self, log=None, server_addr="localhost", server_port=9000, atca_port=9100, offline=False, pub_root=None, script_id=None, **kwargs):
         """
         """
+
+        self._server_addr = server_addr
+        self._server_port = server_port
+        self._atca_port = atca_port
+
+        self._client = pyrogue.interfaces.VirtualClient(addr=self._server_addr, port=self._server_port)
+
+        self._atca = pyrogue.interfaces.VirtualClient(addr=self._server_addr, port=self._atca_port)
 
         # Set up logging
         self.log = log
@@ -87,7 +94,7 @@ class SmurfBase:
         # do this than just hardcoding paths? This needs to be cleaned
         # up somehow
 
-        self.amcc = 'AMCc.'
+        self.amcc = 'AMCc'
 
         self.smurf_application = self.amcc + 'SmurfApplication.'
 

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -25,6 +25,8 @@ class SmurfBase:
     ----
     log : log file or None, optional, default None
         The log file to write to. If None, creates a new log file.
+    server_port: int or None, optional, default 9099
+        The server port on the server to connect to
     epics_root : str or None, optional, default None
         The name of the epics root. For example "test_epics".
     offline : bool, optional, default False
@@ -58,7 +60,7 @@ class SmurfBase:
     Overall progress on a task
     """
 
-    def __init__(self, log=None, epics_root=None, offline=False,
+    def __init__(self, log=None, server_port=9099, epics_root=None, offline=False,
                  pub_root=None, script_id=None, **kwargs):
         """
         """

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -15,6 +15,7 @@
 #-----------------------------------------------------------------------------
 from pysmurf.client.command.cryo_card import CryoCard
 from pysmurf.client.util.pub import Publisher
+import pyrogue
 from .logger import SmurfLogger
 
 class SmurfBase:

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -187,8 +187,12 @@ class SmurfBase:
         self.trigger_root = self.amctiming + 'EvrV2CoreTriggers.'
         self.timing_status = self.amctiming + 'TimingFrameRx.'
 
-        self.C = CryoCard(self.rtm_spi_cryo_root + 'read',
-                          self.rtm_spi_cryo_root + 'write')
+        self.C = CryoCard(
+            self.rtm_spi_cryo_root + 'read',
+            self.rtm_spi_cryo_root + 'write',
+            self._server_addr,
+            self._server_port
+        )
         self.freq_resp = {}
 
         # RTM slow DAC parameters (used, e.g., for TES biasing). The

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -95,7 +95,7 @@ class SmurfBase:
         # do this than just hardcoding paths? This needs to be cleaned
         # up somehow
 
-        self.amcc = 'AMCc'
+        self.amcc = 'AMCc.'
 
         self.smurf_application = self.amcc + 'SmurfApplication.'
 

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -378,9 +378,6 @@ class SmurfConfig:
         ##### Building full validation schema
         schema_dict = {}
 
-        # Only used if none specified in pysmurf instantiation
-        schema_dict['epics_root'] = And(str, len)
-
         #### Start specifiying init schema
         # init must be present
         schema_dict['init'] = {}

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -83,8 +83,6 @@ class SmurfConfigPropertiesMixin:
 
     def __init__(self, *args, **kwargs):
         """SmurfConfigPropertiesMixin constructor."""
-        # EPICS
-        self._epics_root = None
 
         # Directories
         self._smurf_cmd_dir = None
@@ -193,9 +191,6 @@ class SmurfConfigPropertiesMixin:
               instance.
 
         """
-        ## EPICS
-        self.epics_root = config.get('epics_root')
-
         ## Directories
         self.smurf_cmd_dir = config.get('smurf_cmd_dir')
         self.tune_dir = config.get('tune_dir')
@@ -1785,35 +1780,6 @@ class SmurfConfigPropertiesMixin:
         self._default_tune = value
 
     ## End default_tune property definition
-    ###########################################################################
-
-    ###########################################################################
-    ## Start epics_root property definition
-
-    # Getter
-    @property
-    def epics_root(self):
-        """Short description.
-
-        Gets or sets ?.
-        Units are ?.
-
-        Specified in the pysmurf configuration file as
-        `smurf_to_mce:epics_root`.
-
-        See Also
-        --------
-        ?
-
-        """
-        return self._epics_root
-
-    # Setter
-    @epics_root.setter
-    def epics_root(self, value):
-        self._epics_root = value
-
-    ## End epics_root property definition
     ###########################################################################
 
     ###########################################################################

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -50,8 +50,6 @@ class SmurfControl(SmurfCommandMixin,
 
     Args
     ----
-    epics_root : str, optional, default None
-       The epics root to be used.
     cfg_file : str, optional, default None
        Config file path.  Must be provided if not on offline mode.
     data_dir : str, optional, default None
@@ -72,10 +70,6 @@ class SmurfControl(SmurfCommandMixin,
        implemented here are in smurf_cmd.py.
     no_dir :  bool, optional, default False
        Whether to make a skip making a directory.
-    shelf_manager : str, optional, default 'shm-smrf-sp01'
-       Shelf manager ip or network name.  Usually each SMuRF server is
-       connected one-to-one with a SMuRF crate, and the default shelf
-       manager name is configured to be 'shm-smrf-sp01'
     validate_config : bool, optional, default True
        Whether to check if the input config file is correct.
 
@@ -96,11 +90,9 @@ class SmurfControl(SmurfCommandMixin,
     initialize
     """
 
-    def __init__(self, epics_root=None,
-                 cfg_file=None, data_dir=None, name=None, make_logfile=True,
+    def __init__(self, cfg_file=None, data_dir=None, name=None, make_logfile=True,
                  setup=False, offline=False, smurf_cmd_mode=False,
-                 no_dir=False, shelf_manager='shm-smrf-sp01',
-                 validate_config=True, data_path_id=None, **kwargs):
+                 no_dir=False, validate_config=True, data_path_id=None, **kwargs):
         """Constructor for the SmurfControl class.
 
         See the SmurfControl class docstring for more details.
@@ -127,26 +119,6 @@ class SmurfControl(SmurfCommandMixin,
             # Populate SmurfConfigPropertiesMixin properties with
             # values from loaded pysmurf configuration file.
             self.copy_config_to_properties(self.config)
-
-        # Save shelf manager - Should this be in the config?
-        self.shelf_manager = shelf_manager
-
-        # Setting epics_root
-        #
-        # self.epics_root is already populated by the above call to
-        # copy_config_to_properties() from the pysmurf configuration
-        # file (if a configuration file is provided).
-        #
-        # Override epics_root from pysmurf configuration file if user
-        # provides a different one.
-        if epics_root is not None:
-            # If user provides an epics root, override whatever's in
-            # the pysmurf cfg file with it.
-            self.epics_root = epics_root
-        # In offline mode, epics root is not needed.
-        if offline:
-            self.epics_root = ''
-        # Done setting epics_root
 
         super().__init__(offline=offline, **kwargs)
 

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -610,9 +610,9 @@ class SmurfControl(SmurfCommandMixin,
             self.set_trigger_enable(0, 1, write_log=write_log)
             ## only sets enable, but is initialized to True already by
             ## default, and crashing for unknown reasons in rogue 4.
-            self.set_evr_channel_reg_enable(0, True, write_log=write_log)
+            self.set_evr_trigger_dest_type(0, 2, write_log=write_log)
             self.set_evr_trigger_channel_reg_dest_sel(0,
-                                                      0x20000,
+                                                      0x0,
                                                       write_log=write_log)
 
             self.set_enable_ramp_trigger(1, write_log=write_log)

--- a/python/pysmurf/client/command/smurf_atca_monitor.py
+++ b/python/pysmurf/client/command/smurf_atca_monitor.py
@@ -31,7 +31,7 @@ class SmurfAtcaMonitorMixin(SmurfBase):
 
     """
 
-    _write_atca_monitor_state_reg = ":Crate:SaveState"
+    _write_atca_monitor_state_reg = "Crate.SaveState"
 
     def write_atca_monitor_state(self, val, **kwargs):
         """Writes atca_monitor state to yml file.
@@ -44,14 +44,11 @@ class SmurfAtcaMonitorMixin(SmurfBase):
            The path (including file name) to write the yml file to.
 
         """
-        self._caput(
-            self.shelf_manager + self._write_atca_monitor_state_reg,
-            val, **kwargs)
+        self._caput( self._write_atca_monitor_state_reg, val, **kwargs)
 
-    _board_temp_fpga_reg = 'BoardTemp:FPGA'
+    _board_temp_fpga_reg = 'BoardTemp.FPGA'
 
-    def get_board_temp_fpga(
-            self, slot_number=None, atca_epics_root=None, **kwargs):
+    def get_board_temp_fpga(self, slot_number=None, **kwargs):
         r"""Returns the AMC carrier board temperature.
 
         Args
@@ -62,15 +59,6 @@ class SmurfAtcaMonitorMixin(SmurfBase):
             :class:`~pysmurf.client.base.smurf_control.SmurfControl`
             class attribute
             :attr:`~pysmurf.client.base.smurf_control.SmurfControl.slot_number`.
-        atca_epics_root : str or None, optional, default None
-            ATCA monitor server application EPICS root.  If None,
-            defaults to the
-            :class:`~pysmurf.client.base.smurf_control.SmurfControl`
-            class attribute
-            :attr:`~pysmurf.client.base.smurf_control.SmurfControl.shelf_manager`.
-            For typical systems, atca_epics_root is the name of the
-            shelf manager which for default systems is
-            'shm-smrf-sp01'.
         \**kwargs
             Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
@@ -84,16 +72,13 @@ class SmurfAtcaMonitorMixin(SmurfBase):
         """
         if slot_number is None:
             slot_number=self.slot_number
-        if atca_epics_root is None:
-            shelf_manager=self.shelf_manager
         return self._caget(
-            f'{shelf_manager}:Crate:Sensors:Slots:{slot_number}:' +
+            f'Crate.Sensors.Slots.{slot_number}.' +
             self._board_temp_fpga_reg,**kwargs)
 
-    _board_temp_rtm_reg = 'BoardTemp:RTM'
+    _board_temp_rtm_reg = 'BoardTemp.RTM'
 
-    def get_board_temp_rtm(
-            self, slot_number=None, atca_epics_root=None, **kwargs):
+    def get_board_temp_rtm( self, slot_number=None, **kwargs):
         r"""Returns the RTM board temperature.
 
         Args
@@ -104,15 +89,6 @@ class SmurfAtcaMonitorMixin(SmurfBase):
             :class:`~pysmurf.client.base.smurf_control.SmurfControl`
             class attribute
             :attr:`~pysmurf.client.base.smurf_control.SmurfControl.slot_number`.
-        atca_epics_root : str or None, optional, default None
-            ATCA monitor server application EPICS root.  If None,
-            defaults to the
-            :class:`~pysmurf.client.base.smurf_control.SmurfControl`
-            class attribute
-            :attr:`~pysmurf.client.base.smurf_control.SmurfControl.shelf_manager`.
-            For typical systems, atca_epics_root is the name of the
-            shelf manager which for default systems is
-            'shm-smrf-sp01'.
         \**kwargs
             Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
@@ -126,16 +102,13 @@ class SmurfAtcaMonitorMixin(SmurfBase):
         """
         if slot_number is None:
             slot_number=self.slot_number
-        if atca_epics_root is None:
-            shelf_manager=self.shelf_manager
         return self._caget(
-            f'{shelf_manager}:Crate:Sensors:Slots:{slot_number}:' +
+            f'Crate.Sensors.Slots.{slot_number}.' +
             self._board_temp_rtm_reg,**kwargs)
 
-    _junction_temp_fpga_reg = 'JunctionTemp:FPG'
+    _junction_temp_fpga_reg = 'JunctionTemp.FPG'
 
-    def get_junction_temp_fpga(
-            self, slot_number=None, atca_epics_root=None, **kwargs):
+    def get_junction_temp_fpga( self, slot_number=None, **kwargs):
         r"""Returns FPGA junction temperature.
 
         FPGA die temperature - probably from a sensor on the FPGA.  If
@@ -151,15 +124,6 @@ class SmurfAtcaMonitorMixin(SmurfBase):
             :class:`~pysmurf.client.base.smurf_control.SmurfControl`
             class attribute
             :attr:`~pysmurf.client.base.smurf_control.SmurfControl.slot_number`.
-        atca_epics_root : str or None, optional, default None
-            ATCA monitor server application EPICS root.  If None,
-            defaults to the
-            :class:`~pysmurf.client.base.smurf_control.SmurfControl`
-            class attribute
-            :attr:`~pysmurf.client.base.smurf_control.SmurfControl.shelf_manager`.
-            For typical systems, atca_epics_root is the name of the
-            shelf manager which for default systems is
-            'shm-smrf-sp01'.
         \**kwargs
             Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
@@ -173,16 +137,11 @@ class SmurfAtcaMonitorMixin(SmurfBase):
         """
         if slot_number is None:
             slot_number=self.slot_number
-        if atca_epics_root is None:
-            shelf_manager=self.shelf_manager
-        return self._caget(
-            f'{shelf_manager}:Crate:Sensors:Slots:{slot_number}:' +
-            self._junction_temp_fpga_reg,**kwargs)
+        return self._caget( f'Crate.Sensors.Slots.{slot_number}.' + self._junction_temp_fpga_reg,**kwargs)
 
-    _board_temp_amc_reg = 'BoardTemp:AMC{}'
+    _board_temp_amc_reg = 'BoardTemp.AMC{}'
 
-    def get_board_temp_amc(self, bay, slot_number=None,
-                           atca_epics_root=None, **kwargs):
+    def get_board_temp_amc(self, bay, slot_number=None, **kwargs):
         r"""Returns the AMC board temperature.
 
         Args
@@ -195,15 +154,6 @@ class SmurfAtcaMonitorMixin(SmurfBase):
             :class:`~pysmurf.client.base.smurf_control.SmurfControl`
             class attribute
             :attr:`~pysmurf.client.base.smurf_control.SmurfControl.slot_number`.
-        atca_epics_root : str or None, optional, default None
-            ATCA monitor server application EPICS root.  If None,
-            defaults to the
-            :class:`~pysmurf.client.base.smurf_control.SmurfControl`
-            class attribute
-            :attr:`~pysmurf.client.base.smurf_control.SmurfControl.shelf_manager`.
-            For typical systems, atca_epics_root is the name of the
-            shelf manager which for default systems is
-            'shm-smrf-sp01'.
         \**kwargs
             Arbitrary keyword arguments.  Passed directly to the
             `_caget` call.
@@ -217,20 +167,15 @@ class SmurfAtcaMonitorMixin(SmurfBase):
         """
         if slot_number is None:
             slot_number=self.slot_number
-        if atca_epics_root is None:
-            shelf_manager=self.shelf_manager
         # For some reason, the bay 0 AMC is at AMC[0] and the bay 1
         # AMC is at AMC[2], hence the bay*2.
-        return self._caget(
-            f'{shelf_manager}:Crate:Sensors:Slots:{slot_number}:' +
-            self._board_temp_amc_reg.format(bay*2),**kwargs)
+        return self._caget( f'Crate.Sensors.Slots.{slot_number}.' + self._board_temp_amc_reg.format(bay*2),**kwargs)
 
     _amc_product_asset_tag_reg = 'Product_Asset_Tag'
     _amc_product_version_reg = 'Product_Version'
 
     def get_amc_sn(
             self, bay, slot_number=None,
-            atca_epics_root=None,
             shelf_manager=None,
             use_shell=False,
             **kwargs):
@@ -273,15 +218,6 @@ class SmurfAtcaMonitorMixin(SmurfBase):
             :class:`~pysmurf.client.base.smurf_control.SmurfControl`
             class attribute
             :attr:`~pysmurf.client.base.smurf_control.SmurfControl.slot_number`.
-        atca_epics_root : str or None, optional, default None
-            ATCA monitor server application EPICS root.  If None,
-            defaults to the
-            :class:`~pysmurf.client.base.smurf_control.SmurfControl`
-            class attribute
-            :attr:`~pysmurf.client.base.smurf_control.SmurfControl.shelf_manager`.
-            For typical systems, atca_epics_root is the name of the
-            shelf manager which for default systems is
-            'shm-smrf-sp01'.
         use_shell : bool, optional, default False
             If False, polls the ATCA monitor EPICs server ; if True,
             runs slower shell command to poll this attribute.  This
@@ -313,8 +249,6 @@ class SmurfAtcaMonitorMixin(SmurfBase):
         """
         if slot_number is None:
             slot_number=self.slot_number
-        if atca_epics_root is None:
-            atca_epics_root=self.shelf_manager
         if shelf_manager is None:
             shelf_manager=self.shelf_manager
         if use_shell:
@@ -331,7 +265,7 @@ class SmurfAtcaMonitorMixin(SmurfBase):
         else:
             # For some reason, the bay 0 AMC is at AMC[0] and the bay 1
             # AMC is at AMC[2], hence the bay*2.
-            atca_epics_path=f'{atca_epics_root}:Crate:Sensors:Slots:{slot_number}:' + f'AMCInfo:{bay*2}:'
+            atca_epics_path=f'Crate.Sensors.Slots.{slot_number}.' + f'AMCInfo.{bay*2}.'
             amc_product_asset_tag=self._caget(atca_epics_path +
                                               self._amc_product_asset_tag_reg, as_string=True,
                                               **kwargs)
@@ -345,7 +279,6 @@ class SmurfAtcaMonitorMixin(SmurfBase):
 
     def get_carrier_sn(
             self, slot_number=None,
-            atca_epics_root=None,
             shelf_manager=None,
             use_shell=False,
             **kwargs):
@@ -376,15 +309,6 @@ class SmurfAtcaMonitorMixin(SmurfBase):
             :class:`~pysmurf.client.base.smurf_control.SmurfControl`
             class attribute
             :attr:`~pysmurf.client.base.smurf_control.SmurfControl.slot_number`.
-        atca_epics_root : str or None, optional, default None
-            ATCA monitor server application EPICS root.  If None,
-            defaults to the
-            :class:`~pysmurf.client.base.smurf_control.SmurfControl`
-            class attribute
-            :attr:`~pysmurf.client.base.smurf_control.SmurfControl.shelf_manager`.
-            For typical systems, atca_epics_root is the name of the
-            shelf manager which for default systems is
-            'shm-smrf-sp01'.
         use_shell : bool, optional, default False
             If False, polls the ATCA monitor EPICs server ; if True,
             runs slower shell command to poll this attribute.  This
@@ -416,8 +340,6 @@ class SmurfAtcaMonitorMixin(SmurfBase):
         """
         if slot_number is None:
             slot_number=self.slot_number
-        if atca_epics_root is None:
-            atca_epics_root=self.shelf_manager
         if shelf_manager is None:
             shelf_manager=self.shelf_manager
         if use_shell:
@@ -438,7 +360,7 @@ class SmurfAtcaMonitorMixin(SmurfBase):
                          self.LOG_ERROR)
                 return None
         else:
-            atca_epics_path=f'{atca_epics_root}:Crate:Sensors:Slots:{slot_number}:CarrierInfo:'
+            atca_epics_path=f'Crate.Sensors.Slots.{slot_number}.CarrierInfo.'
             carrier_product_asset_tag=self._caget(atca_epics_path +
                                                   self._carrier_product_asset_tag_reg, as_string=True,
                                                   **kwargs)
@@ -457,7 +379,6 @@ class SmurfAtcaMonitorMixin(SmurfBase):
 
     def get_rtm_sn(
             self, slot_number=None,
-            atca_epics_root=None,
             shelf_manager=None,
             use_shell=False,
             **kwargs):
@@ -487,15 +408,6 @@ class SmurfAtcaMonitorMixin(SmurfBase):
             :class:`~pysmurf.client.base.smurf_control.SmurfControl`
             class attribute
             :attr:`~pysmurf.client.base.smurf_control.SmurfControl.slot_number`.
-        atca_epics_root : str or None, optional, default None
-            ATCA monitor server application EPICS root.  If None,
-            defaults to the
-            :class:`~pysmurf.client.base.smurf_control.SmurfControl`
-            class attribute
-            :attr:`~pysmurf.client.base.smurf_control.SmurfControl.shelf_manager`.
-            For typical systems, atca_epics_root is the name of the
-            shelf manager which for default systems is
-            'shm-smrf-sp01'.
         use_shell : bool, optional, default False
             If False, polls the ATCA monitor EPICs server ; if True,
             runs slower shell command to poll this attribute.  This
@@ -527,8 +439,6 @@ class SmurfAtcaMonitorMixin(SmurfBase):
         """
         if slot_number is None:
             slot_number=self.slot_number
-        if atca_epics_root is None:
-            atca_epics_root=self.shelf_manager
         if shelf_manager is None:
             shelf_manager=self.shelf_manager
         if use_shell:
@@ -545,7 +455,7 @@ class SmurfAtcaMonitorMixin(SmurfBase):
                          self.LOG_ERROR)
                 return None
         else:
-            atca_epics_path=f'{atca_epics_root}:Crate:Sensors:Slots:{slot_number}:RTMInfo:'
+            atca_epics_path=f'Crate.Sensors.Slots.{slot_number}.RTMInfo.'
             rtm_product_asset_tag=self._caget(atca_epics_path +
                                               self._rtm_product_asset_tag_reg, as_string=True,
                                               **kwargs)

--- a/python/pysmurf/client/command/smurf_cmd.py
+++ b/python/pysmurf/client/command/smurf_cmd.py
@@ -198,7 +198,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--epics-prefix', help='The epics root',
+    parser.add_argument('--server-port', help='The Server Port',
                         action='store', default=None, type=str)
 
     # Offline mode
@@ -336,9 +336,9 @@ if __name__ == "__main__":
     if n_cmds > 1:
         sys.exit(0)
 
-    epics_prefix = args.epics_prefix
+    server_port = args.server_port
 
-    S = pysmurf.client.SmurfControl(epics_root=epics_prefix,
+    S = pysmurf.client.SmurfControl(server_port=server_port,
         cfg_file=cfg_filename, smurf_cmd_mode=True, setup=False,
         offline=offline)
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -58,6 +58,7 @@ class SmurfCommandMixin(SmurfBase):
 
         var.set(val)
 
+    def _caget(self, pvname, **kwargs):
         """Gets variables from epics.
 
         Wrapper around pyrogue lcaget. Gets variables from epics.

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -59,7 +59,11 @@ class SmurfCommandMixin(SmurfBase):
         if var == None:
             raise Exception(f"Invalid node: {pvname}")
 
-        var.set(val)
+        # For the ATCA EPICS interface, a command is called with .set
+        if not atca and var.isCommand:
+            var.call(val)
+        else:
+            var.set(val)
 
     def _caget(self, pvname, atca=False, **kwargs):
         """Gets variables from epics.

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -29,7 +29,7 @@ class SmurfCommandMixin(SmurfBase):
 
     _global_poll_enable_reg = 'AMCc:enable'
 
-    def _caput(self, pvname, val, *args, **kwargs):
+    def _caput(self, pvname, val, **kwargs):
         """Puts variables into epics.
 
         Wrapper around pyrogue lcaput. Puts variables into epics.
@@ -41,19 +41,14 @@ class SmurfCommandMixin(SmurfBase):
         val: any
             The value to put into epics
         """
+        err = False
+        for k,v in kwargs.items():
 
-        if len(args) != 0 or len(kwargs) != 0:
-            print("-------------------------------------------------")
-            print("Unexpected args:")
+            if v is not None:
+                print(f"Unexpected kwargs: {k} = {v}")
+                err=True
 
-            for a in args:
-                print(f"   {a}")
-
-            print("Unexpected kwargs:")
-
-            for k,v in kwargs.items():
-                print(f"   {k} = {v}")
-
+        if err:
             raise Exception("Bad args passed to caput")
 
         var = self._vr.getNode(pvname)
@@ -77,19 +72,14 @@ class SmurfCommandMixin(SmurfBase):
         ret : str
             The requested value.
         """
+        err = False
+        for k,v in kwargs.items():
 
-        if len(args) != 0 or len(kwargs) != 0:
-            print("-------------------------------------------------")
-            print("Unexpected args:")
+            if v is not None:
+                print(f"Unexpected kwargs: {k} = {v}")
+                err=True
 
-            for a in args:
-                print(f"   {a}")
-
-            print("Unexpected kwargs:")
-
-            for k,v in kwargs.items():
-                print(f"   {k} = {v}")
-
+        if err:
             raise Exception("Bad args passed to caput")
 
         var = self._vr.getNode(pvname)

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -27,7 +27,7 @@ from pysmurf.client.util import tools, dscounters
 
 class SmurfCommandMixin(SmurfBase):
 
-    _global_poll_enable_reg = 'AMCc:enable'
+    _global_poll_enable_reg = 'AMCc.enable'
 
     def _caput(self, pvname, val, atca=False, **kwargs):
         """Puts variables into epics.
@@ -3346,7 +3346,7 @@ class SmurfCommandMixin(SmurfBase):
     #########################################################
     ## start rtm arbitrary waveform
 
-    _rtm_arb_waveform_lut_table_reg = 'Lut[{}]:MemArray'
+    _rtm_arb_waveform_lut_table_reg = 'Lut[{}].MemArray'
 
     def set_rtm_arb_waveform_lut_table(self, reg, arr, pad=0, **kwargs):
         """
@@ -5276,7 +5276,7 @@ class SmurfCommandMixin(SmurfBase):
                  f'(userConfig[0]={uc0}).',self.LOG_USER)
 
     # Triggering commands
-    _trigger_width_reg = 'EvrV2TriggerReg[{}]:Width'
+    _trigger_width_reg = 'EvrV2TriggerReg[{}].Width'
 
     def set_trigger_width(self, chan, val, **kwargs):
         """
@@ -5286,7 +5286,7 @@ class SmurfCommandMixin(SmurfBase):
             self.trigger_root + self._trigger_width_reg.format(chan),
             val, **kwargs)
 
-    _trigger_enable_reg = 'EvrV2TriggerReg[{}]:EnableTrig'
+    _trigger_enable_reg = 'EvrV2TriggerReg[{}].EnableTrig'
 
     def set_trigger_enable(self, chan, val, **kwargs):
         r"""Set trigger pulse generation enable for requested channel.
@@ -5348,7 +5348,7 @@ class SmurfCommandMixin(SmurfBase):
             self.trigger_root + self._trigger_enable_reg.format(chan),
             **kwargs)
 
-    _trigger_channel_reg_enable_reg = 'EvrV2ChannelReg[{}]:EnableReg'
+    _trigger_channel_reg_enable_reg = 'EvrV2ChannelReg[{}].EnableReg'
 
     def set_evr_channel_reg_enable(self, chan, val, **kwargs):
         r"""Set trigger channel enable.
@@ -5413,7 +5413,7 @@ class SmurfCommandMixin(SmurfBase):
             self._trigger_channel_reg_enable_reg.format(chan),
             **kwargs)
 
-    _trigger_reg_enable_reg = 'EvrV2TriggerReg[{}]:enable'
+    _trigger_reg_enable_reg = 'EvrV2TriggerReg[{}].enable'
 
     def set_evr_trigger_reg_enable(self, chan, val, **kwargs):
         """
@@ -5423,7 +5423,7 @@ class SmurfCommandMixin(SmurfBase):
             self._trigger_reg_enable_reg.format(chan),
             val, **kwargs)
 
-    _trigger_channel_reg_count_reg = 'EvrV2ChannelReg[{}]:Count'
+    _trigger_channel_reg_count_reg = 'EvrV2ChannelReg[{}].Count'
 
     def get_evr_channel_reg_count(self, chan, **kwargs):
         """
@@ -5433,7 +5433,7 @@ class SmurfCommandMixin(SmurfBase):
             self._trigger_channel_reg_count_reg.format(chan),
             **kwargs)
 
-    _evr_trigger_dest_type_reg = 'EvrV2ChannelReg[{}]:DestType'
+    _evr_trigger_dest_type_reg = 'EvrV2ChannelReg[{}].DestType'
 
     def set_evr_trigger_dest_type(self, chan, value, **kwargs):
         r"""Set trigger channel destination type.
@@ -5515,7 +5515,7 @@ class SmurfCommandMixin(SmurfBase):
             self._evr_trigger_dest_type_reg.format(chan),
             **kwargs)
 
-    _trigger_channel_reg_dest_sel_reg = 'EvrV2ChannelReg[{}]:DestSel'
+    _trigger_channel_reg_dest_sel_reg = 'EvrV2ChannelReg[{}].DestSel'
 
     def set_evr_trigger_channel_reg_dest_sel(self, chan, val, **kwargs):
         """
@@ -6002,7 +6002,7 @@ class SmurfCommandMixin(SmurfBase):
             self.lmk.format(bay) + self._lmk_reg.format(reg),
             **kwargs)
 
-    _mcetransmit_debug_reg = 'AMCc:mcetransmitDebug'
+    _mcetransmit_debug_reg = 'AMCc.mcetransmitDebug'
 
     def set_mcetransmit_debug(self, val, **kwargs):
         """
@@ -6069,7 +6069,7 @@ class SmurfCommandMixin(SmurfBase):
             self.frame_rx_stats + self._frame_out_order_count_reg,
             **kwargs)
 
-    _channel_mask_reg = 'ChannelMapper:Mask'
+    _channel_mask_reg = 'ChannelMapper.Mask'
 
     def set_channel_mask(self, mask, **kwargs):
         """
@@ -6098,7 +6098,7 @@ class SmurfCommandMixin(SmurfBase):
             self.smurf_processor + self._channel_mask_reg,
             **kwargs)
 
-    _unwrapper_reset_reg = 'Unwrapper:reset'
+    _unwrapper_reset_reg = 'Unwrapper.reset'
 
     def set_unwrapper_reset(self, **kwargs):
         """
@@ -6243,7 +6243,7 @@ class SmurfCommandMixin(SmurfBase):
             self.smurf_processor + self._filter_gain_reg,
             **kwargs)
 
-    _downsampler_mode_reg = 'Downsampler:DownsamplerMode'
+    _downsampler_mode_reg = 'Downsampler.DownsamplerMode'
 
     def set_downsample_mode(self, mode):
         """
@@ -6279,7 +6279,7 @@ class SmurfCommandMixin(SmurfBase):
 
         return ret
 
-    _downsampler_factor_reg = 'Downsampler:InternalFactor'
+    _downsampler_factor_reg = 'Downsampler.InternalFactor'
 
     def set_downsample_factor(self, factor, get_nearby=False, desperation=2, **kwargs):
         """
@@ -6343,7 +6343,7 @@ class SmurfCommandMixin(SmurfBase):
 
         return self._caget(self.smurf_processor + self._downsampler_factor_reg, **kwargs)
 
-    _downsampler_external_bitmask_reg = 'Downsampler:ExternalBitmask'
+    _downsampler_external_bitmask_reg = 'Downsampler.ExternalBitmask'
 
     def set_downsample_external_bitmask(self, bitmask):
         """
@@ -6397,7 +6397,7 @@ class SmurfCommandMixin(SmurfBase):
             self.smurf_processor + self._filter_disable_reg,
             **kwargs)
 
-    _max_file_size_reg = 'FileWriter:MaxFileSize'
+    _max_file_size_reg = 'FileWriter.MaxFileSize'
 
     def set_max_file_size(self, size, **kwargs):
         """Set maximum file size for streamed data.
@@ -6449,7 +6449,7 @@ class SmurfCommandMixin(SmurfBase):
             self.smurf_processor + self._max_file_size_reg,
             as_string=True, **kwargs))
 
-    _data_file_name_reg = 'FileWriter:DataFile'
+    _data_file_name_reg = 'FileWriter.DataFile'
 
     def set_data_file_name(self, name, **kwargs):
         """
@@ -6476,7 +6476,7 @@ class SmurfCommandMixin(SmurfBase):
         return self._caget(self.smurf_processor + self._data_file_name_reg,
             **kwargs)
 
-    _data_file_open_reg = 'FileWriter:Open'
+    _data_file_open_reg = 'FileWriter.Open'
 
     def open_data_file(self, **kwargs):
         """
@@ -6485,7 +6485,7 @@ class SmurfCommandMixin(SmurfBase):
         self._caput(self.smurf_processor + self._data_file_open_reg, 1,
             **kwargs)
 
-    _data_file_close_reg = 'FileWriter:Close'
+    _data_file_close_reg = 'FileWriter.Close'
 
     def close_data_file(self, **kwargs):
         """

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -76,6 +76,7 @@ class SmurfCommandMixin(SmurfBase):
         ret : str
             The requested value.
         """
+        as_string = kwargs.pop("as_string", False)
         err = False
         for k,v in kwargs.items():
 
@@ -94,7 +95,10 @@ class SmurfCommandMixin(SmurfBase):
         if var == None:
             raise Exception(f"Invalid node: {pvname}")
 
-        return var.get()
+        if as_string:
+            return var.getDisp()
+        else:
+            return var.get()
 
     #### Start SmurfApplication gets/sets
     _smurf_version_reg = 'SmurfVersion'

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -29,7 +29,7 @@ class SmurfCommandMixin(SmurfBase):
 
     _global_poll_enable_reg = 'AMCc:enable'
 
-    def _caput(self, pvname, val, **kwargs):
+    def _caput(self, pvname, val, atca=False, **kwargs):
         """Puts variables into epics.
 
         Wrapper around pyrogue lcaput. Puts variables into epics.
@@ -51,14 +51,17 @@ class SmurfCommandMixin(SmurfBase):
         if err:
             raise Exception("Bad args passed to caput")
 
-        var = self._vr.getNode(pvname)
+        if atca:
+            var = self._atca.root.getNode(pvname)
+        else:
+            var = self._client.root.getNode(pvname)
 
         if var == None:
             raise Exception(f"Invalid node: {pvname}")
 
         var.set(val)
 
-    def _caget(self, pvname, **kwargs):
+    def _caget(self, pvname, atca=False, **kwargs):
         """Gets variables from epics.
 
         Wrapper around pyrogue lcaget. Gets variables from epics.
@@ -83,7 +86,10 @@ class SmurfCommandMixin(SmurfBase):
         if err:
             raise Exception("Bad args passed to caput")
 
-        var = self._vr.getNode(pvname)
+        if atca:
+            var = self._atca.root.getNode(pvname)
+        else:
+            var = self._client.root.getNode(pvname)
 
         if var == None:
             raise Exception(f"Invalid node: {pvname}")

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -68,14 +68,13 @@ class SmurfCommandMixin(SmurfBase):
             var.setDisp(val)
         else:
             if not atca and cast_type:
-                # python types are better handled by rogue
                 if isinstance(val, np.ndarray):
-                    val = [i.item() for i in val]
-                elif isinstance(val, np.generic):
-                    val = val.item()
-                # also check that the type matches variable type
-                var_type = type(var.value())
-                val = var_type(val)
+                    val = val.astype(var.value().dtype)
+                else:
+                    if isinstance(val, np.generic):
+                        val = val.item()
+                    var_type = type(var.value())
+                    val = var_type(val)
             var.set(val)
 
     def _caget(self, pvname, atca=False, **kwargs):

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -709,7 +709,7 @@ class SmurfCommandMixin(SmurfBase):
 
         if sync_group:
 
-            varList = [self._client.root.getNode(monitorPV)
+            varList = [self._client.root.getNode(monitorPV)]
 
 
             sg = SyncGroup([monitorPV])

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -47,7 +47,7 @@ class SmurfCommandMixin(SmurfBase):
 
             if v is not None:
                 print(f"Unexpected kwargs: {k} = {v}")
-                err=True
+                #err=True
 
         if err:
             raise Exception("Bad args passed to caput")
@@ -99,7 +99,7 @@ class SmurfCommandMixin(SmurfBase):
 
             if v is not None:
                 print(f"Unexpected kwargs: {k} = {v}")
-                err=True
+                #err=True
 
         if err:
             raise Exception("Bad args passed to caput")

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -3055,7 +3055,7 @@ class SmurfCommandMixin(SmurfBase):
     # Waveform engine commands
     _start_addr_reg = 'StartAddr[{}]'
 
-    def set_waveform_start_addr(self, bay, engine, val, convert=True, **kwargs):
+    def set_waveform_start_addr(self, bay, engine, val, **kwargs):
         """
         No description
 
@@ -3067,12 +3067,9 @@ class SmurfCommandMixin(SmurfBase):
             Which waveform engine.
         val : int or str
             What value to set.
-        convert : bool, optional, default True
-            Convert the input from an integer to a string of hex
-            values before setting.
         """
-        if convert:
-            val = self.int_to_hex_string(val)
+        if isinstance(val, str):
+            val = int(val, 16)
         self._caput(
             self.waveform_engine_buffers_root.format(bay) +
             self._start_addr_reg.format(engine),
@@ -3095,16 +3092,17 @@ class SmurfCommandMixin(SmurfBase):
         val = self._caget(
             self.waveform_engine_buffers_root.format(bay) +
             self._start_addr_reg.format(engine),
+            as_string=True,
             **kwargs)
 
         if convert:
-            return self.hex_string_to_int(val)
+            return int(val, 16)
         else:
             return val
 
     _end_addr_reg = 'EndAddr[{}]'
 
-    def set_waveform_end_addr(self, bay, engine, val, convert=True, **kwargs):
+    def set_waveform_end_addr(self, bay, engine, val, **kwargs):
         """
         No description
 
@@ -3116,11 +3114,9 @@ class SmurfCommandMixin(SmurfBase):
             Which waveform engine.
         val : int
             What val to set.
-        convert : bool, optional, default True
-            Convert the output from a string of hex values to an int.
         """
-        if convert:
-            val = self.int_to_hex_string(val)
+        if isinstance(val, str):
+            val = int(val, 16)
         self._caput(
             self.waveform_engine_buffers_root.format(bay) +
             self._end_addr_reg.format(engine),
@@ -3148,10 +3144,11 @@ class SmurfCommandMixin(SmurfBase):
         val = self._caget(
             self.waveform_engine_buffers_root.format(bay) +
             self._end_addr_reg.format(engine),
+            as_string=True,
             **kwargs)
 
         if convert:
-            return self.hex_string_to_int(val)
+            return int(val, 16)
         else:
             return val
 
@@ -3172,8 +3169,8 @@ class SmurfCommandMixin(SmurfBase):
         convert : bool, optional, default True
             Convert the output from a string of hex values to an int.
         """
-        if convert:
-            val = self.int_to_hex_string(val)
+        if isinstance(val, str):
+            val = int(val, 16)
         self._caput(
             self.waveform_engine_buffers_root.format(bay) +
             self._wr_addr_reg.format(engine),
@@ -3201,10 +3198,11 @@ class SmurfCommandMixin(SmurfBase):
         val = self._caget(
             self.waveform_engine_buffers_root.format(bay) +
             self._wr_addr_reg.format(engine),
+            as_string=True,
             **kwargs)
 
         if convert:
-            return self.hex_string_to_int(val)
+            return int(val, 16)
         else:
             return val
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -46,7 +46,7 @@ class SmurfCommandMixin(SmurfBase):
         for k,v in kwargs.items():
 
             if v is not None:
-                print(f"Unexpected kwargs: {k} = {v}")
+                self.log(f"Unexpected kwargs: {k} = {v}", self.LOG_INFO)
                 #err=True
 
         if err:

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -4088,7 +4088,7 @@ class SmurfCommandMixin(SmurfBase):
         """
         assert (dac in range(1,33)),'dac must be an integer and in [1,32]'
         self.set_rtm_slow_dac_data(
-            dac, val/self._rtm_slow_dac_bit_to_volt, **kwargs)
+            dac, int(val/self._rtm_slow_dac_bit_to_volt), **kwargs)
 
 
     def get_rtm_slow_dac_volt(self, dac, **kwargs):

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -1366,7 +1366,7 @@ class SmurfCommandMixin(SmurfBase):
             self._cryo_root(band) + self._amplitude_scales_reg,
             **kwargs)
 
-    _amplitude_scale_array_reg = 'amplitudeScaleArray'
+    _amplitude_scale_array_reg = 'amplitudeScale'
 
     def set_amplitude_scale_array(self, band, val, **kwargs):
         """
@@ -1414,7 +1414,7 @@ class SmurfCommandMixin(SmurfBase):
         new_amp[np.where(old_amp!=0)] = tone_power
         self.set_amplitude_scale_array(self, new_amp, **kwargs)
 
-    _feedback_enable_array_reg = 'feedbackEnableArray'
+    _feedback_enable_array_reg = 'feedbackEnable'
 
     def set_feedback_enable_array(self, band, val, **kwargs):
         """
@@ -1815,7 +1815,7 @@ class SmurfCommandMixin(SmurfBase):
             self._band_root(band) + self._feedback_enable_reg,
             **kwargs)
 
-    _loop_filter_output_array_reg = 'loopFilterOutputArray'
+    _loop_filter_output_array_reg = 'loopFilterOutput'
 
     def get_loop_filter_output_array(self, band, **kwargs):
         """
@@ -1843,7 +1843,7 @@ class SmurfCommandMixin(SmurfBase):
             self._tone_frequency_offset_mhz_reg,
             **kwargs)
 
-    _center_frequency_array_reg = 'centerFrequencyArray'
+    _center_frequency_array_reg = 'centerFrequency'
 
     def set_center_frequency_array(self, band, val, **kwargs):
         """
@@ -1876,7 +1876,7 @@ class SmurfCommandMixin(SmurfBase):
             self._band_root(band) + self._feedback_gain_reg,
             **kwargs)
 
-    _eta_phase_array_reg = 'etaPhaseArray'
+    _eta_phase_array_reg = 'etaPhase'
 
     def set_eta_phase_array(self, band, val, **kwargs):
         """
@@ -1892,7 +1892,7 @@ class SmurfCommandMixin(SmurfBase):
             self._cryo_root(band) + self._eta_phase_array_reg,
             **kwargs)
 
-    _frequency_error_array_reg = 'frequencyErrorArray'
+    _frequency_error_array_reg = 'frequencyError'
 
     def set_frequency_error_array(self, band, val, **kwargs):
         """
@@ -1908,7 +1908,7 @@ class SmurfCommandMixin(SmurfBase):
             self._cryo_root(band) + self._frequency_error_array_reg,
             **kwargs)
 
-    _eta_mag_array_reg = 'etaMagArray'
+    _eta_mag_array_reg = 'etaMag'
 
     def set_eta_mag_array(self, band, val, **kwargs):
         """

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -22,7 +22,7 @@ import numpy as np
 from packaging import version
 
 from pysmurf.client.base import SmurfBase
-from pysmurf.client.command.sync_group import SyncGroup as SyncGroup
+#from pysmurf.client.command.sync_group import SyncGroup as SyncGroup
 from pysmurf.client.util import tools, dscounters
 
 class SmurfCommandMixin(SmurfBase):
@@ -708,6 +708,10 @@ class SmurfCommandMixin(SmurfBase):
         self.log(f'{triggerPV} sent', self.LOG_USER)
 
         if sync_group:
+
+            varList = [self._client.root.getNode(monitorPV)
+
+
             sg = SyncGroup([monitorPV])
             sg.wait()
             vals = sg.get_values()

--- a/python/pysmurf/client/command/sync_group.py
+++ b/python/pysmurf/client/command/sync_group.py
@@ -15,6 +15,7 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 from pyrogue import VariableWait
+from time import time
 
 """
 This class is written by Mitch to read PVs simultanesouly
@@ -23,20 +24,32 @@ class SyncGroup(object):
     def __init__(self, pvs, client, timeout=30.0):
         self.pvnames = pvs
         self.timeout = timeout
-        self.pvs = []
+        self.pvs = {}
+        self.updated = {}
+        #self.vals = {}
         for pvname in pvs:
             node = client.root.getNode(pvname)
             if node is None:
                 raise ValueError(f"Failed to get node {pvname}")
-            self.pvs.append(node)
+            self.pvs[pvname] = node
+            self.updated[pvname] = False
+            node.addListener(self._receive_update)
 
-    def get_values(self):
-        return {self.pvnames[i]: self.pvs[i].get() for i in range(len(self.pvs))}
+    def _receive_update(self, path, val):
+        if path in self.pvs:
+            self.updated[path] = True
+            #self.vals[path] = val.get()
+
+    def get_values(self, read=False):
+        #if read or (not all(self.updated.values())):
+        #    return {self.pvnames[i]: self.pvs[i].get() for i in range(len(self.pvs))}
+        #else:
+        #    return self.vals
+        return {k: self.pvs[k].get() for k in self.pvs}
 
     # blocking wait for all to complete
     def wait(self):
-        VariableWait(
-            self.pvs,
-            lambda varValues: all([v.updated for v in varValues]),
-            timeout=self.timeout
-        )
+        done = lambda: all(self.updated.values())
+        start = time()
+        while not done() and ((time() - start) < self.timeout): 
+            continue

--- a/python/pysmurf/client/command/sync_group.py
+++ b/python/pysmurf/client/command/sync_group.py
@@ -14,56 +14,24 @@
 # copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-import time
-try:
-    import epics
-except ModuleNotFoundError:
-    print("sync_group.py - epics not found.")
+from pyrogue import VariableWait
 
 """
 This class is written by Mitch to read PVs simultanesouly
 """
 class SyncGroup(object):
-    def __init__(self, pvs, timeout=30.0, skip_first=True):
+    def __init__(self, pvs, client, timeout=30.0):
         self.pvnames = pvs
-        self.values = dict()
         self.timeout = timeout
-        self.first = [skip_first] * len(pvs)
-        self.pvs = [epics.PV(pv, callback=self.channel_changed,
-            auto_monitor=True) for pv in pvs]
-
-    def channel_changed(self, pvname, value, *args, **kwargs):
-        # don't fill on initial connection
-        if self.first[self.pvnames.index(pvname)]:
-            self.first[self.pvnames.index(pvname)] = False
-            return
-        self.values[pvname] = value
+        self.pvs = [client.root.getNode(pvname) for pvname in pvs]
 
     def get_values(self):
-        val  = self.values
-        self.values = dict()
-        return val
-
-    # non-blocking check if done
-    def check(self):
-        return all([n in self.values for n in self.pvnames])
-
-    # clear if want to force re-arm
-    def clear(self):
-        self.values = dict()
+        return {self.pvnames[i]: self.pvs[i].get() for i in range(len(self.pvs))}
 
     # blocking wait for all to complete
-    def wait(self,epics_poll=False):
-        t0 = time.time()
-        while not all([n in self.values for n in self.pvnames]):
-            if epics_poll:
-                # better performance using this over time.sleep() but
-                # it can eat a lot of CPU, so better to use epics.poll
-                # for short waits/acquisitions where latency is a
-                # concern.  For more details see:
-                # https://cars9.uchicago.edu/software/python/pyepics3/advanced.html#time-sleep-or-epics-poll
-                epics.ca.poll()
-            else:
-                time.sleep(.001)
-            if time.time() - t0 > self.timeout:
-                raise Exception('Timeout waiting for PVs to update.')
+    def wait(self):
+        VariableWait(
+            self.pvs,
+            lambda varValues: all([v.updated for v in varValues]),
+            timeout=self.timeout
+        )

--- a/python/pysmurf/client/test/conftest.py
+++ b/python/pysmurf/client/test/conftest.py
@@ -1,6 +1,4 @@
 def pytest_addoption(parser):
-    parser.addoption("--epics", action="store", required=True,
-                     help="The target pysmurf server's epics prefix")
 
     parser.addoption("--config", action="store",
                      default="/usr/local/src/pysmurf/cfg_files/stanford/"

--- a/python/pysmurf/client/test/test_loopback.py
+++ b/python/pysmurf/client/test/test_loopback.py
@@ -18,9 +18,9 @@ import pysmurf.client
 
 @pytest.fixture(scope='session')
 def smurf_control(request):
-    epics_prefix = request.config.getoption("--epics")
+    server_port = request.config.getoption("--port")
     config_file = request.config.getoption("--config")
-    S = pysmurf.client.SmurfControl(epics_root=epics_prefix,
+    S = pysmurf.client.SmurfControl(server_port=server_port,
                                     cfg_file=config_file,
                                     setup=request.param,
                                     make_logfile=False,

--- a/python/pysmurf/client/test/test_resonator.py
+++ b/python/pysmurf/client/test/test_resonator.py
@@ -13,11 +13,11 @@ import pysmurf.client
 
 @pytest.fixture(scope='session')
 def smurf_control():
-    epics_prefix = 'smurf_server_s5'
+    server_port = 9000
     config_file = os.path.join('/usr/local/src/pysmurf/',
                                'cfg_files/stanford/',
                                'experiment_fp30_cc02-03_lbOnlyBay0.cfg' )
-    S = pysmurf.client.SmurfControl(epics_root=epics_prefix,
+    S = pysmurf.client.SmurfControl(server_port=server_port,
                                     cfg_file=config_file,
                                     setup=False,
                                     make_logfile=False,

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2307,7 +2307,7 @@ class SmurfTuneMixin(SmurfBase):
                self._cryo_root(band) + self._eta_scan_results_imag_reg]
 
         if sync_group:
-            sg = SyncGroup(pvs, skip_first=False)
+            sg = SyncGroup(pvs, self._client)
 
             sg.wait()
             vals = sg.get_values()

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3722,16 +3722,10 @@ class SmurfTuneMixin(SmurfBase):
 
         I = self.get_eta_scan_results_real(band, count=n_step*n_channels)
         I = np.asarray(I)
-        idx = np.where( I > 2**23 )
-        I[idx] = I[idx] - 2**24
-        I /= 2**23
         I = I.reshape(n_channels, n_step)
 
         Q = self.get_eta_scan_results_imag(band, count=n_step*n_channels)
         Q = np.asarray(Q)
-        idx = np.where( Q > 2**23 )
-        Q[idx] = Q[idx] - 2**24
-        Q /= 2**23
         Q = Q.reshape(n_channels, n_step)
 
         resp_scan = I + 1j*Q

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -1457,11 +1457,11 @@ class SmurfUtilMixin(SmurfBase):
         """
         # Ask mitch why this is what it is...
         if bay == 0:
-            stream0 = self.epics_root + ":AMCc:Stream0"
-            stream1 = self.epics_root + ":AMCc:Stream1"
+            stream0 = "AMCc.Stream0"
+            stream1 = "AMCc.Stream1"
         else:
-            stream0 = self.epics_root + ":AMCc:Stream2"
-            stream1 = self.epics_root + ":AMCc:Stream3"
+            stream0 = "AMCc.Stream2"
+            stream1 = "AMCc.Stream3"
 
         pvs = [stream0, stream1]
         sg  = SyncGroup(pvs, skip_first=True)

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -1959,7 +1959,7 @@ class SmurfUtilMixin(SmurfBase):
         self.set_amplitude_scales(band, 0, **kwargs)
         n_channels = self.get_number_channels(band)
         self.set_feedback_enable_array(
-            band, np.zeros(n_channels, dtype=int), **kwargs)
+            band, np.zeros(n_channels, dtype=np.uint32), **kwargs)
         self.set_cfg_reg_ena_bit(0, wait_after=.2, **kwargs)
 
     def channel_off(self, band, channel, **kwargs):
@@ -2000,8 +2000,8 @@ class SmurfUtilMixin(SmurfBase):
         if desired_feedback_limit_mhz > subband_bandwidth/2:
             desired_feedback_limit_mhz = subband_bandwidth/2
 
-        desired_feedback_limit_dec = np.floor(desired_feedback_limit_mhz/
-            (subband_bandwidth/2**16.))
+        desired_feedback_limit_dec = int(np.floor(desired_feedback_limit_mhz/
+            (subband_bandwidth/2**16.)))
 
         self.set_feedback_limit(band, desired_feedback_limit_dec, **kwargs)
 

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -1464,7 +1464,7 @@ class SmurfUtilMixin(SmurfBase):
             stream1 = "AMCc.Stream3"
 
         pvs = [stream0, stream1]
-        sg  = SyncGroup(pvs, skip_first=True)
+        sg  = SyncGroup(pvs, self._client)
 
         # trigger PV
         if not hw_trigger:

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -1472,7 +1472,6 @@ class SmurfUtilMixin(SmurfBase):
         else:
             self.set_arm_hw_trigger(bay, 1, write_log=write_log)
 
-        time.sleep(.1)
         sg.wait()
 
         vals = sg.get_values()

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -41,7 +41,7 @@ class PcieDev():
     """
     def __init__(self, dev, name, description):
         import rogue.hardware.axi
-        from SmurfPcie import SmurfKcu1500RssiOffload10GbE as fpga
+        import SmurfKcu1500RssiOffload as fpga
         self._root = pyrogue.Root(name=name,description=description, pollEn='False',initRead='True')
         self._memMap = rogue.hardware.axi.AxiMemMap(dev)
         self._root.add(fpga.Core(memBase=self._memMap))

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -41,7 +41,7 @@ class PcieDev():
     """
     def __init__(self, dev, name, description):
         import rogue.hardware.axi
-        import SmurfKcu1500RssiOffload as fpga
+        from SmurfPcie import SmurfKcu1500RssiOffload10GbE as fpga
         self._root = pyrogue.Root(name=name,description=description, pollEn='False',initRead='True')
         self._memMap = rogue.hardware.axi.AxiMemMap(dev)
         self._root.add(fpga.Core(memBase=self._memMap))

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -42,7 +42,7 @@ class PcieDev():
     def __init__(self, dev, name, description):
         import rogue.hardware.axi
         import SmurfKcu1500RssiOffload as fpga
-        self._root = pyrogue.Root(name=name,description=description, serverPort=None, pollEn='False',initRead='True')
+        self._root = pyrogue.Root(name=name,description=description, pollEn='False',initRead='True')
         self._memMap = rogue.hardware.axi.AxiMemMap(dev)
         self._root.add(fpga.Core(memBase=self._memMap))
         self._root.start()
@@ -225,25 +225,25 @@ class PcieCard():
 
         # Get system status:
 
+        # Check if we use the PCIe for communication
+        if 'pcie-' in comm_type:
+            self._use_pcie = True
+        else:
+            self._use_pcie = False
+
         # Check if the PCIe card for RSSI is present in the system
-        if Path(dev_rssi).exists():
+        if self._use_pcie and Path(dev_rssi).exists():
             self._pcie_rssi_present = True
             self._pcie_rssi = PcieDev(dev=dev_rssi, name='pcie_rssi', description='PCIe for RSSI')
         else:
             self._pcie_rssi_present = False
 
         # Check if the PCIe card for DATA is present in the system
-        if Path(dev_data).exists():
+        if self._use_pcie and Path(dev_data).exists():
             self._pcie_data_present = True
             self._pcie_data = PcieDev(dev=dev_data, name='pcie_data', description='PCIe for DATA')
         else:
             self._pcie_data_present = False
-
-        # Check if we use the PCIe for communication
-        if 'pcie-' in comm_type:
-            self._use_pcie = True
-        else:
-            self._use_pcie = False
 
         # We need the IP address when the PCIe card is present, but not in used too.
         # If the PCIe card is present, this value could be updated later.

--- a/python/pysmurf/core/devices/_SmurfProcessor.py
+++ b/python/pysmurf/core/devices/_SmurfProcessor.py
@@ -292,7 +292,7 @@ class SmurfProcessor(pyrogue.Device):
 
         # If a root was defined, connect it to the file writer, on channel 1
         if root:
-            pyrogue.streamConnect(root, self.file_writer.getChannel(1))
+            pyrogue.streamConnect(root.stream, self.file_writer.getChannel(1))
 
         # If a transmitter device was defined, add it to the tree and connect it to the chain
         if txDevice:
@@ -307,11 +307,10 @@ class SmurfProcessor(pyrogue.Device):
 
             # Tap the data frames at the output of the post data emulator, and send them to transmitter'
             # data channel, though the fifo.
-            pyrogue.streamTap(    self.post_data_emulator, self.fifo_data)
+            pyrogue.streamConnect(self.post_data_emulator, self.fifo_data)
             pyrogue.streamConnect(self.fifo_data,          self.transmitter.getDataChannel())
 
             # If a root was defined, connect  it to the transmitter's meta data channel.
-            # Use streamTap as it was already connected to the file writer.
             if root:
                 # Add a fifo for the meta data frames. It will hold up to 100 copies of the input frames,
                 # to be send to the transmitter device. If the fifo is full, new frames will be dropped.
@@ -323,7 +322,7 @@ class SmurfProcessor(pyrogue.Device):
 
                 # Tap the metadata frames from the root, and send them to the transmitter's meta data
                 # channel, through the fifo.
-                pyrogue.streamTap(    root,           self.fifo_meta)
+                pyrogue.streamConnect(root.stream, self.fifo_meta)
                 pyrogue.streamConnect(self.fifo_meta, self.transmitter.getMetaChannel())
 
             # Add the transmitter device to the root here, after adding the fifos, so that it appears
@@ -332,7 +331,7 @@ class SmurfProcessor(pyrogue.Device):
 
     def _getStreamSlave(self):
         """
-        Method called by streamConnect, streamTap and streamConnectBiDir to access slave.
+        Method called by streamConnect and streamConnectBiDir to access slave.
         We will pass a reference to the smurf device of the first element in the chain,
         which is the 'FrameStatistics'.
         """

--- a/python/pysmurf/core/roots/CmbEth.py
+++ b/python/pysmurf/core/roots/CmbEth.py
@@ -87,13 +87,11 @@ class CmbEth(Common):
         # Setup base class
         Common.__init__(self,
                         config_file    = config_file,
-                        epics_prefix   = epics_prefix,
                         polling_en     = polling_en,
                         pv_dump_file   = pv_dump_file,
                         txDevice       = txDevice,
                         configure      = configure,
                         VariableGroups = VariableGroups,
-                        server_port    = server_port,
                         disable_bay0   = disable_bay0,
                         disable_bay1   = disable_bay1,
                         **kwargs)

--- a/python/pysmurf/core/roots/CmbEth.py
+++ b/python/pysmurf/core/roots/CmbEth.py
@@ -27,7 +27,6 @@ class CmbEth(Common):
     def __init__(self, *,
                  ip_addr        = "",
                  config_file    = None,
-                 epics_prefix   = "EpicsPrefix",
                  polling_en     = True,
                  pv_dump_file   = "",
                  disable_bay0   = False,

--- a/python/pysmurf/core/roots/CmbPcie.py
+++ b/python/pysmurf/core/roots/CmbPcie.py
@@ -29,7 +29,6 @@ class CmbPcie(Common):
                  pcie_dev_rssi  = "/dev/datadev_0",
                  pcie_dev_data  = "/dev/datadev_1",
                  config_file    = None,
-                 epics_prefix   = "EpicsPrefix",
                  polling_en     = True,
                  pv_dump_file   = "",
                  disable_bay0   = False,
@@ -82,7 +81,6 @@ class CmbPcie(Common):
         # Setup base class
         Common.__init__(self,
                         config_file    = config_file,
-                        epics_prefix   = epics_prefix,
                         polling_en     = polling_en,
                         pv_dump_file   = pv_dump_file,
                         txDevice       = txDevice,

--- a/python/pysmurf/core/roots/CmbPcie.py
+++ b/python/pysmurf/core/roots/CmbPcie.py
@@ -40,6 +40,9 @@ class CmbPcie(Common):
                  server_port    = 0,
                  **kwargs):
 
+        # Set this once, before creating any instances
+        rogue.hardware.axi.AxiStreamDma.zeroCopyDisable(pcie_dev_rssi)
+
         # TDEST 0 routed to streamr0 (SRPv3)
         self._srpStream = rogue.hardware.axi.AxiStreamDma(pcie_dev_rssi,(pcie_rssi_lane*0x100 + 0),True)
 
@@ -71,7 +74,6 @@ class CmbPcie(Common):
         # channels 0, 1, 4, 5.
         for i in [0, 1, 4, 5]:
             tmp = rogue.hardware.axi.AxiStreamDma(pcie_dev_rssi,(pcie_rssi_lane*0x100 + 0x80 + i), True)
-            tmp.setZeroCopyEn(False)
             self._ddr_streams.append(tmp)
 
         # Streaming interface stream

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -52,7 +52,7 @@ class Common(pyrogue.Root):
         # self._fpga = Top level FPGA
 
         # Add ZMQ Server
-        self.zmqServer = pyrogue.interfaces.ZmqServer(root=self, addr='*', incGroups='stream', port=server_port)
+        self.zmqServer = pyrogue.interfaces.ZmqServer(root=self, addr='*', port=server_port)
         self.addInterface(self.zmqServer)
 
         # Add streamer

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -35,7 +35,6 @@ class Common(pyrogue.Root):
                  stream_pv_size = 2**19,    # Not sub-classed
                  stream_pv_type = 'Int16',  # Not sub-classed
                  configure      = False,
-                 epics_prefix   = None,
                  VariableGroups = None,
                  server_port    = 0,
                  disable_bay0   = False,

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -28,7 +28,6 @@ import pysmurf.core.utilities
 class Common(pyrogue.Root):
     def __init__(self, *,
                  config_file    = None,
-                 epics_prefix   = "EpicsPrefix",
                  polling_en     = True,
                  pv_dump_file   = None,
                  txDevice       = None,
@@ -36,6 +35,7 @@ class Common(pyrogue.Root):
                  stream_pv_size = 2**19,    # Not sub-classed
                  stream_pv_type = 'Int16',  # Not sub-classed
                  configure      = False,
+                 epics_prefix   = None,
                  VariableGroups = None,
                  server_port    = 0,
                  disable_bay0   = False,
@@ -43,13 +43,20 @@ class Common(pyrogue.Root):
                  **kwargs):
 
         pyrogue.Root.__init__(self, name="AMCc", initRead=True, pollEn=polling_en,
-            timeout=5.0, streamIncGroups='stream', serverPort=server_port, **kwargs)
+            timeout=5.0, **kwargs)
 
         #########################################################################################
         # The following interfaces are expected to be defined at this point by a sub-class
         # self._streaming_stream # Data stream interface
         # self._ddr_streams # 4 DDR Interface Streams
         # self._fpga = Top level FPGA
+
+        # Add ZMQ Server
+        self.zmqServer = pyrogue.interfaces.ZmqServer(root=self, addr='*', incGroups='stream', port=server_port)
+        self.addInterface(self.zmqServer)
+
+        # Add streamer
+        self.stream = pyrogue.interfaces.stream.Variable(root=self, incGroups='stream')
 
         # Add PySmurf Application Block
         self.add(pysmurf.core.devices.SmurfApplication())
@@ -85,7 +92,7 @@ class Common(pyrogue.Root):
         ## Streaming interface streams
         # We have already connected TDEST 0xC1 to the smurf_processor receiver,
         # so we need to tapping it to the data writer.
-        pyrogue.streamTap(self._streaming_stream, self._stm_interface_writer.getChannel(0))
+        pyrogue.streamConnect(self._streaming_stream, self._stm_interface_writer.getChannel(0))
 
         # Run control for streaming interfaces
         self.add(pyrogue.RunControl(
@@ -117,38 +124,29 @@ class Common(pyrogue.Root):
         # Variable groups
         self._VariableGroups = VariableGroups
 
-        # Add epics interface
-        self._epics = None
-        if epics_prefix:
-            print(f"Starting EPICS server using prefix \"{epics_prefix}\"")
-            from pyrogue.protocols import epics
-            self._epics = epics.EpicsCaServer(base=epics_prefix, root=self)
-            self._pv_dump_file = pv_dump_file
+        # RTH: To be replaced with DataReceivers
+        #    if stream_pv_size:
+        #        print(
+        #            "Enabling stream data on PVs " +
+        #            f"(buffer size = {stream_pv_size} points, " +
+        #            f"data type = {stream_pv_type})")
 
-            # PVs for stream data
-            # This should be replaced with DataReceiver objects
-            if stream_pv_size:
-                print(
-                    "Enabling stream data on PVs " +
-                    f"(buffer size = {stream_pv_size} points, " +
-                    f"data type = {stream_pv_type})")
+        #        self._stream_fifos  = []
+        #        self._stream_slaves = []
+        #        for i in range(4):
+        #            self._stream_slaves.append(self._epics.createSlave(name=f"AMCc:Stream{i}",
+        #                                                               maxSize=stream_pv_size,
+        #                                                               type=stream_pv_type))
 
-                self._stream_fifos  = []
-                self._stream_slaves = []
-                for i in range(4):
-                    self._stream_slaves.append(self._epics.createSlave(name=f"AMCc:Stream{i}",
-                                                                       maxSize=stream_pv_size,
-                                                                       type=stream_pv_type))
+        #            # Calculate number of bytes needed on the fifo
+        #            if '16' in stream_pv_type:
+        #                fifo_size = stream_pv_size * 2
+        #            else:
+        #                fifo_size = stream_pv_size * 4
 
-                    # Calculate number of bytes needed on the fifo
-                    if '16' in stream_pv_type:
-                        fifo_size = stream_pv_size * 2
-                    else:
-                        fifo_size = stream_pv_size * 4
-
-                    self._stream_fifos.append(rogue.interfaces.stream.Fifo(1000, fifo_size, True)) # changes
-                    pyrogue.streamConnect(self._stream_fifos[i],self._stream_slaves[i])
-                    pyrogue.streamTap(self._ddr_streams[i], self._stream_fifos[i])
+        #            self._stream_fifos.append(rogue.interfaces.stream.Fifo(1000, fifo_size, True)) # changes
+        #            pyrogue.streamConnect(self._stream_fifos[i],self._stream_slaves[i])
+        #            pyrogue.streamTap(self._ddr_streams[i], self._stream_fifos[i])
 
 
         # Update SaveState to not read before saving
@@ -196,14 +194,6 @@ class Common(pyrogue.Root):
             print(f"Attibute error: {attr_error}")
         print("")
 
-        # Start epics
-        if self._epics:
-            self._epics.start()
-
-            # Dump the PV list to the expecified file
-            if self._pv_dump_file:
-                self._epics.dump(self._pv_dump_file)
-
         # Add publisher, pub_root & script_id need to be updated
         self._pub = pysmurf.core.utilities.SmurfPublisher(root=self)
 
@@ -236,8 +226,6 @@ class Common(pyrogue.Root):
 
     def stop(self):
         print("Stopping servers...")
-        if self._epics:
-            self._epics.stop()
 
         print("Stopping root...")
         pyrogue.Root.stop(self)
@@ -389,3 +377,4 @@ class Common(pyrogue.Root):
             # Call the command and set the status to the returned value
             # False = 'Unlocked', True: 'Locked'
             self.SmurfApplication.JesdStatus.set(self._jesd_health_cmd.call())
+

--- a/python/pysmurf/core/roots/DevBoardEth.py
+++ b/python/pysmurf/core/roots/DevBoardEth.py
@@ -28,7 +28,6 @@ class DevBoardEth(Common):
     def __init__(self, *,
                  ip_addr        = "",
                  config_file    = None,
-                 epics_prefix   = "EpicsPrefix",
                  polling_en     = True,
                  pv_dump_file   = "",
                  disable_bay0   = False,
@@ -68,7 +67,6 @@ class DevBoardEth(Common):
         # Setup base class
         Common.__init__(self,
                         config_file    = config_file,
-                        epics_prefix   = epics_prefix,
                         polling_en     = polling_en,
                         pv_dump_file   = pv_dump_file,
                         txDevice       = txDevice,

--- a/python/pysmurf/core/roots/DevBoardPcie.py
+++ b/python/pysmurf/core/roots/DevBoardPcie.py
@@ -29,7 +29,6 @@ class DevBoardPcie(Common):
                  pcie_dev_rssi  = "/dev/datadev_0",
                  pcie_dev_data  = "/dev/datadev_1",
                  config_file    = None,
-                 epics_prefix   = "EpicsPrefix",
                  polling_en     = True,
                  pv_dump_file   = "",
                  disable_bay0   = False,
@@ -68,7 +67,6 @@ class DevBoardPcie(Common):
         # Setup base class
         Common.__init__(self,
                         config_file    = config_file,
-                        epics_prefix   = epics_prefix,
                         polling_en     = polling_en,
                         pv_dump_file   = pv_dump_file,
                         txDevice       = txDevice,

--- a/python/pysmurf/core/roots/EmulationRoot.py
+++ b/python/pysmurf/core/roots/EmulationRoot.py
@@ -28,7 +28,6 @@ from pysmurf.core.roots.Common import Common
 class EmulationRoot(Common):
     def __init__(self, *,
                  config_file    = None,
-                 epics_prefix   = "EpicsPrefix",
                  polling_en     = True,
                  pv_dump_file   = "",
                  disable_bay0   = False,
@@ -54,7 +53,6 @@ class EmulationRoot(Common):
         # Setup base class
         Common.__init__(self,
                         config_file    = config_file,
-                        epics_prefix   = epics_prefix,
                         polling_en     = polling_en,
                         pv_dump_file   = pv_dump_file,
                         txDevice       = txDevice,

--- a/python/pysmurf/core/server_scripts/Common.py
+++ b/python/pysmurf/core/server_scripts/Common.py
@@ -23,6 +23,7 @@ import socket
 import subprocess
 import sys
 import zipfile
+import logging
 
 import pyrogue
 
@@ -47,6 +48,16 @@ def process_args(args):
         args.config_file. Also set the server port to  a default values
         if it was not defined.
     """
+
+    # Setup logging
+    logger = logging.getLogger()
+    logger.setLevel(args.log_level)
+    # set up a handler with timestamps
+    handler = logging.StreamHandler()
+    handler.setLevel(args.log_level)
+    formatter = logging.Formatter("[%(asctime)s] %(levelname)s:%(name)s: %(msg)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
     # Verify if the zip file was specified
     if args.zip_file:
@@ -203,6 +214,10 @@ def make_parser(parser=None):
                        )
     group.add_argument('--use-qt', action='store_true', dest='use_qt',
                        default=False, help="Use the QT ."
+                       )
+    group.add_argument('--log-level', type=str.upper, help="Set the logging level.",
+                       choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+                       default="WARNING"
                        )
 
     return parser

--- a/python/pysmurf/core/utilities/_SmurfDataReceiver.py
+++ b/python/pysmurf/core/utilities/_SmurfDataReceiver.py
@@ -46,7 +46,7 @@ class SmurfDataReceiver(pr.DataReceiver):
         datRaw = frame.getNumpy(0,fl)  # uint8
 
         # Convert to 16-bit signed numpy
-        dat = np.array(datRaw, np.int16)
+        dat = datRaw.view(np.int16)
 
         # Update data
         self.Data.set(dat,write=True)
@@ -60,7 +60,7 @@ class SmurfDataReceiver(pr.DataReceiver):
         datRaw = frame.getNumpy(0,fl)  # uint8
 
         # Convert to 8-bit signed numpy
-        dat = np.array(datRaw, np.int8)
+        dat = datRaw.view(np.int8)
 
         # Update data
         self.Data.set(dat,write=True)

--- a/server_scripts/cmb_eth.py
+++ b/server_scripts/cmb_eth.py
@@ -66,15 +66,8 @@ if __name__ == "__main__":
             if args['use_gui']:
                 # Start the GUI
                 print("Starting GUI...\n")
-
-                if args['use_qt']:
-                    # Start the QT GUI, is selected by the user
-                    import pyrogue.gui
-                    pyrogue.gui.runGui(root=root,title=args['windows_title'])
-                else:
-                    # Otherwise, start the PyDM GUI
-                    import pyrogue.pydm
-                    pyrogue.pydm.runPyDM(root=root, title=args['windows_title'])
+                import pyrogue.pydm
+                pyrogue.pydm.runPyDM(serverList=root.zmqServer.address, title=args['windows_title'])
 
             else:
                 # Stop the server when Crtl+C is pressed

--- a/server_scripts/cmb_eth.py
+++ b/server_scripts/cmb_eth.py
@@ -53,7 +53,6 @@ if __name__ == "__main__":
 
         with CmbEth( ip_addr        = args['ip_addr'],
                      config_file    = args['config_file'],
-                     epics_prefix   = args['epics_prefix'],
                      polling_en     = args['polling_en'],
                      pv_dump_file   = args['pv_dump_file'],
                      disable_bay0   = args['disable_bay0'],

--- a/server_scripts/cmb_pcie.py
+++ b/server_scripts/cmb_pcie.py
@@ -47,7 +47,6 @@ if __name__ == "__main__":
                                         dev_data  = args['pcie_dev_data']):
 
         with CmbPcie( config_file    = args['config_file'],
-                      epics_prefix   = args['epics_prefix'],
                       polling_en     = args['polling_en'],
                       pv_dump_file   = args['pv_dump_file'],
                       disable_bay0   = args['disable_bay0'],

--- a/server_scripts/cmb_pcie.py
+++ b/server_scripts/cmb_pcie.py
@@ -63,15 +63,8 @@ if __name__ == "__main__":
             if args['use_gui']:
                 # Start the GUI
                 print("Starting GUI...\n")
-
-                if args['use_qt']:
-                    # Start the QT GUI, is selected by the user
-                    import pyrogue.gui
-                    pyrogue.gui.runGui(root=root,title=args['windows_title'])
-                else:
-                    # Otherwise, start the PyDM GUI
-                    import pyrogue.pydm
-                    pyrogue.pydm.runPyDM(root=root, title=args['windows_title'])
+                import pyrogue.pydm
+                pyrogue.pydm.runPyDM(serverList=root.zmqServer.address, title=args['windows_title'])
 
             else:
                 # Stop the server when Crtl+C is pressed

--- a/server_scripts/dev_board_eth.py
+++ b/server_scripts/dev_board_eth.py
@@ -67,15 +67,8 @@ if __name__ == "__main__":
             if args['use_gui']:
                 # Start the GUI
                 print("Starting GUI...\n")
-
-                if args['use_qt']:
-                    # Start the QT GUI, is selected by the user
-                    import pyrogue.gui
-                    pyrogue.gui.runGui(root=root,title=args['windows_title'])
-                else:
-                    # Otherwise, start the PyDM GUI
-                    import pyrogue.pydm
-                    pyrogue.pydm.runPyDM(root=root, title=args['windows_title'])
+                import pyrogue.pydm
+                pyrogue.pydm.runPyDM(serverList=root.zmqServer.address, title=args['windows_title'])
 
             else:
                 # Stop the server when Crtl+C is pressed

--- a/server_scripts/dev_board_eth.py
+++ b/server_scripts/dev_board_eth.py
@@ -54,7 +54,6 @@ if __name__ == "__main__":
 
         with DevBoardEth(  ip_addr        = args['ip_addr'],
                            config_file    = args['config_file'],
-                           epics_prefix   = args['epics_prefix'],
                            polling_en     = args['polling_en'],
                            pv_dump_file   = args['pv_dump_file'],
                            disable_bay0   = args['disable_bay0'],

--- a/server_scripts/dev_board_pcie.py
+++ b/server_scripts/dev_board_pcie.py
@@ -64,15 +64,8 @@ if __name__ == "__main__":
             if args['use_gui']:
                 # Start the GUI
                 print("Starting GUI...\n")
-
-                if args['use_qt']:
-                    # Start the QT GUI, is selected by the user
-                    import pyrogue.gui
-                    pyrogue.gui.runGui(root=root,title=args['windows_title'])
-                else:
-                    # Otherwise, start the PyDM GUI
-                    import pyrogue.pydm
-                    pyrogue.pydm.runPyDM(root=root, title=args['windows_title'])
+                import pyrogue.pydm
+                pyrogue.pydm.runPyDM(serverList=root.zmqServer.address, title=args['windows_title'])
 
             else:
                 # Stop the server when Crtl+C is pressed

--- a/server_scripts/dev_board_pcie.py
+++ b/server_scripts/dev_board_pcie.py
@@ -48,7 +48,6 @@ if __name__ == "__main__":
                                         dev_data  = args['pcie_dev_data']):
 
         with DevBoardPcie( config_file    = args['config_file'],
-                           epics_prefix   = args['epics_prefix'],
                            polling_en     = args['polling_en'],
                            pcie_rssi_lane = args['pcie_rssi_lane'],
                            pv_dump_file   = args['pv_dump_file'],

--- a/server_scripts/emulate.py
+++ b/server_scripts/emulate.py
@@ -36,7 +36,6 @@ if __name__ == "__main__":
     from pysmurf.core.roots.EmulationRoot import EmulationRoot
 
     with EmulationRoot ( config_file    = args['config_file'],
-                         epics_prefix   = args['epics_prefix'],
                          polling_en     = args['polling_en'],
                          pv_dump_file   = args['pv_dump_file'],
                          disable_bay0   = args['disable_bay0'],

--- a/server_scripts/emulate.py
+++ b/server_scripts/emulate.py
@@ -23,6 +23,9 @@ import pysmurf.core.devices
 import pysmurf.core.transmitters
 import pysmurf.core.server_scripts.Common as common
 
+def varListener(path, value):
+    print(f"Got var update: {path} = {value}")
+
 # Main body
 if __name__ == "__main__":
 
@@ -41,7 +44,10 @@ if __name__ == "__main__":
                          server_port    = args['server_port'],
                          txDevice       = pysmurf.core.transmitters.BaseTransmitter(name='Transmitter')) as root:
 
+
+        #root.addVarListener(varListener)
+
         # Start the GUI
-        import pyrogue.gui
         print("Starting GUI...\n")
-        pyrogue.gui.runGui(root=root)
+        import pyrogue.pydm
+        pyrogue.pydm.runPyDM(serverList=root.zmqServer.address, title=args['windows_title'])

--- a/server_scripts/emulate_local.py
+++ b/server_scripts/emulate_local.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
         root.saveVariableList("varlist.txt")
 
         # Start the GUI
-        import pyrogue.pydm
         print("Starting GUI...\n")
-        pyrogue.pydm.runPyDM(root=root)
+        import pyrogue.pydm
+        pyrogue.pydm.runPyDM(serverList=root.zmqServer.address, title=args['windows_title'])
 

--- a/server_scripts/emulate_local.py
+++ b/server_scripts/emulate_local.py
@@ -42,7 +42,6 @@ from pysmurf.core.roots.EmulationRoot import EmulationRoot
 if __name__ == "__main__":
 
     with EmulationRoot ( config_file    = "",
-                         epics_prefix   = "Test",
                          polling_en     = True,
                          pv_dump_file   = "epics_dump.txt",
                          disable_bay0   = False,

--- a/src/smurf/core/emulators/StreamDataEmulator.cpp
+++ b/src/smurf/core/emulators/StreamDataEmulator.cpp
@@ -195,7 +195,7 @@ void sce::StreamDataEmulator<T>::acceptFrame(ris::FramePtr frame)
             ris::FrameLockPtr fLock = frame->lock();
 
             // Make sure the frame is a single buffer, copy if necessary
-            if ( ! this->ensureSingleBuffer(frame,true) )
+            if ( ! ris::Slave::ensureSingleBuffer(frame,true) )
             {
                 eLog_->error("Failed to copy frame to single buffer. Check downstream slave types, maybe add a FIFO?");
                 return;


### PR DESCRIPTION
Wide-ranging changes to the code to support a move to rogue v6. As of opening this draft, what has been tested includes `full_band_amplitude_sweep` and `find_freq` and both produce results consistent with the old code, with apparently improved performance.

Changes in supporting code:
- slaclab/cryo-det#56
- slaclab/rogue#1025
- [smurf-roguev6-docker](https://github.com/slaclab/smurf-roguev6-docker/tree/main)
