### PR TITLE
fix(set_feedback_limit_khz): correct off-by-2 register scaling (#787)

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2149,26 +2149,36 @@ class SmurfUtilMixin(SmurfBase):
 
     def set_feedback_limit_khz(self, band, feedback_limit_khz, **kwargs):
         """
-        Sets the feedback limit
+        Sets the feedback limit, which clamps the magnitude of the
+        per-channel tracked-tone deviation before the loop saturates.
+
+        The 16-bit ``feedbackLimit`` register encodes the limit as a
+        fraction of the per-subband half-width (the same convention as
+        ``eta_mag``). Requests larger than the half-width are clamped,
+        and the integer is clamped to ``2**16 - 1`` so an input equal
+        to the half-width does not wrap to zero in firmware.
 
         Args
         ----
         band : int
-            The band that is to be turned off.
+            The 500 MHz band whose feedback limit will be set.
         feedback_limit_khz : float
-            The feedback rate in units of kHz.
+            Maximum permitted tracked-tone deviation, in kHz.
         """
         digitizer_freq_mhz = self.get_digitizer_frequency_mhz(band)
         n_subband = self.get_number_sub_bands(band)
 
-        subband_bandwidth = 2 * digitizer_freq_mhz / n_subband
-        desired_feedback_limit_mhz = feedback_limit_khz/1000.
+        subband_half_width_mhz = digitizer_freq_mhz / n_subband
+        desired_feedback_limit_mhz = feedback_limit_khz / 1000.
 
-        if desired_feedback_limit_mhz > subband_bandwidth/2:
-            desired_feedback_limit_mhz = subband_bandwidth/2
+        if desired_feedback_limit_mhz > subband_half_width_mhz:
+            desired_feedback_limit_mhz = subband_half_width_mhz
 
-        desired_feedback_limit_dec = int(np.floor(desired_feedback_limit_mhz/
-            (subband_bandwidth/2**16.)))
+        desired_feedback_limit_dec = int(np.floor(
+            desired_feedback_limit_mhz / (subband_half_width_mhz / 2**16.)))
+
+        if desired_feedback_limit_dec >= 2**16:
+            desired_feedback_limit_dec = 2**16 - 1
 
         self.set_feedback_limit(band, desired_feedback_limit_dec, **kwargs)
 


### PR DESCRIPTION
## Summary

- Fixes #787. The `feedbackLimit` register encodes the limit as a fraction of the per-subband half-width (`digitizer_freq_mhz / n_subbands`), matching the `eta_mag` convention used elsewhere in the same DSP block (`smurf_tune.py:409-413`). The previous formula divided by the full subband bandwidth (`2 * digitizer_freq_mhz / n_subbands`), producing a register value half the intended one — exactly the off-by-2 reported in the issue and consistent with `@swh76`'s observation that the helper caps out at `0x8000` instead of using the full 16-bit range.
- Switch the denominator to `subband_half_width_mhz / 2**16` and clamp the integer to `2**16 - 1` so an input equal to the half-width does not wrap to zero in firmware.
- Fix a copy-paste error in the docstring (`"The band that is to be turned off"`) and document the clamp.

## Behavior change ⚠️

`set_feedback_limit_khz` — and the `feedbackLimitkHz` config key consumed automatically by `SmurfControl` at setup (`smurf_control.py:574`) — will now write register values **~2× larger** than before, yielding tracking that is twice as permissive. Direction is correct (this is the bug fix), but operators who tuned `feedbackLimitkHz` against the buggy formula will see a behavior change at next setup and should review their configs. Every shipped config in `cfg_files/` (typically `225` or `2000` kHz) is affected.

## Verification

Numerical golden values for canonical SMuRF (`digitizer_freq_mhz = 614.4`, `n_subband = 256`, half-width `2.4 MHz`):

| `feedback_limit_khz` | Old register | New register |
| --- | --- | --- |
| 225 | `0x0C00` (3072) | `0x1800` (6144) |
| 600 | `0x2000` (8192) | `0x4000` (16384) |
| 1200 | `0x4000` (16384) | `0x8000` (32768) |
| 2400 (= half-width) | `0x8000` (32768) | `0xFFFF` (65535) |
| 5000 (above cap) | `0x8000` clamp | `0xFFFF` clamp |

The 1200 → `0x4000` data point under the old formula matches what was reported in the issue. The new formula doubles the register value, restoring agreement with the firmware encoding and `@swh76`'s `set_feedback_limit(0, 2**16-1)` workaround.

`flake8 --count python/pysmurf/client/util/smurf_util.py` → 0 errors (matches what the `Flake8 Tests` CI job runs).

## Test plan

- [ ] `flake8` CI job passes
- [ ] Hardware verification by the issue reporter (`@swh76` or the MIT folks): `set_feedback_limit_khz(band, 1200)` followed by `get_feedback_limit(band)` should return ~32768 (was ~16384)
- [ ] Hardware verification: original symptom from #787 (1200 kHz limit yielding only ±600 kHz of tracking) is resolved — should now show ±1200 kHz

## Out-of-scope

- Editing shipped configs in `cfg_files/`. Deployment-specific.
- Adding regression unit tests. Worth doing, but a separate concern; the project has no non-hardware test scaffolding today.
- Touching `set_feedback_limit` in `smurf_command.py`. Unchanged.

Reviewers — feel free to flag any of the above for inclusion in this PR if you'd prefer to address them here rather than in follow-ups.

Closes #787