### PR TITLE
fix(rtm_slow_dac): Make DAC chip parameters configurable (#543)

### DIFF
--- a/cfg_files/template/template.cfg
+++ b/cfg_files/template/template.cfg
@@ -145,6 +145,14 @@
 "bias_line_resistance" : 15800,
 "high_low_current_ratio" : 6.08,
 
+# RTM slow DAC chip parameters.  Defaults match the AD5790 with a 10V
+# reference voltage on standard RTM revisions.  Override only if your
+# RTM uses a different DAC chip or reference voltage.
+# "rtm_slow_dac": {
+#         "rtm_slow_dac_max_volt": 10.0,
+#         "rtm_slow_dac_nbits": 20
+# },
+
 "high_current_mode_bool": 0,
 
 "all_bias_groups": [7],

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -235,15 +235,22 @@ class SmurfBase:
 
         self.freq_resp = {}
 
-        # RTM slow DAC parameters (used, e.g., for TES biasing). The
-        # DACs are AD5790 chips
-        self._rtm_slow_dac_max_volt = 10. # Max unipolar DAC voltage,
-                                        # in Volts
-        self._rtm_slow_dac_nbits = 20
+        # RTM slow DAC parameters (used, e.g., for TES biasing).
+        # Defaults match the AD5790 chips on standard RTMs with a
+        # 10V reference voltage.  Override via the `rtm_slow_dac`
+        # section of the pysmurf configuration file for boards that
+        # use a different DAC chip or reference voltage.  Values may
+        # have already been set by SmurfConfigPropertiesMixin from
+        # the cfg file, in which case those win.
+        if getattr(self, '_rtm_slow_dac_max_volt', None) is None:
+            self._rtm_slow_dac_max_volt = 10.
+        if getattr(self, '_rtm_slow_dac_nbits', None) is None:
+            self._rtm_slow_dac_nbits = 20
         # x2 because _rtm_slow_dac_max_volt is the maximum *unipolar*
         # voltage.  Units of Volt/bit
-        self._rtm_slow_dac_bit_to_volt = (2*self._rtm_slow_dac_max_volt/
-                                          (2**(self._rtm_slow_dac_nbits)))
+        self._rtm_slow_dac_bit_to_volt = (
+            2 * self._rtm_slow_dac_max_volt /
+            (2 ** self._rtm_slow_dac_nbits))
 
         # LUT table length for arbitrary waveform generation
         self._lut_table_array_length = 2048

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -733,6 +733,25 @@ class SmurfConfig:
         }
         #### Done specifying flux-ramp related
 
+        #### Start specifying RTM slow DAC schema
+        # Defaults match the AD5790 DAC chips on standard RTMs with
+        # a 10V reference voltage.  Override only on RTMs that use
+        # a different DAC chip or reference voltage.
+        rtm_slow_dac_defaults = {
+            'rtm_slow_dac_max_volt': 10.,
+            'rtm_slow_dac_nbits': 20,
+        }
+        rsd_key = Optional('rtm_slow_dac', default=rtm_slow_dac_defaults)
+        schema_dict[rsd_key] = {
+            Optional('rtm_slow_dac_max_volt',
+                     default=rtm_slow_dac_defaults['rtm_slow_dac_max_volt']):
+                And(Use(float), lambda f: f > 0),
+            Optional('rtm_slow_dac_nbits',
+                     default=rtm_slow_dac_defaults['rtm_slow_dac_nbits']):
+                And(int, lambda n: n > 0),
+        }
+        #### Done specifying RTM slow DAC schema
+
         #### Start specifying constants schema
         # If all of a schema dictionary's keys are optional, must specify
         # them both in the schema key for that dictionary, and in the

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -155,6 +155,11 @@ class SmurfConfigPropertiesMixin:
         self._fraction_full_scale = None
         self._reset_rate_khz = None
 
+        # RTM slow DAC (AD5790 by default)
+        self._rtm_slow_dac_max_volt = None
+        self._rtm_slow_dac_nbits = None
+        self._rtm_slow_dac_bit_to_volt = None
+
         # Cryocard
         self._bias_line_resistance = None
         self._high_low_current_ratio = None
@@ -328,6 +333,11 @@ class SmurfConfigPropertiesMixin:
         self.num_flux_ramp_counter_bits = flux_ramp_cfg['num_flux_ramp_counter_bits']
         self.reset_rate_khz = tune_band_cfg.get('reset_rate_khz')
         self.fraction_full_scale = tune_band_cfg.get('fraction_full_scale')
