### PR TITLE
Fix for deprecated set-output call.

### DIFF
--- a/.github/workflows/test-or-deploy.yml
+++ b/.github/workflows/test-or-deploy.yml
@@ -129,7 +129,7 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          echo ::set-output name=branch::"${BRANCH_NAME:-$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { $1=$2=""; sub("  ",""); gsub(" ","/"); print }')}"
+          echo "branch=${BRANCH_NAME:-$(echo "$GITHUB_REF" | awk 'BEGIN { FS = "/" } ; { $1=$2=""; sub("  ",""); gsub(" ","/"); print }')}" >> "$GITHUB_OUTPUT"
 
       # Build docker image
       - name: Build docker image
@@ -203,7 +203,7 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          echo ::set-output name=branch::"${BRANCH_NAME:-$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { $1=$2=""; sub("  ",""); gsub(" ","/"); print }')}"
+          echo "branch=${BRANCH_NAME:-$(echo "$GITHUB_REF" | awk 'BEGIN { FS = "/" } ; { $1=$2=""; sub("  ",""); gsub(" ","/"); print }')}" >> "$GITHUB_OUTPUT"	
 
       # Build docker image
       - name: Build docker Image
@@ -288,7 +288,7 @@ jobs:
       # It will used to tag the docker image
       - name: Get release tag
         id: get_tag
-        run: echo ::set-output name=tag::"${GITHUB_REF#refs/tags/}"
+	run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       # Setup python3
       - name: Setup python 3.8.12
@@ -367,7 +367,7 @@ jobs:
       # It will used to tag the docker image
       - name: Get release tag
         id: get_tag
-        run: echo ::set-output name=tag::"${GITHUB_REF#refs/tags/}"
+	run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       # Setup Docker build environment
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Description

Have been seeing these errors in docker build logs for some time:

```
Warning: The set-output command is deprecated and will be disabled soon. 
Please upgrade to using Environment Files. For more information see: 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

This should fix.

## Function interfaces that changed

None.