### PR TITLE
Migrate docker images to github enterprise.

### DIFF
--- a/.github/workflows/test-or-deploy.yml
+++ b/.github/workflows/test-or-deploy.yml
@@ -295,8 +295,9 @@ jobs:
       - name: Login to Dockerhub
         uses: docker/login-action@v1
         with:
-          username: tidair
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: slacrherbst
+          password: ${{ secrets.GH_TOKEN }}
 
       # Build and push the docker image
       # Note about tokens: In this stage we need to use the SLACLAB TOKEN
@@ -337,8 +338,9 @@ jobs:
       - name: Login to Dockerhub
         uses: docker/login-action@v1
         with:
-          username: tidair
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: slacrherbst
+          password: ${{ secrets.GH_TOKEN }}
 
       # Build and push the docker image
       - name: Build and push image to Dockerhub
@@ -347,5 +349,5 @@ jobs:
           context: ./docker/client
           file: ./docker/client/Dockerfile
           push: true
-          tags: tidair/pysmurf-client:${{ steps.get_tag.outputs.tag }}
+          tags: ghcr.io/slaclab/pysmurf-client:${{ steps.get_tag.outputs.tag }}
           build-args: branch=${{ steps.get_tag.outputs.tag }}

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-base:R3.0.2
+FROM ghcr.io/slaclab/smurf-base:R3.0.3
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.10.2
+FROM ghcr.io/slaclab/smurf-rogue:R3.10.5
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/

--- a/docker/server/build.sh
+++ b/docker/server/build.sh
@@ -25,7 +25,7 @@
 . validate.sh
 
 # Dockerhub repositories definitions
-dockerhub_org_name='tidair'
+dockerhub_org_name='ghcr.io/slaclab'
 dockerhub_repo_stable='pysmurf-server'
 dockerhub_repo_base='pysmurf-server-base'
 


### PR DESCRIPTION
## Description

Migrates the SMuRF docker images away from docker hub and use the container feature in github enterprise instead.

## Jira Issue

None.

## Tests done on this branch

@slacrherbst tested smurf-roguev6-docker and smurf-pcie-docker with success.

## Interfaces that changed

This change should be fairly straight forward but will need to ask the SO people to point to a slightly different base url.