### PR TITLE
docker.server: Update carrier FW tag.

### DIFF
--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -28,8 +28,8 @@ config_repo=https://github.com/slaclab/smurf_cfg
 # The files will be downloaded from the release list of assets.
 
 # Firmware version for uMUX systems
-fw_repo_tag=MicrowaveMuxBpEthGen2_v1.1.1
-mcs_file_name=MicrowaveMuxBpEthGen2-0x01010000-20210928123941-ruckman-02ed52a.mcs.gz
+fw_repo_tag=MicrowaveMuxBpEthGen2_v1.3.0
+mcs_file_name=MicrowaveMuxBpEthGen2-0x01030000-20240913132239-ruckman-1feb01f.mcs.gz
 
 # Firmware version for TKID systems
 tkid_fw_repo_tag=CryoDetKid_v2.0.0

--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -32,8 +32,8 @@ fw_repo_tag=MicrowaveMuxBpEthGen2_v1.3.0
 mcs_file_name=MicrowaveMuxBpEthGen2-0x01030000-20240913132239-ruckman-1feb01f.mcs.gz
 
 # Firmware version for TKID systems
-tkid_fw_repo_tag=CryoDetKid_v2.0.0
-tkid_mcs_file_name=CryoDetKid-0x00000101-20230620224002-bareese-e3253bd.mcs.gz
+tkid_fw_repo_tag=v2.1.0
+tkid_mcs_file_name=CryoDetKid-0x02010000-20240920083819-ruckman-ec69acf.mcs.gz
 
 # Define the configuration version:
 # =================================

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -442,7 +442,7 @@ class SmurfConfig:
 
                 # data_out_mux
                 Optional("data_out_mux",
-                         default=default_data_out_mux_dict[band]) : \
+                         default=default_data_out_mux_dict[band]) :
                 And([Use(int)], list, lambda l: len(l) == 2 and
                     l[0] != l[1] and all(0 <= ll <= 9 for ll in l)),
 


### PR DESCRIPTION
New firmware includes a fix to the stream FIFO that can cause it to lock up if a very large frame is encountered.