### PR TITLE
fix(SmurfControl): Allow loading cfg_file in offline mode (#609)

### DIFF
--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -249,12 +249,20 @@ class SmurfControl(SmurfCommandMixin,
             else:
                 self.log.set_logfile(None)
 
-            # Which bays were enabled on pysmurf server startup?
-            self.bays = self.which_bays()
+            if not self.offline:
+                # Which bays were enabled on pysmurf server startup?
+                self.bays = self.which_bays()
 
-            # Crate/carrier configuration details that won't change.
-            self.crate_id = self.get_crate_id()
-            self.slot_number = self.get_slot_number()
+                # Crate/carrier configuration details that won't change.
+                self.crate_id = self.get_crate_id()
+                self.slot_number = self.get_slot_number()
+            else:
+                # Offline: no hardware to query. Derive bays from the
+                # config-defined bands so downstream band/bay validation
+                # is consistent.
+                self.bays = sorted({b // 4 for b in self._bands})
+                self.crate_id = None
+                self.slot_number = None
 
             # Channel assignment files
             self.channel_assignment_files = {}


### PR DESCRIPTION
## Summary
- Fixes [#609](https://github.com/slaclab/pysmurf/issues/609) — `SmurfControl(offline=True, cfg_file=<path>)` previously crashed during `initialize()`.
- `which_bays()`, `get_crate_id()` and `get_slot_number()` resolve to `_caget()`, which returns `None` in offline mode; the next `for bay in self.bays` then raised `TypeError: argument of type 'NoneType' is not iterable`.
- Skip those three register reads when `self.offline` is `True` and derive `self.bays` from the config-defined `self._bands` (`bay = band // 4`) so the downstream band/bay validation stays consistent. `crate_id` / `slot_number` are set to `None`. The online path is byte-identical.

## Test plan
- [x] Reproduced the original crash on `main` with `SmurfControl(offline=True, cfg_file=<cfg>)` → `TypeError`.
- [x] Re-ran with the patch applied: construction succeeds; `S.R_sh`, `S.pA_per_phi0`, `S.bays`, `S.crate_id`, `S.slot_number` all populated as expected.
- [x] `flake8 --count python/` clean (matches CI invocation).
- [x] Client smoke import (`python -c 'import matplotlib; matplotlib.use("Agg"); import pysmurf.client'`) passes.
- [ ] Online regression covered by existing CI.

## Out of scope

- Making `setup()` offline-safe (not requested by #609; offline users don't pass `setup=True`).
- Refactoring `which_bays`/`get_crate_id`/`get_slot_number` themselves to be offline-aware — extra surface area, not needed.
- Changes to `base_class.py` — already handled by commit `16b44046`.

Reviewers: flag any of the above as in-scope and we can fold it into this PR.