+
+        ## RTM slow DAC
+        rtm_slow_dac_cfg = config.get('rtm_slow_dac') or {}
+        self.rtm_slow_dac_max_volt = rtm_slow_dac_cfg.get('rtm_slow_dac_max_volt')
+        self.rtm_slow_dac_nbits = rtm_slow_dac_cfg.get('rtm_slow_dac_nbits')
 
         ## Cryocard
         self.bias_line_resistance = config.get('bias_line_resistance')
@@ -1403,6 +1413,98 @@ class SmurfConfigPropertiesMixin:
         self._reset_rate_khz = value
 
     ## End reset_rate_khz property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start RTM slow DAC property definitions
+
+    def _recompute_rtm_slow_dac_bit_to_volt(self):
+        """Recompute the bit-to-volt scaling when both inputs are set."""
+        if (self._rtm_slow_dac_max_volt is not None and
+                self._rtm_slow_dac_nbits is not None):
+            # x2 because _rtm_slow_dac_max_volt is the maximum *unipolar*
+            # voltage.  Units of Volt/bit.
+            self._rtm_slow_dac_bit_to_volt = (
+                2 * self._rtm_slow_dac_max_volt /
+                (2 ** self._rtm_slow_dac_nbits))
+
+    @property
+    def rtm_slow_dac_max_volt(self):
+        """Maximum unipolar voltage of the RTM slow DAC chips, in Volts.
+
+        Gets or sets the maximum unipolar output voltage of the RTM
+        slow DACs (used, e.g., for TES biasing).  The DAC range is
+        bipolar: ``[-rtm_slow_dac_max_volt, +rtm_slow_dac_max_volt]``.
+        Default is 10 V, which corresponds to the AD5790 chips on
+        standard RTMs with a 10 V reference voltage.
+
+        Setting this property automatically recomputes
+        :attr:`rtm_slow_dac_bit_to_volt`.
+
+        Specified in the pysmurf configuration file as
+        `rtm_slow_dac:rtm_slow_dac_max_volt`.
+
+        Returns
+        -------
+        float
+           Maximum unipolar RTM slow DAC voltage in Volts.
+
+        """
+        return self._rtm_slow_dac_max_volt
+
+    @rtm_slow_dac_max_volt.setter
+    def rtm_slow_dac_max_volt(self, value):
+        self._rtm_slow_dac_max_volt = value
+        self._recompute_rtm_slow_dac_bit_to_volt()
+
+    @property
+    def rtm_slow_dac_nbits(self):
+        """Number of bits of the RTM slow DAC chips.
+
+        Gets or sets the bit depth of the RTM slow DACs.  Default is
+        20, the resolution of the AD5790 chip on standard RTMs.
+
+        Setting this property automatically recomputes
+        :attr:`rtm_slow_dac_bit_to_volt`.
+
+        Specified in the pysmurf configuration file as
+        `rtm_slow_dac:rtm_slow_dac_nbits`.
+
+        Returns
+        -------
+        int
+           RTM slow DAC bit depth.
+
+        """
+        return self._rtm_slow_dac_nbits
+
+    @rtm_slow_dac_nbits.setter
+    def rtm_slow_dac_nbits(self, value):
+        self._rtm_slow_dac_nbits = value
+        self._recompute_rtm_slow_dac_bit_to_volt()
+
+    @property
+    def rtm_slow_dac_bit_to_volt(self):
+        """Bits-to-Volts conversion factor for the RTM slow DACs.
+
+        Derived from :attr:`rtm_slow_dac_max_volt` and
+        :attr:`rtm_slow_dac_nbits` as
+        ``2 * rtm_slow_dac_max_volt / 2**rtm_slow_dac_nbits``.
+        Units are Volts/bit.
+
+        Returns
+        -------
+        float
+           RTM slow DAC bit-to-volt conversion factor in V/bit.
+
+        """
+        return self._rtm_slow_dac_bit_to_volt
+
+    @rtm_slow_dac_bit_to_volt.setter
+    def rtm_slow_dac_bit_to_volt(self, value):
+        self._rtm_slow_dac_bit_to_volt = value
+
+    ## End RTM slow DAC property definitions
     ###########################################################################
 
     ###########################################################################

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -4316,11 +4316,14 @@ class SmurfCommandMixin(SmurfBase):
 
         volt = self._rtm_slow_dac_bit_to_volt * self.get_rtm_slow_dac_data(dac, **kwargs)
 
