### PR TITLE
feat(take_debug_data): Add match_setup_notches option for rfIQ data (#761)

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -42,7 +42,7 @@ class SmurfUtilMixin(SmurfBase):
     @set_action()
     def take_debug_data(self, band, channel=None, nsamp=2**19, filename=None,
             IQstream=1, single_channel_readout=1, debug=False, rf_iq=False,
-            write_log=True):
+            match_setup_notches=False, write_log=True):
         """Takes raw debugging data.
 
         Args
@@ -63,6 +63,14 @@ class SmurfUtilMixin(SmurfBase):
             Whether to take data in debug mode.
         rf_iq : bool, optional, default False
             Return the RF IQ. Must provide channel.
+        match_setup_notches : bool, optional, default False
+            Only used when ``rf_iq=True``.  When True, scale the returned
+            I and Q so that ``I + 1j*Q`` matches the convention of the
+            ``resp_eta_scan`` arrays produced by
+            :func:`~pysmurf.client.tune.smurf_tune.SmurfTuneMixin.setup_notches`:
+            divides both quadratures by the PFB subband half-width
+            (``digitizer_frequency_mhz / n_subbands``) and flips the sign
+            of Q.  See pysmurf issue #761.
         write_log : bool, optional, default True
             Whether to write low-level commands to the log file.
 
@@ -159,6 +167,16 @@ class SmurfUtilMixin(SmurfBase):
             f, df, sync = self.decode_single_channel(data_filename)
         else:
             f, df, sync = self.decode_data(data_filename)
+
+        if rf_iq and match_setup_notches:
+            # Convert rf_iq I/Q to the setup_notches resp_eta_scan
+            # convention: I_setup = I_rfiq / subband_half_width_mhz,
+            # Q_setup = -Q_rfiq / subband_half_width_mhz.  See issue #761.
+            n_subbands = self.get_number_sub_bands()
+            digitizer_frequency_mhz = self.get_digitizer_frequency_mhz()
+            subband_half_width_mhz = digitizer_frequency_mhz / n_subbands
+            f = f / subband_half_width_mhz
+            df = -df / subband_half_width_mhz
 
         return f, df, sync
 


### PR DESCRIPTION
## Summary
Closes #761.

`take_debug_data(..., rf_iq=True)` returns I/Q in a different convention than the `resp_eta_scan` arrays produced by `setup_notches` — the issue reporter showed empirically that `I_rfiq = +1.2 * Re(resp_eta_scan)` and `Q_rfiq = -1.2 * Im(resp_eta_scan)`, where `1.2 MHz = digitizer_frequency_mhz / n_subbands` (the PFB subband half-width).

This adds an opt-in `match_setup_notches=False` kwarg to `take_debug_data`. When `rf_iq=True` and `match_setup_notches=True`, the returned I and Q are divided by `subband_half_width_mhz` and the sign of Q is flipped, so that `I + 1j*Q` matches the `setup_notches` convention. Default-False preserves all current behavior — none of the internal callers (`smurf_noise.py:2007`, `smurf_tune.py:2724,4164,4173`) require changes.

The transformation mirrors the sign-flip precedent at `smurf_tune.py:4049-4053` (`respu = Qu - 1j*Iu`) used in `setup_notches` to remap `eta_scan` output.

Diff is confined to `take_debug_data` (+19/−1 in one file).

## Test plan
- [x] `flake8 --count python/` reports 0 issues (matches CI invocation in `.github/workflows/test-or-deploy.yml`)
- [x] `python -c 'import ast; ast.parse(open("python/pysmurf/client/util/smurf_util.py").read())'` parses cleanly
- [x] `inspect.signature` confirms positional ordering preserved; no existing caller passes `write_log` positionally
- [ ] Hardware integration: rerun the issue's reproducer at a tuned resonator and verify
  ```python
  I, Q, _ = S.take_debug_data(band=0, channel=0, rf_iq=True,
                               match_setup_notches=True, nsamp=2**23)
  resp = S.freq_resp[0]['resonances'][0]['resp_eta_scan']
  # expect mean(I) ~ Re(resp), mean(Q) ~ Im(resp)
  ```
- [ ] Hardware integration: same call without `match_setup_notches=True` shows the pre-existing 1.2x scaling and Q sign vs `resp_eta_scan` (regression check on default path)