### PR TITLE
Upgrades to newer base and rogue dockers built on Ubuntu 22.04.

### DIFF
--- a/.github/workflows/test-or-deploy.yml
+++ b/.github/workflows/test-or-deploy.yml
@@ -33,10 +33,10 @@ jobs:
         uses: actions/checkout@v2
 
       # Setup python3
-      - name: setup python 3.8.10
+      - name: setup python 3.8.12
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8.10
+          python-version: 3.8.12
 
       # Install flake8 modules
       - name: Install dependencies
@@ -86,11 +86,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # Setup python 3.8.10
-      - name: Setup python 3.8.10
+      # Setup python 3.8.12
+      - name: Setup python 3.8.12
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8.10
+          python-version: 3.8.12
 
       # Install requirements, pysmurf, and sphinx
       - name: Install dependencies
@@ -252,10 +252,10 @@ jobs:
         run: echo ::set-output name=tag::"${GITHUB_REF#refs/tags/}"
 
       # Setup python3
-      - name: Setup python 3.8.10
+      - name: Setup python 3.8.12
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8.10
+          python-version: 3.8.12
 
       # Install dependencies of the releaseGen.py script
       - name: Install dependencies

--- a/.github/workflows/test-or-deploy.yml
+++ b/.github/workflows/test-or-deploy.yml
@@ -26,7 +26,7 @@ jobs:
   # Run flake8 on all .py files. Should block deploys to Read The Docs.
   flake8:
     name: Flake8 Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Checkout the code
       - name: Checkout code
@@ -53,7 +53,7 @@ jobs:
   # Validate the server docker image definitions
   docker-definitions:
     name: Docker Definition Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Checkout the code.
       # We use ssh key authentication to be able to access other private
@@ -79,7 +79,7 @@ jobs:
   # Documentation automatic build tests
   test-docs:
     name: Documentation Build Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [flake8, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
@@ -108,7 +108,7 @@ jobs:
   # Server tests
   test-server:
     name: Server Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [flake8, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
@@ -182,7 +182,7 @@ jobs:
   # Client tests
   test-client:
     name: Client Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [flake8, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
@@ -235,7 +235,7 @@ jobs:
   # Deploy new release notes to GitHub
   deploy-release-notes:
     name: Generate Release Notes
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [test-docs, test-server, test-client]  # Run only if all tests passed
     if: startsWith(github.ref, 'refs/tags/')      # Run only on tagged releases
     steps:
@@ -275,7 +275,7 @@ jobs:
   # Server docker
   deploy-server:
     name: Build Server Docker Image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [test-docs, test-server, test-client]  # Run only if all tests passed
     if: startsWith(github.ref, 'refs/tags/')      # Run only on tagged releases
     steps:
@@ -315,7 +315,7 @@ jobs:
   # Client docker
   deploy-client:
     name: Build Client Docker Image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [test-docs, test-server, test-client]  # Run only if all tests passed
     if: startsWith(github.ref, 'refs/tags/')      # Run only on tagged releases
     steps:

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 RUN pip3 install --upgrade pip
 
 RUN pip3 install \
-    scipy==1.5.2 \
+    scipy==1.7.0 \
     pandas==1.1.0 \
     PyYAML==5.3.1 \
     pillow==6.2.2 \

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-base:R2.0.0
+FROM tidair/smurf-base:R3.0.2
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -13,15 +13,15 @@ RUN apt-get update && \
 RUN pip3 install --upgrade pip
 
 RUN pip3 install \
-    scipy==1.7.2 \
-    pandas==1.1.0 \
-    PyYAML==5.3.1 \
-    pillow==6.2.2 \
-    seaborn==0.11.2 \
-    jupyter==1.0.0 \
-    pytest==6.0.1 \
-    GitPython==3.1.7 \
-    schema==0.7.1
+    scipy \
+    pandas \
+    PyYAML \
+    pillow \
+    seaborn \
+    jupyter \
+    pytest \
+    GitPython \
+    schema
 
 # Install pysmurf
 ARG branch

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 RUN pip3 install --upgrade pip
 
 RUN pip3 install \
-    scipy==1.7.0 \
+    scipy==1.7.2 \
     pandas==1.1.0 \
     PyYAML==5.3.1 \
     pillow==6.2.2 \

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 RUN pip3 install --upgrade pip
 
 RUN pip3 install \
-    scipy \
+    scipy==1.8.1 \
     pandas \
     PyYAML \
     pillow \

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.9.3
+FROM tidair/smurf-rogue:R2.10.1
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.10.1
+FROM tidair/smurf-rogue:R2.10.2
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/


### PR DESCRIPTION
## Description

No longer able to release pysmurf because dockers built on Ubuntu 20.04 have been sunsetted.  This bumps the smurf-base-docker revision to https://github.com/slaclab/smurf-base-docker/releases/tag/R3.0.2 and the smurf-rogue docker to revision https://github.com/slaclab/smurf-rogue-docker/releases/tag/R2.10.1.  These new releases are just rebuilds of these dockers based on Ubuntu 22.04 instead of 20.04.