### PR TITLE
Adding dependabot to keep reusable actions automatically up to date.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Description

Adds dependabot hook to keep reusable actions up to date at @BrianJKoopman's suggestion.

## Function interfaces that changed

None.