### PR TITLE
fix(logging): Replace remaining print() calls with self.log() (#698)

### DIFF
--- a/python/pysmurf/client/util/SmurfFileReader.py
+++ b/python/pysmurf/client/util/SmurfFileReader.py
@@ -104,7 +104,8 @@ class SmurfHeader(SmurfHeaderTuple):
 
 class SmurfStreamReader(object):
 
-    def __init__(self, files, *, isRogue=True, metaEnable=False, chanCount=None):
+    def __init__(self, files, *, isRogue=True, metaEnable=False, chanCount=None,
+                 log_callback=print):
         self._isRogue    = isRogue
         self._metaEnable = metaEnable
         self._chanCount  = chanCount
@@ -116,6 +117,7 @@ class SmurfStreamReader(object):
         self._config     = {}
         self._currCount  = 0
         self._totCount   = 0
+        self._log        = log_callback
 
         if isinstance(files,list):
             self._fileList = files
@@ -260,16 +262,16 @@ class SmurfStreamReader(object):
             self._currFName = fn
             self._currCount = 0
 
-            print(f"Processing data records from {self._currFName}")
+            self._log(f"Processing data records from {self._currFName}")
             with open(fn,'rb') as f:
                 self._currFile = f
 
                 while self._nextRecord():
                     yield (self._header, self._data)
 
-            print(f"Processed {self._currCount} data records from {self._currFName}")
+            self._log(f"Processed {self._currCount} data records from {self._currFName}")
 
-        print(f"Processed a total of {self._totCount} data records")
+        self._log(f"Processed a total of {self._totCount} data records")
 
     @property
     def currCount(self):

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -462,11 +462,9 @@ class SmurfUtilMixin(SmurfBase):
 
         processing_delay_us=dsp_delay_us-cable_delay_us
 
-        print('-------------------------------------------------------')
-        print(f'Estimated cable_delay_us={cable_delay_us}')
-        print(f'Estimated dsp_delay_us={dsp_delay_us}')
-        print(f'Estimated processing_delay_us={processing_delay_us}')
-        print('-------------------------------------------------------')
+        self.log(f'Estimated cable_delay_us={cable_delay_us}')
+        self.log(f'Estimated dsp_delay_us={dsp_delay_us}')
+        self.log(f'Estimated processing_delay_us={processing_delay_us}')
 
         #### done measuring dsp delay (cable+processing)
 
@@ -1221,7 +1219,8 @@ class SmurfUtilMixin(SmurfBase):
             # data structures will be build based on that
             first_read = True
             with SmurfStreamReader(datafile,
-                    isRogue=True, metaEnable=True) as file:
+                    isRogue=True, metaEnable=True,
+                    log_callback=self.log) as file:
                 for header, data in file.records():
                     if first_read:
                         # Update flag, so that we don't do this code again


### PR DESCRIPTION
## Summary

Closes #698.

The issue (open since 2022-01-05) flagged two specific blocks of `print()` calls that bypass the pysmurf logger and therefore cannot be redirected to a logfile. This PR routes them through `self.log()` / a passed-in log callback.

### Changes

`python/pysmurf/client/util/smurf_util.py`
- `estimate_phase_delay()` (cited as L351-355 in the issue, currently L465-469): 5 `print()` calls → 3 `self.log(...)` calls. The dashed separator lines are dropped as logfile noise.
- `read_stream_data()` (L1221): the single in-tree `SmurfStreamReader(...)` caller now passes `log_callback=self.log`.

`python/pysmurf/client/util/SmurfFileReader.py`
- `SmurfStreamReader.__init__`: new keyword-only `log_callback=print` kwarg + `self._log = log_callback`. The `print` default preserves existing standalone behaviour for any out-of-tree consumers of this exported class.
- `records()` (cited L263-272): the 3 `Processing data records.../Processed N data records.../Processed a total of N` prints are routed through `self._log`.

### Out of scope

The 7 warning/error prints elsewhere in `SmurfFileReader.py` (`Waring:`/`Warning:` lines at L166, L178, L190, L198, L203, L233, L238) are intentionally untouched — issue #698 explicitly excludes them from scope ("with the exception of some warnings and errors").

### Prior art

An abandoned 2022 branch (`origin/698`, commit `dcd90899`, never merged) attempted a fix but contained a Python syntax error (`self.log` passed positionally after kwargs in `read_stream_data`) and converted only some of the prints called out in the issue. This PR implements the fix from scratch.

Diff: 2 files changed, 11 insertions(+), 10 deletions(-).

## Verification

- `flake8 --count python/` → **0 errors** (matches CI in `.github/workflows/test-or-deploy.yml`)
- `grep -rn "SmurfStreamReader(" python/ docs/` → only the class def + the one updated caller
- Module-level signature smoke test confirms `log_callback=print` default and that all pre-existing kwargs (`isRogue`, `metaEnable`, `chanCount`) are preserved

Hardware verification (logfile redirection of `read_stream_data` and `estimate_phase_delay`) requires a SMuRF crate, so it's left to the user.

## Test plan

- [x] `flake8 --count python/` passes with 0 errors
- [x] Static call-site sweep confirms only the one in-tree caller of `SmurfStreamReader` and that it has been updated
- [x] `SmurfStreamReader.__init__` signature smoke-tested without hardware
- [ ] CI: flake8, docker definitions, docs build
- [ ] Manual on hardware: with `S.set_logfile(<path>)` configured, `S.read_stream_data(<datafile>)` writes "Processing data records...", "Processed N data records...", and "Processed a total of N data records" to the logfile rather than stdout
- [ ] Manual on hardware: `S.estimate_phase_delay(band, ...)` writes the three `Estimated *_delay_us=...` lines to the logfile rather than stdout
- [ ] Manual on hardware: `Waring:`/`Warning:` prints in `SmurfStreamReader._nextRecord` still appear on stdout (intentionally unchanged per issue scope)