### PR TITLE
Protect against rogue type errors

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -1317,6 +1317,12 @@ class SmurfTuneMixin(SmurfBase):
         eta_mag = np.abs(eta)
         eta_angle = np.angle(eta)
         eta_scaled = eta_mag / subband_half_width
+        if eta_scaled > 1:
+            self.log(f"eta_fit: Measured eta {eta_scaled} > 1. Clipping to 1.")
+            eta_scaled = 1
+            eta /= eta_mag
+            eta *= subband_half_width
+            eta_mag = subband_half_width
         eta_phase_deg = eta_angle * 180 / np.pi
 
 
@@ -3995,6 +4001,12 @@ class SmurfTuneMixin(SmurfBase):
                 eta_phase_deg = np.angle(eta)*180/np.pi
                 eta_mag = np.abs(eta)
                 eta_scaled = eta_mag / subband_half_width
+                if eta_scaled > 1:
+                    self.log(f"setup_notches: Measured eta {eta_scaled} > 1. Clipping to 1.")
+                    eta_scaled = 1
+                    eta /= eta_mag
+                    eta *= subband_half_width
+                    eta_mag = subband_half_width
 
                 abs_resp = np.abs(resp_s)
                 idx = np.ravel(np.where(abs_resp == np.min(abs_resp)))[0]
@@ -4049,6 +4061,12 @@ class SmurfTuneMixin(SmurfBase):
                 eta_phase_degu = np.angle(etau)*180/np.pi
                 eta_magu = np.abs(etau)
                 eta_scaledu = eta_magu / subband_half_width
+                if eta_scaledu > 1:
+                    self.log(f"setup_notches: Measured eta {eta_scaledu} > 1. Clipping to 1.")
+                    eta_scaledu = 1
+                    etau /= eta_magu
+                    etau *= subband_half_width
+                    eta_magu = subband_half_width
 
                 abs_respu = np.abs(respu_s)
                 idx = np.ravel(np.where(abs_respu == np.min(abs_respu)))[0]

--- a/python/pysmurf/core/devices/_PcieCard.py
+++ b/python/pysmurf/core/devices/_PcieCard.py
@@ -42,7 +42,7 @@ class PcieDev():
     def __init__(self, dev, name, description):
         import rogue.hardware.axi
         from SmurfPcie import SmurfKcu1500RssiOffload10GbE as fpga
-        self._root = pyrogue.Root(name=name,description=description, pollEn='False',initRead='True')
+        self._root = pyrogue.Root(name=name,description=description, pollEn=False,initRead=True)
         self._memMap = rogue.hardware.axi.AxiMemMap(dev)
         self._root.add(fpga.Core(memBase=self._memMap))
         self._root.start()


### PR DESCRIPTION
In the latest rogue type checking is stricter. This PR adds some protection to avoid tripping up checks on setting values.