### PR TITLE
Removes hardcode limiting RF I/Q data to unfiltered 2.4 MHz data only.

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -72,7 +72,7 @@ class SmurfUtilMixin(SmurfBase):
         if channel is not None:
             if rf_iq:
                 IQstream = False
-                #single_channel_readout = 2
+                # single_channel_readout = 2
                 self.set_rf_iq_stream_enable(band, 1)
 
             if single_channel_readout == 1:


### PR DESCRIPTION
## Description

Closes https://github.com/slaclab/pysmurf/issues/807.

## Function interfaces that changed

N/A.