### PR TITLE
feat(setup): Detect cryocard via SPI cycle-count register (#522)

### DIFF
--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -662,18 +662,24 @@ class SmurfControl(SmurfCommandMixin,
             self.set_payload_size(payload_size)
             self.set_channel_mask([0])
 
+            # Detect cryostat card via the SPI cycle-count register
+            # (0x06). The PIC increments this counter on every SPI
+            # read, so a pair of reads must be strictly increasing if
+            # the card is alive. See slaclab/pysmurf#522.
             try:
-                ## Removed this because better error handling for cc
-                ## communication in
-                ## https://github.com/slaclab/pysmurf/pull/794 Causes this
-                ## command to stall and error out on systems with no
-                ## cryostat card connected.
-                ## also read the temperature of the CC
-                self.log(f"Cryocard temperature = {self.C.read_temperature()}")
-
-                # If C02, set the gate voltages to the default.
-                # If C04, also set the drain voltages to zero.
-                self.set_amp_defaults()
+                if self.C.is_present():
+                    self.log(
+                        "Cryocard detected. Temperature = "
+                        f"{self.C.read_temperature()}")
+                    # If C02, set the gate voltages to the default.
+                    # If C04, also set the drain voltages to zero.
+                    self.set_amp_defaults()
+                else:
+                    self.log(
+                        "No cryostat card detected (cycle-count "
+                        "register 0x06 did not increment); skipping "
+                        "cryocard setup steps.",
+                        self.LOG_USER)
             except Exception:
                 self.log("Attempts to communicate with a cryocard "
                          "failed!  Will assume no cryostat card is"

--- a/python/pysmurf/client/command/cryo_card.py
+++ b/python/pysmurf/client/command/cryo_card.py
@@ -225,6 +225,30 @@ class CryoCard():
         data = self.do_read(self.cycle_count_address)
         return (cmd_data(data))  # do we have the right addres
 
+    def is_present(self):
+        """Probe whether a cryostat card is connected and responding.
+
+        Reads the SPI cycle-count register (0x06) twice. The PIC
+        increments this counter on every SPI read, so a strictly
+        increasing pair of values proves the card is alive and the
+        SPI bus is healthy. Any communication error (e.g. ``do_read``
+        exhausting its retries because no card is wired up) is treated
+        as "not present" rather than propagated.
+
+        Returns
+        -------
+        bool
+            True if the second cycle-count read exceeds the first;
+            False on any communication error or non-incrementing reply.
+        """
+        try:
+            first = self.read_cycle_count()
+            second = self.read_cycle_count()
+        except Exception as e:
+            self.log(f"CryoCard.is_present probe failed: {e}")
+            return False
+        return second > first
+
     def write_ps_en(self, enables):
         """
         Write the bits that turn on the drain LDOs. Do not use this

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -5239,18 +5239,19 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_cryo_card_cycle_count(self, enable_poll=False,
                                   disable_poll=False):
-        """
-        No description
+        """Return the cryostat card's SPI cycle-count register (0x06).
+
+        The PIC increments this counter on every SPI read, so successive
+        calls must return strictly increasing values when a cryocard is
+        present and responding. Used by :func:`~pysmurf.client.base.\
+smurf_control.SmurfControl.setup` for cryocard detection.
 
         Returns
         -------
-        cycle_count : float
-            The cycle count.
+        cycle_count : int
+            Number of SPI reads the PIC has serviced.
         """
-        self.log(
-            'Not doing anything because not implemented in '
-            'cryo_card.py')
-        # return self.C.read_cycle_count()
+        return self.C.read_cycle_count()
 
     def get_cryo_card_relays(self, enable_poll=False,
                              disable_poll=False):


### PR DESCRIPTION
## Summary
- Closes #522 — adds explicit cryostat-card detection to `SmurfControl.setup()` by reading SPI register `0x06` (cycle-count) twice and verifying the second read is strictly greater than the first. The SmurfC PIC increments this counter on every SPI read, so a non-incrementing pair definitively proves the card is absent or the SPI bus is down.
- Replaces the implicit "did `read_temperature` throw" heuristic at `python/pysmurf/client/base/smurf_control.py:665` with the cycle-count probe the issue actually asked for.
- New low-level helper: `CryoCard.is_present()` (`python/pysmurf/client/command/cryo_card.py:228`) — two reads of `0x06` via the existing `read_cycle_count()`; swallows `do_read` retries-exhausted and returns `False` on any communication error.
- Un-stubs `SmurfCommandMixin.get_cryo_card_cycle_count()` (`python/pysmurf/client/command/smurf_command.py:5240`) — the public wrapper existed but its body was commented out; now actually calls `self.C.read_cycle_count()`. Docstring tightened (return type is `int`, not `float`).
- Outer `try/except` in `setup()` is retained so offline-mode (`_DummyClient.__getattr__` raises `AttributeError`) still degrades gracefully.

Per the [smurfc SpiRegisterMap docs](https://github.com/slaclab/smurfc/blob/master/README.SpiRegisterMap.md), register `0x06` is read-only and returns the number of SPI reads the PIC has serviced.

## Test plan
- [x] `flake8 --count python/` (matches CI invocation in `.github/workflows/test-or-deploy.yml`) → 0 issues
- [x] `python -m py_compile` on all three touched files → clean
- [ ] Hardware-in-the-loop verification (out of scope for repo CI; recommended before merge):
  - On a healthy crate with a cryocard: `S.setup()` logs `"Cryocard detected. Temperature = ..."` and `set_amp_defaults()` runs; `S.C.is_present()` returns `True`; `S.get_cryo_card_cycle_count()` returns increasing integers on successive calls.
  - On a crate with no cryocard / cable disconnected: `S.setup()` logs `"No cryostat card detected (cycle-count register 0x06 did not increment); skipping cryocard setup steps."` and the rest of `setup()` (timing, stream-enable, etc.) completes without raising.