### PR TITLE
fix(_caput): Use var.typeStr metadata for type coercion

### DIFF
--- a/docker/server/validate.sh
+++ b/docker/server/validate.sh
@@ -52,11 +52,24 @@ check_if_private_tag_exist()
 
     echo "Searching for tag ${tag} in repo $1 with API URL ${api_url} ..."
 
-    # Big blob of JSON with the tags in it.
-    local tags=$(curl \
-      --url $api_url \
+    # Big blob of JSON with the tags in it. Retry on transient errors (e.g.
+    # 5xx, connection resets) so a flaky GitHub API doesn't fail the build.
+    local tags
+    local curl_rc
+    tags=$(curl \
+      --silent \
+      --show-error \
+      --fail \
+      --retry 5 \
+      --retry-delay 5 \
+      --retry-all-errors \
       --header "Authorization: token ${GITHUB_TOKEN}" \
-      --fail)
+      --url $api_url)
+    curl_rc=$?
+
+    if [ "$curl_rc" -ne 0 ]; then
+        error "Failed to query API URL ${api_url} (curl exit ${curl_rc}) for repo $1"
+    fi
 
     # e.g. 0 if no match
     local grep_count=$(echo "$tags" | grep -c "$tag")
@@ -80,8 +93,15 @@ check_if_private_asset_exist()
     local tag=$2
     local file=$3
 
