### PR TITLE
fix(smurf_tune.find_freq): Make output filename more unique

### DIFF
--- a/python/pysmurf/client/command/smurf_cmd.py
+++ b/python/pysmurf/client/command/smurf_cmd.py
@@ -19,6 +19,7 @@ import time
 import numpy as np
 
 import pysmurf.client
+from pysmurf.client.util import tools
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 
@@ -162,7 +163,7 @@ def set_port(S, slot, port):
         slots = np.append(slots, slot)
         ports = np.append(ports, port)
 
-    np.savetxt(slot_port_file, np.array([slots, ports]).T, fmt='%i %i')
+    tools.save_to_txt(slot_port_file, np.array([slots, ports]).T, overwrite=True, fmt='%i %i')
 
 
 def get_port(S, slot):

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -256,7 +256,7 @@ class SmurfNoiseMixin(SmurfBase):
                 # outfn = os.path.join(self.plot_dir, save_name)
                 outfn = os.path.join(self.output_dir, save_name)
 
-                np.savetxt(outfn, np.c_[res_freqs, noise_floors[i], f_knees])
+                tools.save_to_txt(outfn, np.c_[res_freqs, noise_floors[i], f_knees])
                 # Publish the data
                 self.pub.register_file(outfn, 'noise_timestream', format='txt')
 
@@ -446,10 +446,10 @@ class SmurfNoiseMixin(SmurfBase):
                                 '_noise_vs_tone_tone.txt')
 
         # Save the data
-        np.savetxt(datafile_save,datafiles, fmt='%s')
+        tools.save_to_txt(datafile_save, datafiles, fmt='%s')
         self.pub.register_file(datafile_save, 'noise_vs_tone_data',
             format='txt')
-        np.savetxt(tone_save, tones, fmt='%i')
+        tools.save_to_txt(tone_save, tones, fmt='%i')
 
         self.pub.register_file(tone_save, 'noise_vs_tone_tone', format='txt')
 
@@ -629,7 +629,7 @@ class SmurfNoiseMixin(SmurfBase):
                                      f'{timestamp}_{var}.txt')
 
 
-        np.savetxt(fn_var_values, var_range)
+        tools.save_to_txt(fn_var_values, var_range)
         # Is this an accurate tag?
         self.pub.register_file(fn_var_values, f'noise_vs_{var}',
                                format='txt')
@@ -681,7 +681,7 @@ class SmurfNoiseMixin(SmurfBase):
         fn_datafiles = os.path.join(psd_dir,
                                     f'{timestamp}_datafiles.txt')
 
-        np.savetxt(fn_datafiles,datafiles, fmt='%s')
+        tools.save_to_txt(fn_datafiles, datafiles, fmt='%s')
         self.pub.register_file(fn_datafiles, 'datafiles', format='txt')
 
         self.log(f'Saving variables values to {fn_var_values}.')
@@ -998,7 +998,7 @@ class SmurfNoiseMixin(SmurfBase):
 
                 path = os.path.join(psd_dir,
                     basename + f'_psd_b{b}ch{ch:03}.txt')
-                np.savetxt(path, np.array([f, Pxx]))
+                tools.save_to_txt(path, np.array([f, Pxx]))
                 self.pub.register_file(path, 'psd', format='txt')
 
             # Explicitly remove objects from memory
@@ -1748,12 +1748,12 @@ class SmurfNoiseMixin(SmurfBase):
                 Pxx = np.ravel(np.sqrt(Pxx))  # pA
 
                 path = os.path.join(psd_dir, basename + f'_psd_ch{ch:03}.txt')
-                np.savetxt(path, np.vstack((f, Pxx)))
+                tools.save_to_txt(path, np.vstack((f, Pxx)))
                 self.pub.register_file(path, 'psd', format='txt')
 
                 data_path = os.path.join(psd_dir, basename +
                     f'_data_ch{ch:03}.txt')
-                np.savetxt(data_path, phase[ch_idx])
+                tools.save_to_txt(data_path, phase[ch_idx])
 
             # Explicitly remove objects from memory
             del timestamp

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -28,6 +28,7 @@ import seaborn as sns
 from pysmurf.client.base import SmurfBase
 from pysmurf.client.command.sync_group import SyncGroup as SyncGroup
 from pysmurf.client.util.pub import set_action
+from pysmurf.client.util.tools import save_to_txt
 from ..util import tools
 
 class SmurfTuneMixin(SmurfBase):
@@ -781,15 +782,15 @@ class SmurfTuneMixin(SmurfBase):
             save_name = timestamp + '_{}_full_band_resp.txt'
 
             path = os.path.join(self.output_dir, save_name.format('freq'))