-        if volt > 9.9:
-            self.log(f'Looks like DAC {dac} is close to max +10V output, {volt}V.')
+        warn_thresh = 0.99 * self._rtm_slow_dac_max_volt
+        if volt > warn_thresh:
+            self.log(f'Looks like DAC {dac} is close to max '
+                     f'+{self._rtm_slow_dac_max_volt}V output, {volt}V.')
 
-        if volt < -9.9:
-            self.log(f'Looks like DAC {dac} is close to min -10V output, {volt}V.')
+        if volt < -warn_thresh:
+            self.log(f'Looks like DAC {dac} is close to min '
+                     f'-{self._rtm_slow_dac_max_volt}V output, {volt}V.')
 
         return volt
 


### PR DESCRIPTION
## Summary

Closes #543.

The RTM slow DAC parameters (`_rtm_slow_dac_max_volt`, `_rtm_slow_dac_nbits`, derived `_rtm_slow_dac_bit_to_volt`) were hardcoded in `SmurfBase.__init__` to AD5790 / 10 V reference values. RTMs using a different DAC chip or reference voltage produced silently wrong physical units in TES bias commands, IV curves, and TES bipolar waveform playback. The `±9.9 V` soft-warning thresholds in `get_rtm_slow_dac_volt` were similarly baked in.

This PR exposes `rtm_slow_dac_max_volt` and `rtm_slow_dac_nbits` through the existing `SmurfConfigPropertiesMixin` / cfg-schema pattern (same approach as `pA_per_phi0`, `hemt_bit_to_V`, `fraction_full_scale`, etc.). Defaults match the AD5790 with a 10 V reference, so existing cfg files and offline mode are unaffected.

### Changes

- **`smurf_config.py`** — new `rtm_slow_dac` schema block with AD5790 defaults and validators (`max_volt > 0`, `nbits > 0`).
- **`smurf_config_properties.py`** — three new underscore attrs in `__init__`, loader call in `copy_config_to_properties`, and `@property` getter/setters for `rtm_slow_dac_max_volt`, `rtm_slow_dac_nbits`, and the derived `rtm_slow_dac_bit_to_volt`. Setting either input recomputes `bit_to_volt` automatically.
- **`base_class.py`** — old unconditional hardcode replaced with a fallback-only block that respects values already populated by the mixin/cfg path. Offline / standalone usage still gets the AD5790 defaults bit-for-bit.
- **`smurf_command.py`** — `±9.9 V` warning thresholds in `get_rtm_slow_dac_volt` now derived as `0.99 * _rtm_slow_dac_max_volt`, so they auto-scale to the configured DAC range.
- **`cfg_files/template/template.cfg`** — commented-out documentation block. Existing site cfgs (b33, kx, lab1, nist, pton, rflab, slac, stanford, ucsd) need no changes — schema injects defaults invisibly.

### Backward compatibility

Verified bit-for-bit: with no `rtm_slow_dac` entry in the cfg, `_rtm_slow_dac_bit_to_volt` evaluates to the exact same `2*10./2**20` value as before.

## Test plan

- [x] `flake8 --count python/` (CI's invocation) — 0 errors
- [x] Schema injects AD5790 defaults when cfg lacks `rtm_slow_dac` block
- [x] Full override `{rtm_slow_dac_max_volt: 5.0, rtm_slow_dac_nbits: 16}` round-trips through schema + mixin
- [x] Partial override (only `max_volt`) keeps the other field at its default
- [x] Invalid values (`max_volt: -1`, `nbits: 0`) raise `SchemaError`
- [x] Property setter recompute: changing `rtm_slow_dac_max_volt` or `rtm_slow_dac_nbits` at runtime updates `_rtm_slow_dac_bit_to_volt` automatically
- [x] All three `SmurfBase.__init__` paths (cfg-populated mixin / mixin-with-None / standalone-no-mixin) produce correct values
- [x] `0.99 * 10.0 == 9.9` confirms warning threshold matches the old hardcode
- [ ] Hardware regression on a real RTM with default cfg (smoke test, no behavior change expected)