### PR TITLE
Editable install broken in server docker.

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -28,7 +28,7 @@ USER cryo
 RUN git config --global --add safe.directory /usr/local/src/pysmurf
 USER root
 WORKDIR pysmurf
-RUN python3 -m pip install -e .
+RUN pip3 install -e ./
 RUN mkdir build
 WORKDIR build
 RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .. && make -j4


### PR DESCRIPTION
## Description

After switch to editable install for pysmurf, works in client docker but doesn't in server docker.  Server docker startup fails.  Switching to same pip editable install command that seems to work in the client docker.

## Tests done on this branch

Tested fix in server docker.

## Function interfaces that changed

None.
