### PR TITLE
fix(set_ramp_rate): Reject 15 kHz flux ramp reset rate (#712)

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -3872,7 +3872,9 @@ class SmurfCommandMixin(SmurfBase):
         flux ramp sawtooth reset rate in kHz
 
         If using timing system, the allowed rates are: 1, 2, 3, 4, 5,
-        6, 8, 10, 12, 15kHz (hardcoded by timing)
+        6, 8, 10, 12 kHz (hardcoded by timing).  15 kHz is excluded
+        because it does not integer-divide 25.6 MHz, which produces
+        malformed flux ramp signals (see slaclab/pysmurf#712).
         """
         rate_sel = self.flux_ramp_rate_to_PV(val)
 
@@ -3885,7 +3887,7 @@ class SmurfCommandMixin(SmurfBase):
             print(
                 "Rate requested is not allowed by timing" +
                 "triggers. Allowed rates are 1, 2, 3, 4, 5, 6, 8, 10," +
-                "12, 15kHz only")
+                "12 kHz only")
 
     def get_ramp_rate(self, **kwargs):
         """

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -3242,13 +3242,24 @@ class SmurfUtilMixin(SmurfBase):
         for the timing triggers.
 
         Hardcoded somewhere that we can't access; this is just a lookup table
-        Allowed reset rates (kHz): 1, 2, 3, 4, 5, 6, 8, 10, 12, 15
+        Allowed reset rates (kHz): 1, 2, 3, 4, 5, 6, 8, 10, 12
+
+        15 kHz is intentionally excluded because it does not integer-divide
+        the 25.6 MHz internal rate, which produces malformed flux ramp
+        signals (see slaclab/pysmurf#712).
 
         Returns:
         rate_sel (int): the rate sel PV for the timing trigger
         """
 
         rates_kHz = np.array([15, 12, 10, 8, 6, 5, 4, 3, 2, 1])
+
+        if val == 15:
+            self.log(
+                "Reset rate of 15 kHz is not allowed because it does not"
+                " integer-divide 25.6 MHz. Allowed rates are 1, 2, 3, 4,"
+                " 5, 6, 8, 10, 12 kHz.")
+            return
 
         try:
             idx = np.where(rates_kHz == val)[0][0] # weird numpy thing sorry


### PR DESCRIPTION
## Summary

Closes #712.

15 kHz does not integer-divide the 25.6 MHz internal rate that drives the flux ramp, so selecting it produces malformed sawtooth signals. The current `flux_ramp_rate_to_PV` lookup table accepts it anyway, exposing it as a valid timing-system rate to users.

This PR:

- Rejects 15 kHz in `flux_ramp_rate_to_PV` (`python/pysmurf/client/util/smurf_util.py`) with a descriptive log message naming the divisibility constraint and listing the allowed rates (1, 2, 3, 4, 5, 6, 8, 10, 12 kHz).
- Leaves the PV-index lookup table intact so `flux_ramp_PV_to_rate` still correctly decodes hardware state that may have been programmed externally to PV index 0.
- Updates the docstring and user-facing error message in `set_ramp_rate` (`python/pysmurf/client/command/smurf_command.py`) to drop 15 kHz and reference the underlying constraint.

This is the "easy fix" called out in the issue. The "smarter fix" (programmatically validate the requested rate against both 25.6 MHz and 122.88 MHz) was not implemented because by that rule 3, 6, and 12 kHz would also be rejected, but the issue author explicitly listed those as empirically valid.

## Test plan

- [x] `flake8 --count python/pysmurf/client/util/smurf_util.py python/pysmurf/client/command/smurf_command.py` passes (matches the CI invocation in `.github/workflows/test-or-deploy.yml`).
- [ ] CI: flake8, docker definitions, docs build.
- [ ] Manual: `S.set_ramp_rate(15)` no longer programs the timing trigger and instead logs the rejection message.
- [ ] Manual: `S.set_ramp_rate(12)` (and other allowed rates) still program the timing trigger as before.