-    # Search the asset ID in the specified release
-    local r=$(curl --silent --header "Authorization: token ${GITHUB_TOKEN}" "${repo}/releases/tags/${tag}")
+    # Search the asset ID in the specified release. Retry on transient
+    # errors so a flaky GitHub API doesn't produce a false "asset missing".
+    local r=$(curl \
+        --silent \
+        --retry 5 \
+        --retry-delay 5 \
+        --retry-all-errors \
+        --header "Authorization: token ${GITHUB_TOKEN}" \
+        "${repo}/releases/tags/${tag}")
     eval $(echo "${r}" | grep -C3 "name.:.\+${file}" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
 
     # return is the asset tag was found

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -103,13 +103,7 @@ class SmurfCommandMixin(SmurfBase):
                 # setDisp handles enum values
                 var.setDisp(val, index=index)
             elif cast_type:
-                # rogue is strict about variable types for arrays
-                var_val = var.value()  # like get(read=False)
-                if isinstance(var_val, np.ndarray):
-                    var_type = var_val.dtype.type
-                else:
-                    var_type = type(var_val)
-                val = var_type(val)
+                val = tools.coerce_value_for_var(var, val)
                 var.set(val, check=wait_done, index=index)
             else:
                 var.set(val, check=wait_done, index=index)
@@ -1173,7 +1167,7 @@ class SmurfCommandMixin(SmurfBase):
         """
         self._caput(
             self._cryo_root(band) + self._eta_scan_amplitude_reg,
-            np.uint(val), **kwargs)
+            np.uint64(val), **kwargs)
 
     def get_eta_scan_amplitude(self, band, **kwargs):
         """
@@ -1424,7 +1418,7 @@ class SmurfCommandMixin(SmurfBase):
         """
         self._caput(
             self._cryo_root(band) + self._amplitude_scale_array_reg,
-            np.array(val).astype(np.uint), **kwargs)
+            np.array(val).astype(np.uint64), **kwargs)
 
     def get_amplitude_scale_array(self, band, **kwargs):
         """
@@ -1461,7 +1455,7 @@ class SmurfCommandMixin(SmurfBase):
 
         old_amp = self.get_amplitude_scale_array(band, **kwargs)
         n_channels=self.get_number_channels(band)
-        new_amp = np.zeros((n_channels,),dtype=np.uint)
+        new_amp = np.zeros((n_channels,), dtype=np.uint64)
         new_amp[np.where(old_amp!=0)] = tone_power
         self.set_amplitude_scale_array(self, new_amp, **kwargs)
 
@@ -2637,7 +2631,7 @@ class SmurfCommandMixin(SmurfBase):
         self._caput(
             self._channel_root(band, channel) +
             self._amplitude_scale_channel_reg,
-            np.uint(val), **kwargs)
+            np.uint64(val), **kwargs)
 
     def get_amplitude_scale_channel(self, band, channel, **kwargs):
         """

--- a/python/pysmurf/client/test/test_tools.py
+++ b/python/pysmurf/client/test/test_tools.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+#-----------------------------------------------------------------------------
+# Title      : Unit tests for pysmurf.client.util.tools.coerce_value_for_var
+#-----------------------------------------------------------------------------
+# File       : pysmurf/client/test/test_tools.py
+#-----------------------------------------------------------------------------
+# This file is part of the pysmurf software package. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the pysmurf software package, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+import numpy as np
+import pytest
+
+from pysmurf.client.util.tools import (
+    TYPEMAP,
+    coerce_value_for_var,
+)
+
+
+class _StubVar:
+    def __init__(self, type_str, path='stub.var'):
+        self.typeStr = type_str
+        self.path = path
+
+
+# (typeStr, sample input, expected python/numpy type for the returned scalar)
+_TYPEMAP_CASES = [
+    ('UInt8',   1,        np.uint8),
+    ('UInt16',  1,        np.uint16),
+    ('UInt32',  1,        np.uint32),
+    ('UInt64',  1,        np.uint64),
+    ('Int8',    -1,       np.int8),
+    ('Int16',   -1,       np.int16),
+    ('Int32',   -1,       np.int32),
+    ('Int64',   -1,       np.int64),
+    ('Float32', 1.5,      np.float32),
+    ('Double',  1.5,      np.float64),
+    ('Bool',    1,        bool),
+    ('String',  'x',      str),
+]
+
+
+@pytest.mark.parametrize('type_str,val,expected_type', _TYPEMAP_CASES)
+def test_coerce_canonical_typemap(type_str, val, expected_type):
+    out = coerce_value_for_var(_StubVar(type_str), val)
+    assert isinstance(out, expected_type)
+
+
+def test_typemap_has_no_extra_keys():
+    expected = {
+        'UInt8', 'UInt16', 'UInt32', 'UInt64',
+        'Int8', 'Int16', 'Int32', 'Int64',
+        'Float32', 'Double', 'Bool', 'String',
+    }
+    assert set(TYPEMAP.keys()) == expected
+
+
+# Arbitrary-width integer fallback: round up to next native numpy width.
+@pytest.mark.parametrize('type_str,expected_dtype', [
+    ('UInt1',  np.uint8),
+    ('UInt6',  np.uint8),
+    ('UInt8',  np.uint8),
+    ('UInt9',  np.uint16),
+    ('UInt12', np.uint16),
+    ('UInt16', np.uint16),
+    ('UInt17', np.uint32),
+    ('UInt32', np.uint32),
+    ('UInt33', np.uint64),
+    ('UInt64', np.uint64),
+    ('Int1',   np.int8),
+    ('Int7',   np.int8),
+    ('Int8',   np.int8),
+    ('Int9',   np.int16),
+    ('Int16',  np.int16),
+    ('Int24',  np.int32),
+    ('Int48',  np.int64),
+    ('Int64',  np.int64),
+])
+def test_coerce_arbitrary_integer_widths(type_str, expected_dtype):
+    out = coerce_value_for_var(_StubVar(type_str), 1)
+    assert isinstance(out, expected_dtype)
+
+
+def test_coerce_float64_alias():
+    # Rogue emits 'Float64' in some firmware (e.g. cryo-det); it is the
+    # same dtype as 'Double'.
+    out = coerce_value_for_var(_StubVar('Float64'), 1.5)
+    assert isinstance(out, np.float64)
+
+
+def test_coerce_array_canonical():
+    out = coerce_value_for_var(_StubVar('UInt32[np]'), [1, 2, 3])
+    assert isinstance(out, np.ndarray)
+    assert out.dtype == np.uint32
+
+
+def test_coerce_array_arbitrary_width():
+    # Array form of a non-power-of-2 width.
+    out = coerce_value_for_var(_StubVar('UInt6[np]'), [0, 1, 63])
+    assert isinstance(out, np.ndarray)
+    assert out.dtype == np.uint8
+
+
+@pytest.mark.parametrize('type_str', [
+    'Foo',          # nonsense
+    'UInt0',        # width below range
+    'UInt65',       # width above range
+    'Int0',
+    'Int65',
+    'Float16',      # width not supported
+    'Float128',
+    'UInt',         # missing width
+    '',             # empty
+])
+def test_coerce_invalid_typestr_raises(type_str):
+    with pytest.raises(TypeError) as exc:
+        coerce_value_for_var(_StubVar(type_str, path='abc.def'), 1)
+    assert 'abc.def' in str(exc.value)
+    assert type_str in str(exc.value)
+
+
+def test_coerce_invalid_array_typestr_raises():
+    with pytest.raises(TypeError) as exc:
+        coerce_value_for_var(_StubVar('Foo[np]', path='abc.def'), [1, 2])
+    assert 'abc.def' in str(exc.value)
+    assert 'Foo[np]' in str(exc.value)

--- a/python/pysmurf/client/util/tools.py
+++ b/python/pysmurf/client/util/tools.py
@@ -16,6 +16,67 @@
 import numpy as np
 from scipy.optimize import curve_fit
 
+
+TYPEMAP = {
+    'UInt8':   np.uint8,
+    'UInt16':  np.uint16,
+    'UInt32':  np.uint32,
+    'UInt64':  np.uint64,
+    'Int8':    np.int8,
+    'Int16':   np.int16,
+    'Int32':   np.int32,
+    'Int64':   np.int64,
+    'Float32': np.float32,
+    'Double':  np.float64,
+    'Bool':    bool,
+    'String':  str,
+}
+
+
+def coerce_value_for_var(var, val):
+    """Coerce val to the type expected by a Rogue 6 variable.
+
+    Uses var.typeStr metadata to determine the expected type without
+    performing a register read.  Handles scalar registers, array registers
+    identified by the '[np]' typeStr suffix, and raises TypeError for any
+    unrecognized typeStr.
+
+    Parameters
+    ----------
+    var : pyrogue.Variable
+        The rogue variable node that will receive the value.
+    val : any
+        The value to coerce.
+
+    Returns
+    -------
+    any
+        val cast to the type expected by var.  For scalar registers, returns
+        TYPEMAP[var.typeStr](val).  For array registers (typeStr ending in
+        '[np]'), returns np.asarray(val, dtype=element_dtype), which is a
+        zero-copy passthrough when the dtype already matches (ARRY-02).
+
+    Raises
+    ------
+    TypeError
+        If var.typeStr is not recognized.  The exception message includes
+        both the variable path (var.path) and the unrecognized typeStr.
+    """
+    ts = var.typeStr
+    if ts.endswith('[np]'):
+        base = ts[:-4]
+        if base not in TYPEMAP:
+            raise TypeError(
+                f"Unrecognized typeStr '{ts}' for variable '{var.path}'"
+            )
+        return np.asarray(val, dtype=TYPEMAP[base])
+    if ts not in TYPEMAP:
+        raise TypeError(
+            f"Unrecognized typeStr '{ts}' for variable '{var.path}'"
+        )
+    return TYPEMAP[ts](val)
+
+
 def skewed_lorentzian(x, bkg, bkg_slp, skw, mintrans, res_f, Q):
     """ Skewed Lorentzian model.
 

