### PR TITLE
fix(assign_channels): Handle empty frequency array (#558)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -1671,6 +1671,13 @@ class SmurfTuneMixin(SmurfBase):
             self.log('Must have band or bandcenter', self.LOG_ERROR)
             raise ValueError('Must have band or bandcenter')
 
+        if len(freq) == 0:
+            self.log('assign_channels called with empty frequency array;' +
+                     ' no channels will be assigned.', self.LOG_USER)
+            return (np.zeros(0, dtype=int),
+                    -1 * np.ones(0, dtype=int),
+                    np.zeros(0))
+
         subbands = np.zeros(len(freq), dtype=int)
         channels = -1 * np.ones(len(freq), dtype=int)
         offsets = np.zeros(len(freq))


### PR DESCRIPTION
## Summary
- Fixes #558. `S.setup_notches(band, new_master_assignment=True)` crashed inside `assign_channels` when no resonators were found.
- Root cause: with empty `freq`, `np.diff(freq)` is length 0, but `np.hstack` prepends/appends a single `True`, so `close_idx` becomes length 1 while `channels` is length 0 — `channels[~close_idx] = -1` raises `IndexError`.
- Adds an early-return guard at the top of `assign_channels` returning empty arrays of the correct dtype and logging a user-visible message, matching the reporter's request to "report error but continue."

## Test plan
- [x] `flake8 --count python/` reports 0 (matches CI in `.github/workflows/test-or-deploy.yml`).
- [x] Reproduced the original `IndexError: boolean index did not match indexed array along dimension 0` offline.
- [x] Verified the patched function returns `(int64[0], int64[0], float64[0])` and emits a `LOG_USER` message instead of crashing.
- [ ] On-system smoke test: call `S.setup_notches(band, new_master_assignment=True)` on a band with no resonators and confirm the call returns cleanly with the new log line.