### PR TITLE
fix(setup_notches): Avoid writing duplicate channel_assignment file (#618)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -1634,7 +1634,7 @@ class SmurfTuneMixin(SmurfBase):
     @set_action()
     def assign_channels(self, freq, band=None, bandcenter=None,
             channel_per_subband=4, as_offset=True, min_offset=0.1,
-            new_master_assignment=False):
+            new_master_assignment=False, save_master_assignment=True):
         """
         Figures out the subbands and channels to assign to resonators
 
@@ -1655,6 +1655,12 @@ class SmurfTuneMixin(SmurfBase):
         min_offset : float, optional, default 0.1
             The minimum offset between two resonators in MHz.  If
             closer, then both are ignored.
+        save_master_assignment : bool, optional, default True
+            Whether to write the new master assignment to disk.  Only
+            meaningful when ``new_master_assignment=True``.  Set to
+            False to compute the assignment without persisting a
+            channel_assignment file (used by ``setup_notches`` for its
+            pre-eta-scan call to avoid producing a redundant file).
 
         Returns
         -------
@@ -1735,7 +1741,8 @@ class SmurfTuneMixin(SmurfBase):
             channels[~close_idx] = -1
 
             # write the channel assignments to file
-            self.write_master_assignment(band, freq, subbands, channels)
+            if save_master_assignment:
+                self.write_master_assignment(band, freq, subbands, channels)
 
         return subbands, channels, offsets
 
@@ -3965,7 +3972,8 @@ class SmurfTuneMixin(SmurfBase):
 
         subbands, channels, offsets = self.assign_channels(input_res, band=band,
             as_offset=False, min_offset=min_offset,
-            new_master_assignment=new_master_assignment)
+            new_master_assignment=new_master_assignment,
+            save_master_assignment=False)
 
         f_sweep = np.arange(-sweep_width, sweep_width, df_sweep)
         n_step  = len(f_sweep)


### PR DESCRIPTION
## Summary
- `setup_notches` calls `assign_channels` twice -- once before the eta scans to lay out channels for the serial sweep, and again afterward using the refined eta-scan frequencies. Both calls received the same `new_master_assignment` flag, so when `True` each call wrote a `*_channel_assignment_b{band}.txt` file. The first file was immediately stale and superseded by the second.
- Adds a `save_master_assignment` kwarg (default `True`) to `assign_channels` that gates the `write_master_assignment(...)` call. The pre-eta-scan call in `setup_notches` now passes `False`; the post-eta-scan call keeps the default and produces the canonical file.
- Other callers (`tune_band`, `tune_band_serial`) are unchanged via the default. Resolves the crash mode noted in the issue thread (where switching the first call to `new_master_assignment=False` would fail on a fresh setup) by leaving the assignment computation alone and only suppressing the redundant disk write.

Closes #618.

## Test plan
- [x] `flake8 --count python/` passes (0 errors), matching the CI flake8 gate.
- [x] File parses (`python -c "import ast; ast.parse(...)"`).
- [x] Static check: only the pre-eta-scan call site in `setup_notches` passes the new kwarg; all other callers use the default.
- [ ] Hardware-in-the-loop on a SMuRF system: call `setup_notches(band, new_master_assignment=True)` and confirm exactly **one** `*_channel_assignment_b{band}.txt` is written for that timestamp window.
- [ ] Hardware-in-the-loop: call `setup_notches(band, new_master_assignment=False)` against an existing master assignment and confirm no new channel-assignment file is written and no crash occurs.
- [ ] Confirm the surviving file's frequencies match the post-eta-scan refined `resonances[k]['freq']` values, not the raw `find_freq` peaks.