### PR TITLE
Upgrade base and rogue dockers to use Ubuntu24.04.

### DIFF
--- a/.github/workflows/test-or-deploy.yml
+++ b/.github/workflows/test-or-deploy.yml
@@ -26,7 +26,7 @@ jobs:
   # Run flake8 on all .py files. Should block deploys to Read The Docs.
   flake8:
     name: Flake8 Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       # Checkout the code
       - name: Checkout code
@@ -53,7 +53,7 @@ jobs:
   # Validate the server docker image definitions
   docker-definitions:
     name: Docker Definition Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.actor != 'dependabot[bot]'
     steps:
       # Checkout the code.
@@ -80,7 +80,7 @@ jobs:
   # Documentation automatic build tests
   test-docs:
     name: Documentation Build Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [flake8, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
@@ -109,7 +109,7 @@ jobs:
   # Server tests
   test-server:
     name: Server Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [flake8, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
@@ -183,7 +183,7 @@ jobs:
   # Client tests
   test-client:
     name: Client Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [flake8, docker-definitions]   # Run only if all checks passed
     steps:
       # Checkout the code
@@ -235,7 +235,7 @@ jobs:
   # Build wheel
   build-wheel:
     name: Build Wheel
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [test-docs, test-server, test-client]  # Run only if all tests passed
     steps:
       - name: setup python 3.8
@@ -274,7 +274,7 @@ jobs:
   # Deploy new release notes to GitHub
   deploy-release-notes:
     name: Generate Release Notes
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [test-docs, test-server, test-client]  # Run only if all tests passed
     if: startsWith(github.ref, 'refs/tags/')      # Run only on tagged releases
     steps:
@@ -314,7 +314,7 @@ jobs:
   # Server docker
   deploy-server:
     name: Build Server Docker Image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [test-docs, test-server, test-client]  # Run only if all tests passed
     if: startsWith(github.ref, 'refs/tags/')      # Run only on tagged releases
     steps:
@@ -355,7 +355,7 @@ jobs:
   # Client docker
   deploy-client:
     name: Build Client Docker Image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [test-docs, test-server, test-client]  # Run only if all tests passed
     if: startsWith(github.ref, 'refs/tags/')      # Run only on tagged releases
     steps:

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/slaclab/smurf-base:R3.0.3
+FROM ghcr.io/slaclab/smurf-base:R4.0.2
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
@@ -13,7 +13,7 @@ RUN apt-get update && \
 RUN pip3 install --upgrade pip
 
 RUN pip3 install \
-    scipy==1.8.1 \
+    scipy \
     pandas \
     PyYAML \
     pillow \

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/slaclab/smurf-rogue:R3.10.5
+FROM ghcr.io/slaclab/smurf-rogue:R4.0.0
 
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/


### PR DESCRIPTION
## Description

Also upgrades EPICs from 3.15.5 to 3.15.9, and takes latest versions of most pip installed python packages instead of pinning them.

## Tests done on this branch

Pending.

## Function interfaces that changed

None.