### PR TITLE
fix(full_band_ampl_sweep): Restore centerFrequencyMHz after SerialFindFreq (#723)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3679,6 +3679,10 @@ class SmurfTuneMixin(SmurfBase):
         #
         self.set_eta_scan_freq(band, freq_scan.flatten())
         self.set_eta_scan_amplitude(band, tone_power)
+
+        # SerialFindFreq overwrites per-channel centerFrequencyMHz while
+        # sweeping; snapshot it so we can restore tuned channels (issue #723).
+        center_freq_pre = self.get_center_frequency_array(band)
         self.set_run_serial_find_freq(band, 1)
 
         I = self.get_eta_scan_results_real(band, count=n_step*n_channels)
@@ -3688,6 +3692,8 @@ class SmurfTuneMixin(SmurfBase):
         Q = self.get_eta_scan_results_imag(band, count=n_step*n_channels)
         Q = np.asarray(Q)
         Q = Q.reshape(n_channels, n_step)
+
+        self.set_center_frequency_array(band, center_freq_pre)
 
         resp_scan = I + 1j*Q
 


### PR DESCRIPTION
## Summary
- Closes #723.
- `SerialFindFreq` (triggered by writing `runSerialFindFreq=1`) iterates through channels and overwrites each channel's `centerFrequencyMHz` while driving sweep tones for the eta-scan response measurement. On a tuned/locked system, calling `full_band_ampl_sweep` therefore destroyed the per-channel resonator-frequency assignments and forced the user to relock.
- Snapshot `get_center_frequency_array(band)` before `set_run_serial_find_freq(band, 1)` and write it back via `set_center_frequency_array(band, ...)` after the I/Q results are read. Three new lines (one save, one comment, one restore) inside `full_band_ampl_sweep` — no other changes.

## Notes
- This fix only works because of a recent prerequisite: commit `5cb76fbd` (Sep 2025, "fix(smurf_command): Correct centerFrequency register name") renamed `_center_frequency_array_reg` from `centerFrequency` to `centerFrequencyMHz`. Before that, the restore would have silently failed.

## Out of scope

- `setup_notches` — explicitly does not need this fix (see "Scope" above).
- Any firmware change to `SerialFindFreq` itself — the issue is resolved entirely in pysmurf with the existing register helpers.
- Async / parallel `find_freq` variants — not present on this branch (`issues-723` from `main`); they exist on other branches and would need the same treatment if/when merged.

## Test plan
- [x] `flake8 --count python/` — 0 errors (matches CI in `.github/workflows/test-or-deploy.yml`).
- [ ] Hardware validation on a SMuRF crate (no automated test harness exercises this path):
  ```python
  pre = S.get_center_frequency_array(band)
  S.full_band_ampl_sweep(band, subband=[...], tone_power=12, n_read=2)
  post = S.get_center_frequency_array(band)
  np.testing.assert_array_equal(pre, post)   # expect: equal
  ```
- [ ] Confirm channels stay locked after `full_band_ampl_sweep` (no relock required) — the user-facing symptom from #723.
- [ ] Regression check: `S.find_freq(band, ...)` on an untuned system still produces the same resonator list (the saved array is whatever was in firmware pre-sweep; restoring it is a no-op for a fresh band, since `find_freq` already calls `band_off(band)` on entry).