### PR TITLE
Convert setup.py to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ name = "pysmurf"
 dynamic = ["version"]
 description = "The python control software for SMuRF"
 readme = "README.md"
-license-files = ["LICEN[CS]E.*"]
 dependencies = [
     "matplotlib",
     "numpy",


### PR DESCRIPTION
## Description
This PR converts the `setup.py` file to the equivalent `pyproject.toml` file.

While [`setup.py` is not deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/), I don't think it's really needed for this package and could be completely replaced by the `pyproject.toml` file. At the very least a `pyproject.toml` file [should be added](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/).

Resolves #815.

## Jira Issue
I don't have a Jira Issue for this.

## Tests done on this branch
I've installed the package with this change and inspected the installed package structure. Installation no longer has the deprecation warning seen in #815:
```
Building wheels for collected packages: pysmurf
  Building wheel for pysmurf (pyproject.toml) ... done
  Created wheel for pysmurf: filename=pysmurf-9.0.0+3.gb7206e38-py3-none-any.whl size=271351 sha256=360d9fb8ea051481faf2d27062009777d95d38853e4fcfda505195551508c5cb
  Stored in directory: /tmp/pip-ephem-wheel-cache-i9e4ws19/wheels/f2/fa/42/9de8a325499b5bed966817886320786fa5d270a0b012eb5b06
Successfully built pysmurf
```

Some additional directories are being picked up and installed. These don't have `__init__.py` files, and so weren't being installed by the current system. Those are:
```
python/pysmurf/client/test/
python/pysmurf/client/watchdog/
```

I suspect these weren't really used, since they weren't actually getting installed in the old system, but perhaps an `__init__.py` should be added to these. I tried configuring to exclude these directories, but didn't quite get it working. Let me know how you want to handle this and we can figure it out.

I *haven't* tested this installation against any actual hardware.

## Function interfaces that changed
No function interface changes.