### PR TITLE
feat(run_serial_*): Add use_tracked_freq option for biased-TES retune (#736)

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -828,7 +828,8 @@ class SmurfCommandMixin(SmurfBase):
 
     _run_serial_eta_scan_reg = 'runSerialEtaScan'
 
-    def run_serial_eta_scan(self, band, timeout=240, **kwargs):
+    def run_serial_eta_scan(self, band, timeout=240,
+            use_tracked_freq=False, nsamp=2**18, **kwargs):
         """
         Does an eta scan serially across the entire band. You must
         already be tuned close to the resontor dip. Use
@@ -840,7 +841,24 @@ class SmurfCommandMixin(SmurfBase):
             The band to eta scan.
         timeout : float, optional, default 240
             The maximum amount of time to wait for the PV.
+        use_tracked_freq : bool, optional, default False
+            If True, calls
+            :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.update_centers_from_tracked_freq`
+            before turning the flux ramp off, so the scan starts from
+            the bias-shifted resonator frequencies measured by the
+            tracking algorithm rather than the originally programmed
+            centers. Requires the flux ramp to be running and tracking
+            to be set up. Default False preserves legacy behavior.
+        nsamp : int, optional, default 2**18
+            Number of samples used by
+            ``update_centers_from_tracked_freq`` when
+            ``use_tracked_freq`` is True. Ignored otherwise.
         """
+
+        if use_tracked_freq:
+            self.update_centers_from_tracked_freq(
+                band, nsamp=nsamp,
+                write_log=kwargs.get('write_log', False))
 
         # need flux ramp off for this - enforce
         self.flux_ramp_off()
@@ -877,7 +895,8 @@ class SmurfCommandMixin(SmurfBase):
 
     _run_serial_gradient_descent_reg = 'runSerialGradientDescent'
 
-    def run_serial_gradient_descent(self, band, timeout=240, **kwargs):
+    def run_serial_gradient_descent(self, band, timeout=240,
+            use_tracked_freq=False, nsamp=2**18, **kwargs):
         """
         Does a gradient descent search for the minimum.
 
@@ -887,7 +906,27 @@ class SmurfCommandMixin(SmurfBase):
             The band to run serial gradient descent on.
         timeout : float, optional, default 240
             The maximum amount of time to wait for the PV.
+        use_tracked_freq : bool, optional, default False
+            If True, calls
+            :func:`~pysmurf.client.util.smurf_util.SmurfUtilMixin.update_centers_from_tracked_freq`
+            before turning the flux ramp off, so the descent starts from
+            the bias-shifted resonator frequencies measured by the
+            tracking algorithm rather than the originally programmed
+            centers. Required when TESs are biased -- a SQUID-induced
+            phase shift of order 100 kHz will otherwise place the search
+            outside the gradient-descent capture range. Requires the
+            flux ramp to be running and tracking to be set up. Default
+            False preserves legacy behavior.
+        nsamp : int, optional, default 2**18
+            Number of samples used by
+            ``update_centers_from_tracked_freq`` when
+            ``use_tracked_freq`` is True. Ignored otherwise.
         """
+
+        if use_tracked_freq:
+            self.update_centers_from_tracked_freq(
+                band, nsamp=nsamp,
+                write_log=kwargs.get('write_log', False))
 
         # need flux ramp off for this - enforce
         self.flux_ramp_off()

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2063,6 +2063,91 @@ class SmurfUtilMixin(SmurfBase):
         return np.ravel(np.where(amps != 0))
 
     @set_action()
+    def update_centers_from_tracked_freq(self, band, nsamp=2**18,
+            write_log=False):
+        """Re-anchors ``centerFrequencyMHz`` to the bias-shifted resonator
+        frequencies measured by the tracking algorithm.
+
+        When TESs are biased, SQUID-induced phase shifts the resonators
+        by of order 100 kHz away from the tone frequencies originally
+        written to ``centerFrequencyMHz``. The serial gradient-descent
+        and serial eta-scan firmware routines start their search at
+        ``centerFrequencyMHz`` and converge poorly (or not at all) when
+        the true resonator has moved that far.
+
+        This helper takes one ``take_debug_data`` acquisition with
+        ``IQstream=0`` and ``single_channel_readout=0``, averages the
+        per-sample tracked frequency offset over the full record, and
+        adds that mean offset (in MHz) to the existing centerFrequency
+        for every channel in :func:`which_on`. The new centers are
+        written back to the firmware register. Channels that are not on
+        are left untouched. ``setIQStreamEnable`` is restored to 1 on
+        exit, matching the convention used in
+        :func:`~pysmurf.client.tune.smurf_tune.SmurfTuneMixin.tracking_setup`.
+
+        Intended to be called immediately before
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.run_serial_gradient_descent`
+        or
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.run_serial_eta_scan`,
+        while the flux ramp is running and tracking is active. The
+        tracked frequency ``f`` returned by ``take_debug_data`` is only
+        meaningful when tracking is on.
+
+        Args
+        ----
+        band : int
+            The band whose center frequencies will be updated.
+        nsamp : int, optional, default 2**18
+            Number of samples to take in the ``take_debug_data`` call
+            used to measure the tracked frequency.
+        write_log : bool, optional, default False
+            Whether to write low-level commands to the log file.
+
+        Returns
+        -------
+        new_centers : numpy.ndarray
+            The full 512-element ``centerFrequencyMHz`` array as written
+            back to the firmware. If no channels are on, the array is
+            returned unchanged.
+        """
+        active = self.which_on(band)
+        centers = np.array(self.get_center_frequency_array(band),
+                           dtype=float)
+
+        if len(active) == 0:
+            self.log(
+                'update_centers_from_tracked_freq: no channels on for '
+                f'band {band}; centerFrequencyMHz left unchanged.',
+                self.LOG_USER)
+            return centers
+
+        f, _df, _sync = self.take_debug_data(
+            band, IQstream=0, single_channel_readout=0, nsamp=nsamp,
+            write_log=write_log)
+
+        # f has shape (n_samp, n_channels); mean over samples gives the
+        # per-channel offset (MHz) of the tracked resonator from the
+        # currently programmed center.
+        offsets = np.mean(f, axis=0)
+        centers[active] = centers[active] + offsets[active]
+
+        self.set_center_frequency_array(band, centers, write_log=write_log)
+
+        # take_debug_data leaves IQstream disabled when called with
+        # IQstream=0; restore it the same way tracking_setup does.
+        self.set_iq_stream_enable(band, 1, write_log=write_log)
+
+        if write_log:
+            max_shift_khz = float(np.max(np.abs(offsets[active]))) * 1e3
+            self.log(
+                'update_centers_from_tracked_freq: updated '
+                f'{len(active)} channel(s) on band {band}; '
+                f'max |shift| = {max_shift_khz:.1f} kHz.',
+                self.LOG_USER)
+
+        return centers
+
+    @set_action()
     def toggle_feedback(self, band, **kwargs):
         """
         Toggles feedbackEnable (->0->1) and lmsEnables1-3 (->0->1) for


### PR DESCRIPTION
## Summary
Closes #736.

`run_serial_gradient_descent` and `run_serial_eta_scan` start their search at `centerFrequencyMHz`, which `setup_notches` writes once from the initial `find_freq` sweep. When TESs are biased, SQUID phase shifts each resonator by ~100 kHz, so the firmware capture window misses the new minimum and re-tuning is impossible without first unbiasing the detectors.

This adds `SmurfUtilMixin.update_centers_from_tracked_freq(band, nsamp=2**18, write_log=False)`, which takes one `take_debug_data` acquisition with `IQstream=0, single_channel_readout=0` while the flux ramp is running, averages the per-sample tracked-frequency offset, and writes the bias-shifted values back to `centerFrequencyMHz` for every channel in `which_on(band)`. It restores `setIQStreamEnable=1` on exit, matching the convention at the tail of `tracking_setup`. Channels not in `which_on` are left untouched. Returns the full 512-element array as written.

Both `run_serial_gradient_descent` and `run_serial_eta_scan` gain an opt-in `use_tracked_freq=False, nsamp=2**18` kwarg pair. When `use_tracked_freq=True`, the helper is called **before** `flux_ramp_off()` (tracked frequency is only meaningful while tracking is active). Default-False preserves legacy behavior — the existing call sites in `setup_notches` (`smurf_tune.py:402,406`), `noise_vs_bias` (`smurf_noise.py:668-669`), and `take_noise_high_bandwidth` (`smurf_noise.py:1992-1994`) are byte-for-byte equivalent.

Diff is +128/-4 across two files, no new imports.

## Test plan
- [x] `flake8 --count python/` reports 0 issues (matches CI invocation in `.github/workflows/test-or-deploy.yml`)
- [x] `python -c \"import ast, pathlib; ast.parse(pathlib.Path('python/pysmurf/client/util/smurf_util.py').read_text()); ast.parse(pathlib.Path('python/pysmurf/client/command/smurf_command.py').read_text())\"` parses cleanly
- [x] AST signature check confirms `use_tracked_freq` and `nsamp` kwargs added with default-False on both `run_serial_*` functions, helper present on `SmurfUtilMixin`
- [x] `grep -n run_serial_{gradient_descent,eta_scan} python/pysmurf/client/{tune,debug}/*.py` confirms internal callers unchanged (default-False legacy path)
- [ ] Hardware integration: tune a band, run `tracking_setup` with the flux ramp running, apply a TES bias known to shift resonators, then:
  ```python
  # Baseline (existing bug): expect convergence failure / wrong minimum on biased channels
  S.run_serial_gradient_descent(band)
  # Fix: expect convergence on the same biased channels
  S.run_serial_gradient_descent(band, use_tracked_freq=True)
  ```
- [ ] Hardware integration: verify `S.get_center_frequency_array(band)` after the fix call shifts only `which_on` channels by ~the SQUID phase shift; non-on channels unchanged
- [ ] Hardware integration: verify `S.get_iq_stream_enable(band) == 1` after the helper returns (regression check on the restore)
- [ ] Hardware integration: repeat the above with `S.run_serial_eta_scan(band, use_tracked_freq=True)`
- [ ] Hardware integration (empty band): with no channels on, call `S.run_serial_gradient_descent(band, use_tracked_freq=True)`; expect a single log line and `centerFrequencyMHz` unchanged