### PR TITLE
fix(find_freq): Warn user when ADC rails during amplitude sweep (#511)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3440,7 +3440,8 @@ class SmurfTuneMixin(SmurfBase):
             plotname_append='', window=50, rolling_med=True,
             make_subband_plot=False, show_plot=False, grad_cut=.05,
             flip_phase=False, grad_kernel_width=8,
-            amp_cut=.25, pad=2, min_gap=2):
+            amp_cut=.25, pad=2, min_gap=2,
+            check_if_adc_is_saturated=True):
         '''
         Finds the resonances in a band (and specified subbands)
 
@@ -3486,6 +3487,13 @@ class SmurfTuneMixin(SmurfBase):
             search window
         min_gap : int, optional, default 2
             Minimum number of samples between resonances.
+        check_if_adc_is_saturated : bool, optional, default True
+            After the amplitude sweep, inspect each subband's
+            normalized response magnitude.  If any sample is at or
+            above 0.95 the ADC was likely railing on that subband;
+            log a warning naming the affected subbands.  The list is
+            also stored in
+            ``self.freq_resp[band]['find_freq']['railed_subbands']``.
         '''
         band_center = self.get_band_center_mhz(band)
         if subband is None:
@@ -3537,6 +3545,25 @@ class SmurfTuneMixin(SmurfBase):
                 np.append(self.freq_resp[band]['find_freq']['timestamp'], timestamp)
         else:
             self.freq_resp[band]['find_freq']['timestamp'] = np.array([timestamp])
+
+        # Issue #511: find_freq returns normalized response magnitudes
+        # (~[0, 1]).  When the ADC rails the magnitude flat-tops near
+        # 1.0; flag any subband that crosses the threshold so the user
+        # knows to attenuate further.
+        if check_if_adc_is_saturated:
+            rail_threshold = 0.95
+            abs_resp = np.abs(resp)
+            railed_subbands = [int(sb) for sb in subband
+                if np.any(abs_resp[sb] >= rail_threshold)]
+            self.freq_resp[band]['find_freq']['railed_subbands'] = \
+                railed_subbands
+            if railed_subbands:
+                self.log(
+                    f'\033[91mfind_freq: ADC may be railing on band '
+                    f'{band} subbands {railed_subbands} '
+                    f'(|resp| >= {rail_threshold}).  Try increasing '
+                    f'the DC attenuation for this band.\033[00m',
+                    self.LOG_ERROR)
 
         # Find resonator peaks
         res_freq = self.find_all_peak(self.freq_resp[band]['find_freq']['f'],


### PR DESCRIPTION
## Summary
- Closes #511. Adds a post-scan ADC-railing warning to `find_freq` so users know when the amplitude sweep produced bad data because the ADC saturated.
- After `full_band_ampl_sweep` returns, the function inspects each requested subband's normalized response magnitude and logs a red `LOG_ERROR` message naming any subband whose `|resp|` crosses `0.95` — the symptom shown in the issue's screenshot. The list is also stashed in `self.freq_resp[band]['find_freq']['railed_subbands']` for downstream inspection/tests.
- Gated by a new `check_if_adc_is_saturated=True` kwarg, matching the pattern `full_band_resp` already uses (smurf_tune.py:585). Warns rather than raises so partial scan data remains usable for resonators in unrailed subbands.
- Zero added firmware time: detection reuses the response data already collected by the sweep, addressing the issue author's concern that `find_freq` is "already pretty slow."

## Out of scope (intentionally)
- **Adding a firmware register that reports saturation during the eta scan** (suggested in the issue thread by @swh76). That's a Rogue/firmware change and outside this Python-only fix.
- **Adding the same check to `fast_eta_scan` directly.** It returns raw I/Q with no normalization context guaranteed by all callers; doing it at `find_freq` keeps the surface minimal and matches the issue title.
- **Auto-adjusting attenuation.** The issue asks for a warning, not auto-correction.

Reviewers — please flag if any of the above should be folded into this PR rather than deferred.

## Test plan
- [x] `flake8 --count python/` → 0 errors (matches CI invocation in `.github/workflows/test-or-deploy.yml`).
- [x] AST parse of the modified file passes.
- [x] Offline numpy sanity check of the threshold logic with railed / clean / just-under-threshold synthetic subbands picks the correct subband.
- [ ] Hardware regression on a SMuRF system: run `S.find_freq(band, ...)` at deliberately too-low DC attenuation, confirm the red warning fires and `S.freq_resp[band]['find_freq']['railed_subbands']` is non-empty; re-run at nominal attenuation and confirm the list is empty and no warning is emitted.