### PR TITLE
fix(full_band_ampl_sweep): Actually use n_read by averaging multiple sweeps

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3679,17 +3679,20 @@ class SmurfTuneMixin(SmurfBase):
         #
         self.set_eta_scan_freq(band, freq_scan.flatten())
         self.set_eta_scan_amplitude(band, tone_power)
-        self.set_run_serial_find_freq(band, 1)
 
-        I = self.get_eta_scan_results_real(band, count=n_step*n_channels)
-        I = np.asarray(I)
-        I = I.reshape(n_channels, n_step)
+        resp_accum = np.zeros((int(n_read), n_channels, n_step), dtype=complex)
+        for n in range(int(n_read)):
+            self.set_run_serial_find_freq(band, 1)
 
-        Q = self.get_eta_scan_results_imag(band, count=n_step*n_channels)
-        Q = np.asarray(Q)
-        Q = Q.reshape(n_channels, n_step)
+            I = self.get_eta_scan_results_real(band, count=n_step*n_channels)
+            I = np.asarray(I).reshape(n_channels, n_step)
 
-        resp_scan = I + 1j*Q
+            Q = self.get_eta_scan_results_imag(band, count=n_step*n_channels)
+            Q = np.asarray(Q).reshape(n_channels, n_step)
+
+            resp_accum[n] = I + 1j*Q
+
+        resp_scan = np.mean(resp_accum, axis=0)
 
         for sb in subband:
             subchan    = first_channel_per_subband[sb]


### PR DESCRIPTION
## Summary
- Closes #638. The `n_read` parameter of `full_band_ampl_sweep` was accepted in the signature and documented in the docstring as "Numbers of times to sweep", but never referenced inside the function body. The sweep was always executed exactly once, so `find_freq` (default `n_read=2`) was silently doing one sweep where the API contract promised two.
- Hoisted `set_eta_scan_freq` / `set_eta_scan_amplitude` out of the read path (they don't change between reads), wrapped the `set_run_serial_find_freq` trigger + I/Q readback in a loop of length `n_read`, accumulated into a `(n_read, n_channels, n_step)` complex array, and averaged with `np.mean(axis=0)`.
- Mirrors the existing `full_band_resp` pattern (allocate per-read array → loop → mean).

## Behavior
- `n_read=1` is bit-exact with prior behavior (mean over a length-1 axis returns the single sample), so any caller passing 1 sees no change.
- `n_read>1` now actually averages, which is what the docstring (and `find_freq`'s default of 2) has always promised.

## Test plan
- [x] `flake8 --count python/` returns 0 (matches CI invocation in `.github/workflows/test-or-deploy.yml`)
- [x] Static review: `n_read` is now consumed inside the function body, downstream `resp_scan` consumer at the bottom of the function is unchanged
- [ ] Hardware smoke: run `find_freq` with default `n_read=2` and confirm the resonator search behaves at least as well as before (averaging should reduce noise in the response array used for peak finding)