### PR TITLE
Add try/except to cryostat card (=cc) commanding in `setup()` so systems running without ccs don't stall in `setup()`.

### DIFF
--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -688,8 +688,13 @@ class SmurfControl(SmurfCommandMixin,
             # If C04, also set the drain voltages to zero.
             self.set_amp_defaults()
 
-            # also read the temperature of the CC
-            self.log(f"Cryocard temperature = {self.C.read_temperature()}")
+            ## Removed this because better error handling for cc
+            ## communication in
+            ## https://github.com/slaclab/pysmurf/pull/794 Causes this
+            ## command to stall and error out on systems with no
+            ## cryostat card connected.
+            ## also read the temperature of the CC
+            #self.log(f"Cryocard temperature = {self.C.read_temperature()}")
 
             # Setup how this slot handles timing. To take science data, each
             # SMuRF slot should receive timing from the backplane or RTM fiber

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -684,17 +684,22 @@ class SmurfControl(SmurfCommandMixin,
             self.set_payload_size(payload_size)
             self.set_channel_mask([0])
 
-            # If C02, set the gate voltages to the default.
-            # If C04, also set the drain voltages to zero.
-            self.set_amp_defaults()
+            try:
+                ## Removed this because better error handling for cc
+                ## communication in
+                ## https://github.com/slaclab/pysmurf/pull/794 Causes this
+                ## command to stall and error out on systems with no
+                ## cryostat card connected.
+                ## also read the temperature of the CC
+                self.log(f"Cryocard temperature = {self.C.read_temperature()}")
 
-            ## Removed this because better error handling for cc
-            ## communication in
-            ## https://github.com/slaclab/pysmurf/pull/794 Causes this
-            ## command to stall and error out on systems with no
-            ## cryostat card connected.
-            ## also read the temperature of the CC
-            #self.log(f"Cryocard temperature = {self.C.read_temperature()}")
+                # If C02, set the gate voltages to the default.
+                # If C04, also set the drain voltages to zero.
+                self.set_amp_defaults()
+            except Exception:
+                self.log("Attempts to communicate with a cryocard "
+                         "failed!  Will assume no cryostat card is"
+                         " connected and skip cryocard setup steps.")
 
             # Setup how this slot handles timing. To take science data, each
             # SMuRF slot should receive timing from the backplane or RTM fiber


### PR DESCRIPTION
## Description

Fix for https://github.com/slaclab/pysmurf/issues/801.  Due to recent PR https://github.com/slaclab/pysmurf/pull/794 if no cryostat card is connected to a system, it stalls near the end of setup().  This is actually good behavior, but causes stalls during `setup()` on systems with no cryostat card (=cc) connected.  Systems often don't have ccs connected at SLAC during bring-up testing, this PR just adds a try/except to the CC-related calls in `setup()` to get around this bug.

## Tests done on this branch

Ran with change on system with no cryostat card connected to confirm it solves the issue.

## Function interfaces that changed

N/a