### PR TITLE
fix(plot_eta_fit): Swap I & Q axis labels (#882)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -1422,8 +1422,8 @@ class SmurfTuneMixin(SmurfBase):
         ax0 = fig.add_subplot(gs[0,0])
         ax1 = fig.add_subplot(gs[1,0], sharex=ax0)
         ax2 = fig.add_subplot(gs[:,1:])
-        ax0.plot(plot_freq, I, label='I', linestyle=':', color='k')
-        ax0.plot(plot_freq, Q, label='Q', linestyle='--', color='k')
+        ax0.plot(plot_freq, I, label='Q', linestyle=':', color='k')
+        ax0.plot(plot_freq, Q, label='I', linestyle='--', color='k')
         ax0.scatter(plot_freq, amp, c=np.arange(len(freq)), s=3,
             label='amp')
         zero_idx = np.ravel(np.where(plot_freq == 0))[0]
@@ -1456,8 +1456,8 @@ class SmurfTuneMixin(SmurfBase):
         ax2.axvline(0, color='k', linestyle=':', alpha=.5)
 
         ax2.scatter(I, Q, c=np.arange(len(freq)), s=3)
-        ax2.set_xlabel('I')
-        ax2.set_ylabel('Q')
+        ax2.set_xlabel('Q')
+        ax2.set_ylabel('I')
 
         if peak_freq is not None:
             ax0.text(.03, .9, f'{peak_freq:5.2f} MHz',
@@ -4201,8 +4201,8 @@ class SmurfTuneMixin(SmurfBase):
                 np.max(dfQ)]))
             h = sns.jointplot(dfQ, dfI, alpha=.1, edgecolors='none',
                 xlim=(-lims, lims), ylim=(-lims, lims))
-            h.ax_joint.set_xlabel('Q')
-            h.ax_joint.set_ylabel('I')
+            h.ax_joint.set_xlabel('I')
+            h.ax_joint.set_ylabel('Q')
 
             # Draw guiding lines
             h.ax_joint.axhline(0 ,color='k', linestyle=':')


### PR DESCRIPTION
## Summary

Fixes #882. ETA plots auto-generated during `setup_notches` / `eta_fit` had their I and Q display labels reversed. This PR swaps the visible label strings in both ETA-plot generators in `python/pysmurf/client/tune/smurf_tune.py`:

- `plot_eta_fit` (auto-generated during tuning):
  - IQ-circle axes: `set_xlabel('I')` / `set_ylabel('Q')` → `set_xlabel('Q')` / `set_ylabel('I')`
  - Time-series legend: `label='I'` / `label='Q'` → `label='Q'` / `label='I'`
- `calculate_eta_svd` (SVD-based eta plot):
  - `sns.jointplot` axes: `set_xlabel('Q')` / `set_ylabel('I')` → `set_xlabel('I')` / `set_ylabel('Q')`

Internal data variables (`I = np.real(resp)`, `Q = np.imag(resp)`) and the `phase = arctan2(Q, I)` calculation are **unchanged** — only displayed strings change. Diff is exactly six string-literal swaps.

## Out of scope

- Changing the `np.real`/`np.imag` data convention or the upstream hardware register-name convention (`get_eta_scan_results_real` / `get_eta_scan_results_imag`).
- Touching the `eta_phase`/`eta_phase_rot` annotation text in `calculate_eta_svd` (lines 4219–4220).
- Modifying `eta_scan` (line 2225) — its docstring already documents its own non-standard convention; not in the auto-tuning path.

Reviewers: if any of the above should be addressed in this PR rather than a follow-up, please flag in review.

## Test plan

- [x] `flake8 --count python/` passes with zero errors (matches CI invocation in `.github/workflows/test-or-deploy.yml`)
- [x] `git diff -w` shows only the six string-literal swaps, no other changes
- [ ] Hardware verification (@benderan): re-run an automatic tune (`setup_notches` / `eta_fit` path) and confirm the saved ETA plot PNG now shows I/Q labels matching expected resonator IQ-circle orientation