-            np.savetxt(path, f)
+            save_to_txt(path, f)
             self.pub.register_file(path, 'full_band_resp', format='txt')
 
             path = os.path.join(self.output_dir, save_name.format('real'))
-            np.savetxt(path, np.real(resp))
+            save_to_txt(path, np.real(resp))
             self.pub.register_file(path, 'full_band_resp', format='txt')
 
             path = os.path.join(self.output_dir, save_name.format('imag'))
-            np.savetxt(path, np.imag(resp))
+            save_to_txt(path, np.imag(resp))
             self.pub.register_file(path, 'full_band_resp', format='txt')
 
         if return_plot_path:
@@ -3518,11 +3519,12 @@ class SmurfTuneMixin(SmurfBase):
         save_name = '{}_b{:d}_amp_sweep_{}.txt'
 
         path = os.path.join(self.output_dir, save_name.format(timestamp, band, 'freq'))
-        np.savetxt(path, f)
+        # will raise an error if the file already exists
+        save_to_txt(path, f)
         self.pub.register_file(path, 'sweep_response', format='txt')
 
         path = os.path.join(self.output_dir, save_name.format(timestamp, band, 'resp'))
-        np.savetxt(path, resp)
+        save_to_txt(path, resp)
         self.pub.register_file(path, 'sweep_response', format='txt')
 
         # Place in dictionary - dictionary declared in smurf_control
@@ -3550,7 +3552,7 @@ class SmurfTuneMixin(SmurfBase):
         # Save resonances
         path = os.path.join(self.output_dir,
             save_name.format(timestamp, band, 'resonance'))
-        np.savetxt(path, self.freq_resp[band]['find_freq']['resonance'])
+        save_to_txt(path, self.freq_resp[band]['find_freq']['resonance'])
         self.pub.register_file(path, 'resonances', format='txt')
 
         # Call plotting
@@ -4927,7 +4929,7 @@ class SmurfTuneMixin(SmurfBase):
 
                 path = os.path.join(self.output_dir,
                     save_name.format(timestamp, str(band),'resonance'))
-                np.savetxt(path, freq_dict[band]['find_freq']['resonance'])
+                save_to_txt(path, freq_dict[band]['find_freq']['resonance'])
                 self.pub.register_file(path, 'resonances', format='txt')
 
         return freq_dict

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3515,13 +3515,13 @@ class SmurfTuneMixin(SmurfBase):
         timestamp = self.get_timestamp()
 
         # Save data
-        save_name = '{}_amp_sweep_{}.txt'
+        save_name = '{}_b{:d}_amp_sweep_{}.txt'
 
-        path = os.path.join(self.output_dir, save_name.format(timestamp, 'freq'))
+        path = os.path.join(self.output_dir, save_name.format(timestamp, band, 'freq'))
         np.savetxt(path, f)
         self.pub.register_file(path, 'sweep_response', format='txt')
 
-        path = os.path.join(self.output_dir, save_name.format(timestamp, 'resp'))
+        path = os.path.join(self.output_dir, save_name.format(timestamp, band, 'resp'))
         np.savetxt(path, resp)
         self.pub.register_file(path, 'sweep_response', format='txt')
 
@@ -3549,7 +3549,7 @@ class SmurfTuneMixin(SmurfBase):
 
         # Save resonances
         path = os.path.join(self.output_dir,
-            save_name.format(timestamp, 'resonance'))
+            save_name.format(timestamp, band, 'resonance'))
         np.savetxt(path, self.freq_resp[band]['find_freq']['resonance'])
         self.pub.register_file(path, 'resonances', format='txt')
 

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -28,6 +28,7 @@ from pysmurf.client.base import SmurfBase
 from pysmurf.client.command.sync_group import SyncGroup as SyncGroup
 from pysmurf.client.util.SmurfFileReader import SmurfStreamReader
 from pysmurf.client.util.pub import set_action
+from pysmurf.client.util import tools
 
 class SmurfUtilMixin(SmurfBase):
 
@@ -1071,7 +1072,7 @@ class SmurfUtilMixin(SmurfBase):
             # raw data output
             mask_fname = os.path.join(data_filename.replace('.dat',
                 '_mask.txt'))
-            np.savetxt(mask_fname, channel_mask, fmt='%i')
+            tools.save_to_txt(mask_fname, channel_mask, fmt='%i')
             self.pub.register_file(mask_fname, 'mask')
             self.log(mask_fname)
 
@@ -1079,7 +1080,7 @@ class SmurfUtilMixin(SmurfBase):
                 if write_log:
                     self.log("Writing frequency mask.")
                 freq_mask = self.make_freq_mask(channel_mask)