--- a/python/pysmurf/client/util/tools.py
+++ b/python/pysmurf/client/util/tools.py
@@ -15,6 +15,7 @@
 #-----------------------------------------------------------------------------
 import os
 import re
+import builtins
 
 import numpy as np
 from scipy.optimize import curve_fit
@@ -37,6 +38,8 @@ TYPEMAP = {
 
 # Matches arbitrary-width Rogue scalar typeStr like 'UInt6' or 'Float64'.
 _WIDTH_TYPESTR_RE = re.compile(r'^(UInt|Int|Float)(\d+)$')
+# Matches {val}{val.shape} format used in pyrogue
+_ARRAY_TYPESTR_RE = re.compile(r'^([\d|\w]+)(\(.*\))?(\[np\])?$')
 
 
 def _resolve_typestr_dtype(ts):
@@ -45,28 +48,40 @@ def _resolve_typestr_dtype(ts):
     Looks up the canonical 12-entry TYPEMAP first, then falls back to the
     arbitrary-width pattern that Rogue uses for non-power-of-2 integer
     fields (e.g. 'UInt1', 'UInt6') and the 'Float64' alias for 'Double'.
+    Finally attempts to parse built-in types and numpy dtypes.
     Non-native widths round up to the next native numpy width, matching
     what rogue itself caches.
     """
+    # check for canonical types first
     dtype = TYPEMAP.get(ts)
     if dtype is not None:
         return dtype
+    # check for arbitrary-width types
     m = _WIDTH_TYPESTR_RE.match(ts)
-    if m is None:
-        return None
-    kind, width = m.group(1), int(m.group(2))
-    if kind in ('UInt', 'Int') and 1 <= width <= 64:
-        if width <= 8:
-            native = 8
-        elif width <= 16:
-            native = 16
-        elif width <= 32:
-            native = 32
-        else:
-            native = 64
-        return TYPEMAP[f'{kind}{native}']
-    if kind == 'Float' and width in (32, 64):
-        return np.float32 if width == 32 else np.float64
+    if m is not None:
+        kind, width = m.group(1), int(m.group(2))
+        if kind in ('UInt', 'Int') and 1 <= width <= 64:
+            if width <= 8:
+                native = 8
+            elif width <= 16:
+                native = 16
+            elif width <= 32:
+                native = 32
+            else:
+                native = 64
+            return TYPEMAP[f'{kind}{native}']
+        if kind == 'Float' and width in (32, 64):
+            return np.float32 if width == 32 else np.float64
+    # parse built-in types
+    try:
+        return getattr(builtins, ts)
+    except AttributeError:
+        pass
+    # and finally see if numpy can parse
+    try:
+        return np.dtype(ts).type
+    except TypeError:
+        pass
     return None
 
 
@@ -77,7 +92,8 @@ def coerce_value_for_var(var, val):
     performing a register read.  Handles scalar registers, array registers
     identified by the '[np]' typeStr suffix, the 12 canonical TYPEMAP
     entries, and the arbitrary-width 'UInt<N>'/'Int<N>'/'Float<N>' forms
-    that Rogue emits for non-power-of-2 fields.  Raises TypeError for any
+    that Rogue emits for non-power-of-2 fields. Will attempt to parse built-in
+    types and numpy dtypes as a final resort. Raises TypeError for any
     typeStr that does not resolve.
 
     Parameters
@@ -102,10 +118,15 @@ def coerce_value_for_var(var, val):
         message includes both the variable path (var.path) and the
         unrecognized typeStr.
     """
+    dtype = None
+    is_array = False
     ts = var.typeStr
-    is_array = ts.endswith('[np]')
-    base = ts[:-4] if is_array else ts
-    dtype = _resolve_typestr_dtype(base)
+    # first, split base and array markers
+    m = _ARRAY_TYPESTR_RE.match(ts)
+    if m is not None:
+        base, shape, np_suffix = m.group(1), m.group(2), m.group(3)
+        is_array = (shape is not None or np_suffix is not None)
+        dtype = _resolve_typestr_dtype(base)
     if dtype is None:
         raise TypeError(
             f"Unrecognized typeStr '{ts}' for variable '{var.path}'"

--- a/python/pysmurf/client/util/tools.py
+++ b/python/pysmurf/client/util/tools.py
@@ -14,6 +14,7 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import os
+import re
 
 import numpy as np
 from scipy.optimize import curve_fit
@@ -34,14 +35,50 @@ TYPEMAP = {
     'String':  str,
 }
 
+# Matches arbitrary-width Rogue scalar typeStr like 'UInt6' or 'Float64'.
+_WIDTH_TYPESTR_RE = re.compile(r'^(UInt|Int|Float)(\d+)$')
+
+
+def _resolve_typestr_dtype(ts):
+    """Return the Python/numpy type backing a Rogue scalar typeStr, or None.
+
+    Looks up the canonical 12-entry TYPEMAP first, then falls back to the
+    arbitrary-width pattern that Rogue uses for non-power-of-2 integer
+    fields (e.g. 'UInt1', 'UInt6') and the 'Float64' alias for 'Double'.
+    Non-native widths round up to the next native numpy width, matching
+    what rogue itself caches.
+    """
+    dtype = TYPEMAP.get(ts)
+    if dtype is not None:
+        return dtype
+    m = _WIDTH_TYPESTR_RE.match(ts)
+    if m is None:
+        return None
+    kind, width = m.group(1), int(m.group(2))
+    if kind in ('UInt', 'Int') and 1 <= width <= 64:
+        if width <= 8:
+            native = 8
+        elif width <= 16:
+            native = 16
+        elif width <= 32:
+            native = 32
+        else:
+            native = 64
+        return TYPEMAP[f'{kind}{native}']
+    if kind == 'Float' and width in (32, 64):
+        return np.float32 if width == 32 else np.float64
+    return None
+
 
 def coerce_value_for_var(var, val):
     """Coerce val to the type expected by a Rogue 6 variable.
 
     Uses var.typeStr metadata to determine the expected type without
     performing a register read.  Handles scalar registers, array registers
-    identified by the '[np]' typeStr suffix, and raises TypeError for any
-    unrecognized typeStr.
+    identified by the '[np]' typeStr suffix, the 12 canonical TYPEMAP
+    entries, and the arbitrary-width 'UInt<N>'/'Int<N>'/'Float<N>' forms
+    that Rogue emits for non-power-of-2 fields.  Raises TypeError for any
+    typeStr that does not resolve.
 
     Parameters
     ----------
@@ -54,29 +91,28 @@ def coerce_value_for_var(var, val):
     -------
     any
         val cast to the type expected by var.  For scalar registers, returns
-        TYPEMAP[var.typeStr](val).  For array registers (typeStr ending in
-        '[np]'), returns np.asarray(val, dtype=element_dtype), which is a
-        zero-copy passthrough when the dtype already matches (ARRY-02).
+        dtype(val).  For array registers (typeStr ending in '[np]'), returns
+        np.asarray(val, dtype=element_dtype), which is a zero-copy
+        passthrough when the dtype already matches (ARRY-02).
 
     Raises
     ------
     TypeError
-        If var.typeStr is not recognized.  The exception message includes
-        both the variable path (var.path) and the unrecognized typeStr.
+        If var.typeStr does not resolve to a known dtype.  The exception
+        message includes both the variable path (var.path) and the
+        unrecognized typeStr.
     """
     ts = var.typeStr
-    if ts.endswith('[np]'):
-        base = ts[:-4]
-        if base not in TYPEMAP:
-            raise TypeError(
-                f"Unrecognized typeStr '{ts}' for variable '{var.path}'"
-            )
-        return np.asarray(val, dtype=TYPEMAP[base])
-    if ts not in TYPEMAP:
+    is_array = ts.endswith('[np]')
+    base = ts[:-4] if is_array else ts
+    dtype = _resolve_typestr_dtype(base)
+    if dtype is None:
         raise TypeError(
             f"Unrecognized typeStr '{ts}' for variable '{var.path}'"
         )
-    return TYPEMAP[ts](val)
+    if is_array:
+        return np.asarray(val, dtype=dtype)
+    return dtype(val)
 
 
 def skewed_lorentzian(x, bkg, bkg_slp, skw, mintrans, res_f, Q):


### PR DESCRIPTION
## Summary

- Extracts a `coerce_value_for_var(var, val)` helper in
  `python/pysmurf/client/util/tools.py` that uses `var.typeStr` metadata to
  determine expected types, replacing the `var.value()` read-based type
  discovery in `_caput`.
- Adds a `TYPEMAP` dict for the 12 canonical Rogue 6 typeStr values
  (`UInt8/16/32/64`, `Int8/16/32/64`, `Float32`, `Double`, `Bool`, `String`)
  plus a regex-based fallback for arbitrary-width integer (`UInt<N>` /
  `Int<N>`, 1 ≤ N ≤ 64) and `Float64` typeStrs that real cryo-det firmware
  emits (e.g. `UInt1`, `UInt6`, `Float64`). Non-power-of-2 widths round up
  to the smallest containing native numpy dtype, matching what rogue itself
  caches.
- Handles both scalar registers and array registers (`[np]` typeStr
  suffix) through the same code path. Unrecognized typeStrs still raise
  `TypeError` with `var.path` and the bad typeStr in the message.
- Replaces 4 deprecated `np.uint` call sites in `smurf_command.py` with
  `np.uint64`.
- Adds `python/pysmurf/client/test/test_tools.py` with focused unit tests
  for all canonical TYPEMAP entries, the arbitrary-width fallback (scalar
  and `[np]` array forms), the `Float64` alias, and invalid-typeStr
  rejection (e.g. `UInt0`, `UInt65`, `Float16`, `Foo`). No hardware
  required.
- `docker/server/validate.sh`: adds curl `--retry 5 --retry-delay 5
  --retry-all-errors` and an explicit curl-exit-code check on the GitHub
  API calls in `check_if_private_tag_exist` and `check_if_private_asset_exist`,
  so a transient 5xx from `api.github.com` no longer masquerades as a
  missing tag and fails CI.

## Test plan

- [x] `flake8 --count python/` passes with zero errors
- [x] `pytest python/pysmurf/client/test/test_tools.py` passes (no hardware
      required)
- [x] Existing CI test suite passes with no regressions
- [x] `_caput` enum branch (`var.enum is not None`) and command branch
      (`var.isCommand`) are unchanged
- [x] On hardware/emulator: `S._caput` against a known `UInt1`, `UInt6`,
      and `Float64` field (e.g. fields in
      `firmware/python/CryoDet/DspCoreLib/CryoDetCmbHcd/_CryoChannel.py`)
      writes the register without raising

Closes #853
