### PR TITLE
Fix server CryoDet import

### DIFF
--- a/docker/server/scripts/server_common.sh
+++ b/docker/server/scripts/server_common.sh
@@ -271,7 +271,8 @@ updatePythonPath()
     # Look for the python directories that match the patterns
     local python_dirs=( $(find ${fw_top_dir} -type d \
                           -regex "^${fw_top_dir}/[^/]+/firmware/python" -o \
-                          -regex "^${fw_top_dir}/[^/]+/firmware/submodules/[^/]+/python") )
+                          -regex "^${fw_top_dir}/[^/]+/firmware/submodules/[^/]+/python" -o \
+						  -regex "^${fw_top_dir}/[^/]+/firmware/submodules/[^/]+/firmware/python") )
 
     # Check if any directory was found
     if [ ${#python_dirs[@]} -eq 0 ]; then


### PR DESCRIPTION
Server not finding CryoDet module in rogue zip file code.

## Description

Latest servers crashing with error

```
Rogue/pyrogue version v6.8.5. https://github.com/slaclab/rogue
smurf package imported
Traceback (most recent call last):
  File "/usr/local/src/pysmurf/server_scripts/cmb_pcie.py", line 33, in <module>
    from pysmurf.core.roots.CmbPcie import CmbPcie
  File "/usr/local/src/pysmurf/python/pysmurf/core/roots/CmbPcie.py", line 19, in <module>
    from CryoDet._MicrowaveMuxBpEthGen2 import FpgaTopLevel
ModuleNotFoundError: No module named 'CryoDet'
```

this should add `CryoDet` module to path.

## Function interfaces that changed

None.