### PR TITLE
Update legacy Dockerfile ENV calls.

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -29,27 +29,27 @@ WORKDIR /usr/local/src
 RUN git clone https://github.com/slaclab/pysmurf.git -b ${branch}
 WORKDIR /usr/local/src/pysmurf
 RUN pip3 install .
-ENV PYSMURF_TOP /usr/local/src/pysmurf
+ENV PYSMURF_TOP=/usr/local/src/pysmurf
 
 RUN mkdir -p /usr/local/src/pysmurf_utilities
 ADD scripts/* /usr/local/src/pysmurf_utilities/
-ENV PATH /usr/local/src/pysmurf_utilities:${PATH}
+ENV PATH=/usr/local/src/pysmurf_utilities:${PATH}
 
 # By default EPICS is configured with 'EPICS_CA_AUTO_ADDR_LIST=YES'
 # which will cause problems is we have multiple NIC, so let's set it
 # to use localhost only for now
-ENV EPICS_CA_AUTO_ADDR_LIST NO
-ENV EPICS_CA_ADDR_LIST localhost
+ENV EPICS_CA_AUTO_ADDR_LIST=NO
+ENV EPICS_CA_ADDR_LIST=localhost
 
 # Default EPICS prefix value
-ENV EPICS_PREFIX "smurf_server"
+ENV EPICS_PREFIX="smurf_server"
 
 # Set GTK3Agg as the matplotlib backend
-ENV MPLBACKEND GTK3Agg
+ENV MPLBACKEND=GTK3Agg
 
 # Set jupyter config stuff
 COPY jupyter /.jupyter
 RUN chown cryo:smurf -R /.jupyter
-ENV JUPYTER_CONFIG_DIR /.jupyter
+ENV JUPYTER_CONFIG_DIR=/.jupyter
 
 ENTRYPOINT ["start_client.sh"]

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /usr/local/src
 RUN git clone https://github.com/slaclab/smurf-pcie.git -b v2.0.0.1
 WORKDIR smurf-pcie
 RUN git submodule sync && git submodule update --init --recursive
-ENV PYTHONPATH /usr/local/src/smurf-pcie/software/python:${PYTHONPATH}
-ENV PYTHONPATH /usr/local/src/smurf-pcie/firmware/submodules/axi-pcie-core/python:${PYTHONPATH}
+ENV PYTHONPATH=/usr/local/src/smurf-pcie/software/python:${PYTHONPATH}
+ENV PYTHONPATH=/usr/local/src/smurf-pcie/firmware/submodules/axi-pcie-core/python:${PYTHONPATH}
 
 # Install pysmurf
 ARG branch
@@ -26,13 +26,13 @@ RUN python3 -m pip install .
 RUN mkdir build
 WORKDIR build
 RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .. && make -j4
-ENV PYTHONPATH /usr/local/src/pysmurf/lib:${PYTHONPATH}
-ENV SMURF_DIR /usr/local/src/pysmurf
+ENV PYTHONPATH=/usr/local/src/pysmurf/lib:${PYTHONPATH}
+ENV SMURF_DIR=/usr/local/src/pysmurf
 
 # Add utilities
 RUN mkdir -p /usr/local/src/pysmurf_utilities
 ADD scripts/* /usr/local/src/pysmurf_utilities/
-ENV PATH /usr/local/src/pysmurf_utilities:${PATH}
+ENV PATH=/usr/local/src/pysmurf_utilities:${PATH}
 
 # Set the working directory to the root
 WORKDIR /


### PR DESCRIPTION
## Description

Was getting this warning in docker builds;

```
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format 
```

This just updates those ENV calls with the newer syntax.

## Function interfaces that changed

None.