### PR TITLE
fix(SmurfCommand): Recover etaScanInProgress on serial scan timeout (#722)

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -685,6 +685,15 @@ class SmurfCommandMixin(SmurfBase):
         return self._caget(self._cryo_root(band) + self._eta_scan_in_progress_reg,
                     **kwargs)
 
+    def set_eta_scan_in_progress(self, band, val, **kwargs):
+        """
+        Force-write the etaScanInProgress flag. Intended for recovery only:
+        if a serial eta scan / gradient descent / min search aborts in
+        firmware, this flag can be left at 1 and block subsequent scans.
+        """
+        self._caput(self._cryo_root(band) + self._eta_scan_in_progress_reg,
+                    val, **kwargs)
+
     _gradient_descent_max_iters_reg = 'gradientDescentMaxIters'
 
     def set_gradient_descent_max_iters(self, band, val, **kwargs):
@@ -828,6 +837,30 @@ class SmurfCommandMixin(SmurfBase):
 
     _run_serial_eta_scan_reg = 'runSerialEtaScan'
 
+    def _wait_for_eta_scan_in_progress(self, band, op_name, timeout):
+        """
+        Wait for the band's etaScanInProgress flag to clear. On timeout,
+        log an error and best-effort force the flag back to 0 so subsequent
+        eta-scan / gradient-descent / min-search commands are not blocked
+        by a stuck flag (firmware can leave it stuck at 1 if the rogue
+        process raises). Re-raises the TimeoutError so the caller knows
+        the operation did not complete (see issue #722).
+        """
+        monitorPV = self._cryo_root(band) + self._eta_scan_in_progress_reg
+        try:
+            self._wait_for(monitorPV, lambda x: x == 0, timeout=timeout)
+        except TimeoutError:
+            self.log(
+                f'{op_name} on band {band} did not finish within {timeout}s. '
+                f'Check the rogue server logs for firmware errors. Forcing '
+                f'etaScanInProgress=0 so subsequent eta-scan commands can '
+                f'run.', self.LOG_ERROR)
+            try:
+                self.set_eta_scan_in_progress(band, 0)
+            except Exception:
+                pass
+            raise
+
     def run_serial_eta_scan(self, band, timeout=240, **kwargs):
         """
         Does an eta scan serially across the entire band. You must
@@ -846,10 +879,10 @@ class SmurfCommandMixin(SmurfBase):
         self.flux_ramp_off()
 
         triggerPV = self._cryo_root(band) + self._run_serial_eta_scan_reg
-        monitorPV = self._cryo_root(band) + self._eta_scan_in_progress_reg
 
         self._caput(triggerPV, 1, **kwargs)
-        self._wait_for(monitorPV, lambda x: x == 0, timeout=timeout)
+        self._wait_for_eta_scan_in_progress(
+            band, 'run_serial_eta_scan', timeout)
 
 
     _run_serial_min_search_reg = 'runSerialMinSearch'
@@ -868,11 +901,10 @@ class SmurfCommandMixin(SmurfBase):
         """
         triggerPV = (
             self._cryo_root(band) + self._run_serial_min_search_reg)
-        monitorPV = (
-            self._cryo_root(band) + self._eta_scan_in_progress_reg)
 
         self._caput(triggerPV, 1, **kwargs)
-        self._wait_for(monitorPV, lambda x: x == 0, timeout=timeout)
+        self._wait_for_eta_scan_in_progress(
+            band, 'run_serial_min_search', timeout)
 
 
     _run_serial_gradient_descent_reg = 'runSerialGradientDescent'
@@ -893,10 +925,10 @@ class SmurfCommandMixin(SmurfBase):
         self.flux_ramp_off()
 
         triggerPV = self._cryo_root(band) + self._run_serial_gradient_descent_reg
-        monitorPV = self._cryo_root(band) + self._eta_scan_in_progress_reg
 
         self._caput(triggerPV, 1, **kwargs)
-        self._wait_for(monitorPV, lambda x: x == 0, timeout=timeout)
+        self._wait_for_eta_scan_in_progress(
+            band, 'run_serial_gradient_descent', timeout)
 
 
     _sel_ext_ref_reg = "SelExtRef"


### PR DESCRIPTION
## Summary

Closes #722.

When `run_serial_gradient_descent` / `run_serial_eta_scan` / `run_serial_min_search` trigger a firmware Process that fails (e.g. raises in rogue), the firmware leaves `etaScanInProgress` stuck at `1`. Every subsequent serial scan on that band then hangs on `_wait_for(monitorPV, lambda x: x == 0)` until the system is manually reset. This is the failure mode @jlashner reported in #722.

This PR wraps the `_wait_for()` in all three commands with a shared helper that, on `TimeoutError`:
- logs a clear `LOG_ERROR` pointing the user at the rogue server logs;
- best-effort force-clears `etaScanInProgress` to `0` so subsequent eta-scan / gradient-descent / min-search calls are no longer blocked;
- re-raises so the caller knows the operation did not complete.

Also adds `set_eta_scan_in_progress()` as an explicit recovery setter (previously only the getter existed).

## Context — relationship to cryo-det PR #60

cryo-det [PR #60](https://github.com/slaclab/cryo-det/pull/60) (commit [`175e67c`](https://github.com/slaclab/cryo-det/commit/175e67c86baa4a5b2b7ceb8b25ea08d0161d3450), merged 2026-03-20) already replaced the `SerialGradientDescent` algorithm with a Barzilai–Borwein method, eliminating the LMS-runaway momentum/cache update that was the original `OverflowError: int too big to convert` trigger reported in #722. The dominant cause is therefore gone in current firmware. This PR closes the **remaining pysmurf-side gap**: any future firmware-side abort (whether from the residual edge case in the new BB algorithm or from any other rogue-side exception) no longer leaves the band unusable.

## Changes

`python/pysmurf/client/command/smurf_command.py`:
- Add `set_eta_scan_in_progress(band, val, **kwargs)` next to the existing getter.
- Add private `_wait_for_eta_scan_in_progress(band, op_name, timeout)` helper.
- Replace the inline `_wait_for(monitorPV, ...)` in `run_serial_eta_scan`, `run_serial_min_search`, and `run_serial_gradient_descent` with calls to the new helper.

`run_parallel_eta_scan` is intentionally left unchanged — it has no `timeout` argument and currently waits forever; adding recovery there would be a behaviour change beyond the scope of #722.

Diff: 1 file changed, 39 insertions(+), 7 deletions(-).

## Verification

- `flake8 --count python/` (the CI check) → 0 errors.
- Static review only — no smurf hardware available in this environment, so the timeout path was not exercised against real firmware. The success path is unchanged (same `_caput` + wait pattern, just routed through a helper).

## Out of scope

- Restoring `amplitudeScale` after a failure. The firmware `_process` zeroes the per-channel amplitude scale array at the start and only restores it at the end; on abort it is left zeroed. Restoring it from pysmurf would require reading it before triggering, which is a behaviour change for the success path too. Worth a separate decision.
- The new BB algorithm in cryo-det itself.