### PR TITLE
Bump cryo-det fw to v1.5.0.

### DIFF
--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -28,8 +28,8 @@ config_repo=https://github.com/slaclab/smurf_cfg
 # The files will be downloaded from the release list of assets.
 
 # Firmware version for uMUX systems
-fw_repo_tag=MicrowaveMuxBpEthGen2_v1.3.0
-mcs_file_name=MicrowaveMuxBpEthGen2-0x01030000-20240913132239-ruckman-1feb01f.mcs.gz
+fw_repo_tag=MicrowaveMuxBpEthGen2_v1.5.0
+mcs_file_name=MicrowaveMuxBpEthGen2-0x01050000-20260225203458-ruckman-8295c380.mcs
 
 # Firmware version for TKID systems
 tkid_fw_repo_tag=v2.1.0


### PR DESCRIPTION
Adds configurable delay to account for DSP latencies between flux ramp trigger and data framing.

## Function interfaces that changed 

None.