-                np.savetxt(os.path.join(data_filename.replace('.dat',
+                tools.save_to_txt(os.path.join(data_filename.replace('.dat',
                     '_freq.txt')), freq_mask, fmt='%4.4f')
                 self.pub.register_file(
                     os.path.join(data_filename.replace('.dat', '_freq.txt')),
@@ -3443,7 +3444,7 @@ class SmurfUtilMixin(SmurfBase):
         self.log(f'Generating gcp mask file. {len(gcp_chans)} ' +
                  'channels added')
 
-        np.savetxt(self.smurf_to_mce_mask_file, gcp_chans, fmt='%i')
+        tools.save_to_txt(self.smurf_to_mce_mask_file, gcp_chans, overwrite=True, fmt='%i')
 
         if read_gcp_mask:
             self.read_smurf_to_gcp_config()

--- a/python/pysmurf/client/util/tools.py
+++ b/python/pysmurf/client/util/tools.py
@@ -13,6 +13,8 @@
 # copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
+import os
+
 import numpy as np
 from scipy.optimize import curve_fit
 
@@ -232,3 +234,23 @@ def utf8_to_str(d):
         The string associated with input d.
     """
     return ''.join([str(s, encoding='UTF-8') for s in d])
+
+def save_to_txt(path: str, data: np.ndarray, overwrite: bool = False, **kwargs):
+    """
+    Saves data to a txt file. Raises and exception if the file
+    already exists unless overwrite is set to True.
+
+    Args
+    ----
+    path : str
+        The full path to the txt file to save to.
+    data : array-like
+        The data to save to the txt file.
+    overwrite : bool
+        If True, overwrite the file if it exists. Default is False.
+    `**kwargs` : dict
+        Additional keyword arguments to pass to np.savetxt (e.g., fmt, delimiter, etc.)
+    """
+    if os.path.exists(path) and not overwrite:
+        raise FileExistsError(f'File {path} already exists and overwrite is False.')
+    np.savetxt(path, data, **kwargs)

--- a/python/pysmurf/client/util/tools.py
+++ b/python/pysmurf/client/util/tools.py
@@ -237,8 +237,9 @@ def utf8_to_str(d):
 
 def save_to_txt(path: str, data: np.ndarray, overwrite: bool = False, **kwargs):
     """
-    Saves data to a txt file. Raises and exception if the file
-    already exists unless overwrite is set to True.
+    Saves data to a txt file. If a file already exists at the given path and
+    overwrite is False, it will generate a new path by appending a number to
+    the filename.
 
     Args
     ----
@@ -252,5 +253,34 @@ def save_to_txt(path: str, data: np.ndarray, overwrite: bool = False, **kwargs):
         Additional keyword arguments to pass to np.savetxt (e.g., fmt, delimiter, etc.)
     """
     if os.path.exists(path) and not overwrite:
-        raise FileExistsError(f'File {path} already exists and overwrite is False.')
+        orig_path = path
+        path = _make_unique_path(path)
+        import warnings
+        warnings.warn(
+            f"File {orig_path} already exists and overwrite is False."
+            f"Will write to {path} instead."
+        )
     np.savetxt(path, data, **kwargs)
+
+def _make_unique_path(path: str) -> str:
+    """
+    If a file already exists at the given path, this function generates a new path by appending
+    a number to the filename.
+
+    Args
+    ----
+    path : str
+        The original file path.
+
+    Returns
+    -------
+    str
+        A unique file path that does not already exist.
+    """
+    base, ext = os.path.splitext(path)
+    i = 1
+    new_path = f"{base}_{i}{ext}"
+    while os.path.exists(new_path):
+        i += 1
+        new_path = f"{base}_{i}{ext}"
+    return new_path


### PR DESCRIPTION
Just discovered an issue where it appears that `find_freq` is overwriting and publishing files with the same path, which is causing issues for `suprsync` at site.

`pysmurf` publishes a new file every time you run `find_freq`. There is a separate file for every band, but it is only labelled by the timestamp up to 1s. (it publishes three files -- `resp`, `resonance`, and `freq`) so if you were to run find_freq in sequence over every band and one of those iterations took less than 1s, you could end up with two files with the same path, the second one overwriting the first, but they would both get published.

I'm a bit surprised that `find_freq` can iterate over bands so quickly, so I will try to confirm that this is in fact what is happening.

The solution proposed here is not necessarily robust, but it should make it much less likely for duplicate files to be generated. (you'd have to be running `find_freq` on the same band in a loop).

I also wrapped the `np.savetxt` in a function that will check for an existing file and overwrite only if asked to. Otherwise this will raise an exception. I set it to not overwrite anywhere it is publishing the file.

I searched for any uses of `amp_sweep` in `pysmurf`, `sodetlib` and `sotodlib` in case they are relying on the file naming pattern, but didn't find anything.