### PR TITLE
Skip docker-definitions if dependabot.

### DIFF
--- a/.github/workflows/test-or-deploy.yml
+++ b/.github/workflows/test-or-deploy.yml
@@ -54,6 +54,7 @@ jobs:
   docker-definitions:
     name: Docker Definition Tests
     runs-on: ubuntu-22.04
+    if: github.actor != 'dependabot[bot]'
     steps:
       # Checkout the code.
       # We use ssh key authentication to be able to access other private


### PR DESCRIPTION
## Description

Dependabot PRs failing checks with this error:

```
Searching for tag MicrowaveMuxBpEthGen2_v1.3.0 in repo https://github.com/slaclab/cryo-det with API URL https://api.github.com/repos/slaclab/cryo-det/tags ...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 401
Error: Tag MicrowaveMuxBpEthGen2_v1.3.0 doesn't exist using API URL https://api.github.com/repos/slaclab/cryo-det/tags for repo https://github.com/slaclab/cryo-det
Error: Process completed with exit code 1.
```

Apparently

```
Dependabot PRs fail to use secrets by default because, for security reasons, GitHub treats them as if they were from a repository fork, granting them only read-only permissions and no access to standard GitHub Actions secrets.
```

For now, let's just try to bypass these checks.

## Function interfaces that changed

None.
