### PR TITLE
fix(all_off): Re-enable RTM DACs to recover from pinned state (#545)

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -3717,6 +3717,13 @@ class SmurfUtilMixin(SmurfBase):
     def all_off(self):
         """
         Turns off everything. Does band off, flux ramp off, then TES bias off.
+
+        Passes ``do_enable=True`` to ``set_tes_bias_off`` so the AD5790
+        control register is re-asserted to 0x2 (enable, normal operation)
+        before zeroing the data register. This recovers DACs that have
+        gotten into an indeterminate state (pinned full-scale negative);
+        writing the data register alone is not always sufficient to
+        unstick them. See issue #545.
         """
         self.log('Turning off tones')
         bands = self._bands
@@ -3727,7 +3734,7 @@ class SmurfUtilMixin(SmurfBase):
         self.flux_ramp_off()
 
         self.log('Turning off all TES biases')
-        self.set_tes_bias_off()
+        self.set_tes_bias_off(do_enable=True)
 
 
     def mask_num_to_gcp_num(self, mask_num):


### PR DESCRIPTION
## Summary

- Closes #545. `all_off()` now re-asserts the AD5790 control register before zeroing the data register, so RTM TES bias DACs that have gotten stuck pinned full-scale negative are recovered to normal operation.
- One-line change: `set_tes_bias_off()` → `set_tes_bias_off(do_enable=True)` in `all_off()`. `set_tes_bias_bipolar_array(do_enable=True)` reads the current 32-DAC enable array, sets only the TES-bias-group DAC indices to `0x2`, and writes it back — non-TES-bias DACs (HEMT gate, 50K bias, C04 drain DACs) are preserved.
- This matches the existing recovery pattern documented in `set_amp_defaults` (smurf_command.py:4622-4636: *"send enable, 0x2, to all gate voltages and drain voltages, otherwise they cannot be controlled, even if the current register reports that they are supposedly enabled"*) and `scratch/shawn/cryocard_c03_setup.py`.
- The firmware-side fix in `MicrowaveMuxBpEthGen2_v1.1.1` (commit ee370aaf) prevents railing during `setDefaults`, but standalone `all_off()` invocations from the CLI (`smurf_cmd --all_off`) or user scripts still need a software-side recovery path.

## Test plan

- [x] `flake8 --count python/` passes (matches CI config in `.github/workflows/test-or-deploy.yml`).
- [ ] Hardware: force RTM DACs into pinned-negative state, confirm pre-fix `S.all_off()` standalone leaves outputs at full-scale negative.
- [ ] Hardware: with fix applied, confirm `S.all_off()` standalone restores all TES bias DAC outputs to 0 V (verify via `S.get_rtm_slow_dac_volt_array()`).
- [ ] Hardware: confirm non-TES-bias DACs (HEMT, 50K, drain) retain prior enable state and voltages across the call.
- [ ] Hardware: confirm `S.setup()` end-to-end still completes (existing `cpld_toggle()` → `all_off()` sequence at `smurf_control.py:648-650` is unaffected).
- [ ] CLI: `smurf_cmd --all_off` exits cleanly with TES bias DACs reading 0 V.