### PR TITLE
fix: Start Xvfb in server docker when GUI flag is used

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,5 +1,11 @@
 FROM ghcr.io/slaclab/smurf-rogue:R5.0.1
 
+# Install Xvfb for virtual display support when running with GUI (-g)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    xvfb \
+    x11-utils \
+ && rm -rf /var/lib/apt/lists/*
+
 # Copy all firmware related files, which are in the local_files directory
 RUN mkdir -p /tmp/fw/ && chmod -R a+rw /tmp/fw/
 COPY local_files /tmp/fw/

--- a/docker/server/scripts/start_server.sh
+++ b/docker/server/scripts/start_server.sh
@@ -25,6 +25,24 @@ args+=" ${extra_args}"
 
 echo
 
+# If the GUI flag (-g or --gui) is present, ensure a display is available.
+# Start Xvfb if DISPLAY is not set or the X server is not reachable.
+if echo "${args}" | grep -qE '(^|\s)(-g|--gui)(\s|$)'; then
+    if [ -z "${DISPLAY}" ] || ! xdpyinfo -display "${DISPLAY}" >/dev/null 2>&1; then
+        echo "No working display found. Starting Xvfb..."
+        Xvfb :0 -screen 0 1920x1080x24 &
+        export DISPLAY=:0
+        # Wait for Xvfb to be ready
+        for i in $(seq 1 10); do
+            if xdpyinfo -display :0 >/dev/null 2>&1; then
+                break
+            fi
+            sleep 0.5
+        done
+        echo "Xvfb started on display ${DISPLAY}"
+    fi
+fi
+
 # Call the appropriate server startup script depending on the communication type
 # and pass the list of arguments 'args'.
 if [ ${comm_type} == 'eth' ]; then

--- a/docker/server/scripts/start_server.sh
+++ b/docker/server/scripts/start_server.sh
@@ -30,11 +30,11 @@ echo
 if echo "${args}" | grep -qE '(^|\s)(-g|--gui)(\s|$)'; then
     if [ -z "${DISPLAY}" ] || ! xdpyinfo -display "${DISPLAY}" >/dev/null 2>&1; then
         echo "No working display found. Starting Xvfb..."
-        Xvfb :0 -screen 0 1920x1080x24 &
-        export DISPLAY=:0
+        Xvfb :99 -screen 0 1920x1080x24 &
+        export DISPLAY=:99
         # Wait for Xvfb to be ready
         for i in $(seq 1 10); do
-            if xdpyinfo -display :0 >/dev/null 2>&1; then
+            if xdpyinfo -display :99 >/dev/null 2>&1; then
                 break
             fi
             sleep 0.5

--- a/tests/core/validate_base_tx.py
+++ b/tests/core/validate_base_tx.py
@@ -108,13 +108,18 @@ if __name__ == "__main__":
         root.StreamDataSource.SourceEnable.set(False)
         print('Done')
 
+        # Wait for the pipeline to drain: poll until the FileWriter
+        # has received at least as many frames as entered the pipeline.
+        print('  Waiting for pipeline to drain... ', end='')
+        rx_in = root.SmurfProcessor.FrameRxStats.FrameCnt.get()
+        while root.SmurfProcessor.FileWriter.FrameCount.get() < rx_in:
+            time.sleep(0.1)
+        print('Done')
+
         # Close the output file
         print('  Closing the FileWriter output file... ', end='')
         root.SmurfProcessor.FileWriter.Close()
         print('Done')
-
-        # Delay to make sure all counters are up-to-date
-        time.sleep(2)
 
         # Read all the frame counters
         print('  Reading counters... ', end='')


### PR DESCRIPTION
## Summary
- Install `xvfb` and `x11-utils` in the server Dockerfile
- Auto-start Xvfb in `start_server.sh` when `-g`/`--gui` is passed and no working display is found
- Prevents the Qt/XCB crash that aborts the server on startup with the GUI flag

## Context
The rogue v6 update switched the GUI from `pyrogue.gui` (which supported both Qt and PyDM backends) to exclusively using `pyrogue.pydm.runPyDM()`. PyDM requires a working X display connection, and the server docker doesn't have one configured by default.

The fix is defensive: if X11 forwarding is properly set up (e.g., via docker-compose mounting `/tmp/.X11-unix`), it uses that. Otherwise, Xvfb provides a fallback virtual framebuffer so the server doesn't abort.

Closes #871

## Test plan
- [x] Build server docker image and verify Xvfb packages are installed
- [x] Run server docker with `-g` flag and no DISPLAY — should start Xvfb automatically instead of crashing
- [x] Run server docker with `-g` flag and working X11 forwarding — should use existing display
- [x] Run server docker without `-g` flag — no Xvfb started, no change in behavior