### PR TITLE
feat(estimate_phase_delay): Add phaseDelaySubbands config field for resonator-free latency fit (#513)

### DIFF
--- a/README.config_file.md
+++ b/README.config_file.md
@@ -12,7 +12,7 @@ The configuration files are stored in the `cfg_files` folder in the pysmurf git 
 4. If you know it, update the `bias_line_resistance` and `R_sh` fields.
 5. Save
 
-You should be able to call this config file when you instantiate your `SmurfControl` object. One of the first steps you'll do is run `estimate_phase_delay`. You can save the outputs into your config file so you will not need to run it in the future. 
+You should be able to call this config file when you instantiate your `SmurfControl` object. One of the first steps you'll do is run `estimate_phase_delay`. You can save the outputs into your config file so you will not need to run it in the future. For best results on detector arrays whose resonator placement is known, populate `phaseDelaySubbands` per band with subbands free of resonators before running it.
 
 # Important Variables
 
@@ -20,8 +20,10 @@ You should be able to call this config file when you instantiate your `SmurfCont
 
 ### band_#
 
-- `refPhaseDelay` - The phase delay parameter. Solve for this using the function `S.estimate_phase_delay(band)`
-- `refPhaseDelayFine` - The fine phase delay parameter. Solve for this using the function `S.estimate_phase_delay(band)`
+- `refPhaseDelay` - DEPRECATED. The phase delay parameter. Solve for this using the function `S.estimate_phase_delay(band)`. Use `bandDelayUs` instead.
+- `refPhaseDelayFine` - DEPRECATED. The fine phase delay parameter. Solve for this using the function `S.estimate_phase_delay(band)`. Use `bandDelayUs` instead.
+- `bandDelayUs` - Total band-level latency compensation in microseconds (analog + DSP). Solve for this using `S.estimate_phase_delay(band)`. Supersedes `refPhaseDelay`/`refPhaseDelayFine`.
+- `phaseDelaySubbands` - Optional list of DSP subband indices that are known to contain no resonators on this hardware. When set, `estimate_phase_delay()` uses these subbands for the DSP latency fit instead of geometrically selecting from its `freq_min`/`freq_max` arguments, avoiding the bias that resonator phase response would otherwise introduce into the linear phase-vs-frequency polyfit. Determining the right subbands is per-array hardware characterization — typically by inspecting a `find_freq` over the full band before tuning.
 - `att_uc` - The upconverter (DAC) attenuator
 - `att_dc` - The downconverter (ADC) attenuator
 - `amplitude_scale` - The probe tone power.

--- a/cfg_files/template/template.cfg
+++ b/cfg_files/template/template.cfg
@@ -8,6 +8,10 @@
 		"iq_swap_in" : 0,
 		"iq_swap_out" : 0,
 		"bandDelayUs" : 8.8,
+		# Optional: subbands known empty of resonators on this hardware,
+		# for a clean estimate_phase_delay() fit.  Omit or null to use
+		# the legacy geometric selection from freq_min/freq_max.
+		# "phaseDelaySubbands" : [50, 51, 52],
 		"trigRstDly" : 15, # 0xF
 		"feedbackEnable": 1,
 		"feedbackGain" : 256,
@@ -23,6 +27,10 @@
 		"iq_swap_in" : 0,
 		"iq_swap_out" : 0,
 		"bandDelayUs" : 8.8,
+		# Optional: subbands known empty of resonators on this hardware,
+		# for a clean estimate_phase_delay() fit.  Omit or null to use
+		# the legacy geometric selection from freq_min/freq_max.
+		# "phaseDelaySubbands" : [50, 51, 52],
 		"trigRstDly" : 15, # 0xF
 		"feedbackEnable": 1,
 		"feedbackGain" : 256,
@@ -38,6 +46,10 @@
 		"iq_swap_in" : 0,
 		"iq_swap_out" : 0,
 		"bandDelayUs" : 8.8,
+		# Optional: subbands known empty of resonators on this hardware,
+		# for a clean estimate_phase_delay() fit.  Omit or null to use
+		# the legacy geometric selection from freq_min/freq_max.
+		# "phaseDelaySubbands" : [50, 51, 52],
 		"trigRstDly" : 15, # 0xF
 		"feedbackEnable": 1,
 		"feedbackGain" : 256,
@@ -53,6 +65,10 @@
 		"iq_swap_in" : 0,
 		"iq_swap_out" : 0,
 		"bandDelayUs" : 8.8,
+		# Optional: subbands known empty of resonators on this hardware,
+		# for a clean estimate_phase_delay() fit.  Omit or null to use
+		# the legacy geometric selection from freq_min/freq_max.
+		# "phaseDelaySubbands" : [50, 51, 52],
 		"trigRstDly" : 15, # 0xF
 		"feedbackEnable": 1,
 		"feedbackGain" : 256,

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -358,7 +358,7 @@ class SmurfConfig:
 
         """
         # Import useful schema objects
-        from schema import Schema, And, Use, Optional, Regex
+        from schema import Schema, And, Or, Use, Optional, Regex
 
         # Start with an extremely limited validation to figure out
         # things that we need to validate the entire configuration
@@ -429,6 +429,18 @@ class SmurfConfig:
 
                 # use bandDelayUs (microseconds) instead of refPhaseDelay(Fine)
                 Optional('bandDelayUs', default=None): And(Use(float), lambda n : 0 <= n < 30),
+
+                # Optional list of DSP subband indices known to be
+                # empty of resonators on this hardware.  When set,
+                # estimate_phase_delay() uses these subbands for the
+                # DSP latency fit instead of geometrically selecting
+                # subbands from its freq_min/freq_max arguments.
+                # This avoids the bias that resonator phase response
+                # would otherwise introduce into the linear
+                # phase-vs-frequency polyfit.
+                Optional('phaseDelaySubbands', default=None):
+                    Or(None, And([Use(int)], list,
+                       lambda l: all(0 <= sb < 128 for sb in l))),
 
                 # RF attenuator on SMuRF output.  UC=up convert.  0.5dB steps.
                 'att_uc': And(int, lambda n: 0 <= n < 2**5),

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -146,6 +146,7 @@ class SmurfConfigPropertiesMixin:
         self._ref_phase_delay = None
         self._ref_phase_delay_fine = None
         self._band_delay_us = None
+        self._phase_delay_subbands = None
         self._att_uc = None
         self._att_dc = None
         self._trigger_reset_delay = None
@@ -301,6 +302,9 @@ class SmurfConfigPropertiesMixin:
             for band in bands}
         self.band_delay_us = {
             band:smurf_init_config[f'band_{band}']['bandDelayUs']
+            for band in bands}
+        self.phase_delay_subbands = {
+            band:smurf_init_config[f'band_{band}']['phaseDelaySubbands']
             for band in bands}
         self.att_uc = {
             band:smurf_init_config[f'band_{band}']['att_uc']
@@ -2302,6 +2306,50 @@ class SmurfConfigPropertiesMixin:
         self._band_delay_us = value
 
     ## End band_delay_us property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start phase_delay_subbands property definition
+
+    # Getter
+    @property
+    def phase_delay_subbands(self):
+        """Subbands known to contain no resonators on this hardware.
+
+        Per-band dict of lists of DSP subband indices to use for
+        :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.estimate_phase_delay`
+        's DSP latency fit.  Restricting the fit to resonator-free
+        subbands avoids the bias that resonator phase response would
+        otherwise introduce into the linear phase-vs-frequency
+        polyfit.
+
+        If `None` for a given band,
+        :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.estimate_phase_delay`
+        falls back to geometric subband selection from its
+        ``freq_min``/``freq_max`` arguments.
+
+        Specified in the pysmurf configuration file under
+        ``init.band_<N>.phaseDelaySubbands``.
+
+        Returns
+        -------
+        dict
+           Per-band dict (keyed by band number) of `list` of `int`
+           or `None`.
+
+        See Also
+        --------
+        :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.estimate_phase_delay`
+
+        """
+        return self._phase_delay_subbands
+
+    # Setter
+    @phase_delay_subbands.setter
+    def phase_delay_subbands(self, value):
+        self._phase_delay_subbands = value
+
+    ## End phase_delay_subbands property definition
     ###########################################################################
 
     ###########################################################################

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -282,7 +282,8 @@ class SmurfUtilMixin(SmurfBase):
     @set_action()
     def estimate_phase_delay(self, band, nsamp=2**19, make_plot=True,
             show_plot=True, save_plot=True, save_data=True, n_scan=5,
-            timestamp=None, uc_att=None, dc_att=None, freq_min=-2.4E6, freq_max=2.4E6):
+            timestamp=None, uc_att=None, dc_att=None, freq_min=-2.4E6,
+            freq_max=2.4E6, subband=None):
         """Estimates total system latency for requested band.
 
         Measures the analog and digital (=processing) phase delay (or
@@ -342,14 +343,17 @@ class SmurfUtilMixin(SmurfBase):
         freq_max : float, optional, default 2.4E6
            Upper bound of the frequency interval used to estimate the
            phase delay, in Hz.  From the center of the 500 MHz band.
-
-        Returns
-        -------
-        processing_delay_us : float
-           Estimated processing phase delay, in microseconds.
-        dsp_corr_delay_us : float
-           Residual total phase delay, for estimated `refPhaseDelay`
-           and `refPhaseDelayFine`.
+        subband : list of int or None, optional, default None
+           Explicit list of DSP subband indices to use for the DSP
+           latency fit.  Use this to restrict the fit to subbands
+           known to be free of resonators on this hardware (resonator
+           phase response would otherwise bias the linear
+           phase-vs-frequency polyfit).  When `None`, falls back to
+           ``self.phase_delay_subbands[band]`` from the configuration
+           file; when that is also `None`, falls back to geometric
+           selection from `freq_min`/`freq_max`.  When in use, the
+           `freq_min`/`freq_max` window is bypassed for the DSP fit
+           (it still bounds the cable-delay fit).
 
         """
 
@@ -365,8 +369,6 @@ class SmurfUtilMixin(SmurfBase):
         self.set_att_uc(band, uc_att, write_log=True)
         self.set_att_dc(band, dc_att, write_log=True)
 
-        # only loop over dsp subbands in requested frequency range (to
-        # save time)
         n_subbands = self.get_number_sub_bands(band)
         digitizer_frequency_mhz = self.get_digitizer_frequency_mhz(band)
         subband_half_width_mhz = digitizer_frequency_mhz/\
@@ -374,16 +376,46 @@ class SmurfUtilMixin(SmurfBase):
         subbands,subband_centers=self.get_subband_centers(band)
         subband_freq_min=-subband_half_width_mhz/2.
         subband_freq_max=subband_half_width_mhz/2.
-        dsp_subbands=[]
-        for sb,sbc in zip(subbands,subband_centers):
-            # ignore unprocessed sub-bands
-            if sb not in subbands:
-                continue
-            lower_sb_freq=sbc+subband_freq_min
-            upper_sb_freq=sbc+subband_freq_max
-            if lower_sb_freq>=(freq_min/1.e6-subband_half_width_mhz) and \
-                    upper_sb_freq<=(freq_max/1.e6+subband_half_width_mhz):
-                dsp_subbands.append(sb)
+
+        # Resolve which DSP subbands to use for the DSP-delay fit.
+        # Precedence: explicit subband arg > per-band config
+        # (phase_delay_subbands) > geometric selection from
+        # freq_min/freq_max.
+        if subband is None and self.phase_delay_subbands is not None:
+            subband = self.phase_delay_subbands.get(band, None)
+
+        explicit_subbands = subband is not None
+        if explicit_subbands:
+            processed_subbands = set(subbands)
+            dsp_subbands = [sb for sb in subband if sb in processed_subbands]
+            skipped = [sb for sb in subband if sb not in processed_subbands]
+            if skipped:
+                self.log(
+                    f'estimate_phase_delay: ignoring phaseDelaySubbands '
+                    f'not in this band\'s processed subbands: {skipped}',
+                    self.LOG_USER)
+            if len(dsp_subbands) == 0:
+                raise ValueError(
+                    f'estimate_phase_delay: phaseDelaySubbands for band '
+                    f'{band} resolved to an empty set of processed '
+                    f'subbands; cannot fit DSP latency.')
+            self.log(
+                f'estimate_phase_delay: using {len(dsp_subbands)} '
+                f'user-specified resonator-free subband(s) for band '
+                f'{band}: {dsp_subbands}', self.LOG_USER)
+        else:
+            # only loop over dsp subbands in requested frequency
+            # range (to save time)
+            dsp_subbands=[]
+            for sb,sbc in zip(subbands,subband_centers):
+                # ignore unprocessed sub-bands
+                if sb not in subbands:
+                    continue
+                lower_sb_freq=sbc+subband_freq_min
+                upper_sb_freq=sbc+subband_freq_max
+                if lower_sb_freq>=(freq_min/1.e6-subband_half_width_mhz) and \
+                        upper_sb_freq<=(freq_max/1.e6+subband_half_width_mhz):
+                    dsp_subbands.append(sb)
 
         if timestamp is None:
             timestamp = self.get_timestamp()
@@ -443,12 +475,17 @@ class SmurfUtilMixin(SmurfBase):
         freq_dsp_subset=np.array(freq_dsp_subset)
         resp_dsp_subset=np.array(resp_dsp_subset)
 
-        idx_dsp = np.where( (freq_dsp_subset > freq_min) &
-            (freq_dsp_subset < freq_max) )
+        # When using user-specified resonator-free subbands, do not
+        # cull samples outside the freq_min/freq_max window — the
+        # user picked the subbands explicitly and wants the full
+        # subband content in the fit.
+        if not explicit_subbands:
+            idx_dsp = np.where( (freq_dsp_subset > freq_min) &
+                (freq_dsp_subset < freq_max) )
 
-        # restrict to requested frequencies only
-        freq_dsp_subset=freq_dsp_subset[idx_dsp]
-        resp_dsp_subset=resp_dsp_subset[idx_dsp]
+            # restrict to requested frequencies only
+            freq_dsp_subset=freq_dsp_subset[idx_dsp]
+            resp_dsp_subset=resp_dsp_subset[idx_dsp]
 
         # to Hz
         freq_dsp_subset=(freq_dsp_subset)*1.0E6
@@ -496,12 +533,15 @@ class SmurfUtilMixin(SmurfBase):
         freq_dsp_corr_subset=np.array(freq_dsp_corr_subset)
         resp_dsp_corr_subset=np.array(resp_dsp_corr_subset)
 
-        # restrict to requested frequency subset
-        idx_dsp_corr = np.where( (freq_dsp_corr_subset > freq_min) & (freq_dsp_corr_subset < freq_max) )
+        # restrict to requested frequency subset (skip when the
+        # user supplied an explicit resonator-free subband list)
+        if not explicit_subbands:
+            idx_dsp_corr = np.where( (freq_dsp_corr_subset > freq_min) &
+                (freq_dsp_corr_subset < freq_max) )
 
-        # restrict to requested frequencies only
-        freq_dsp_corr_subset=freq_dsp_corr_subset[idx_dsp_corr]
-        resp_dsp_corr_subset=resp_dsp_corr_subset[idx_dsp_corr]
+            # restrict to requested frequencies only
+            freq_dsp_corr_subset=freq_dsp_corr_subset[idx_dsp_corr]
+            resp_dsp_corr_subset=resp_dsp_corr_subset[idx_dsp_corr]
 
         # to Hz
         freq_dsp_corr_subset=(freq_dsp_corr_subset)*1.0E6


### PR DESCRIPTION
## Summary
- Adds an Optional per-band config field `phaseDelaySubbands` listing DSP subband indices known to be empty of resonators on this hardware.
- When set, `estimate_phase_delay()` uses those subbands for the DSP latency polyfit instead of geometrically selecting them from `freq_min`/`freq_max`, eliminating the resonator-induced phase distortion that would otherwise bias the linear phase-vs-frequency fit.
- Backward compatible: existing configs hit the original geometric-selection path byte-identical to pre-PR.

Closes #513.

## Changes
- `python/pysmurf/client/base/smurf_config.py` — schema entry validating `list[int]` in `[0, 128)` or `None`; explicit `null` and empty list both accepted at validation (use-time check raises if every entry is unprocessed). Adds `Or` to the schema import.
- `python/pysmurf/client/base/smurf_config_properties.py` — `phase_delay_subbands` per-band dict property, populated by `copy_config_to_properties()`.
- `python/pysmurf/client/util/smurf_util.py` — new `subband` kwarg on `estimate_phase_delay()` with precedence **arg > config (`self.phase_delay_subbands[band]`) > geometric (`freq_min`/`freq_max`)**. When an explicit list is in use, the `freq_min`/`freq_max` post-fit window is bypassed for the DSP fit only; the cable-delay fit (broadband, no resonator issue) is unaffected. Logs which subbands are in use; raises `ValueError` on empty processed-subband resolution.
- `cfg_files/template/template.cfg` — commented-out example in each of the four `band_N` blocks.
- `README.config_file.md` — documents `phaseDelaySubbands` and `bandDelayUs`; marks `refPhaseDelay`/`refPhaseDelayFine` as deprecated.

## Test plan
- [x] `flake8 --count python/` → 0 (matches CI invocation)
- [x] `python3 -m py_compile` on all three modified Python modules — clean
- [x] Schema-validation offline against `cfg_files/template/template.cfg`:
  - field absent → `None` per band (backward compat)
  - explicit `[50, 51, 52]` → accepted
  - out-of-range `[200]` → `SchemaError`
  - explicit `null` → accepted as `None`
  - empty list `[]` → accepted (use-time validation)
- [ ] On-hardware: run `S.estimate_phase_delay(band)` with `phaseDelaySubbands` populated for a band that contains resonators; confirm log line `using N user-specified resonator-free subband(s)` and verify cleaner sub-radian post-correction residuals vs. an unconfigured run.
- [ ] On-hardware backward-compat: load an existing per-site config without `phaseDelaySubbands`; confirm `S.estimate_phase_delay(band)` produces numerically identical output to pre-PR.