### PR TITLE
fix(assign_channels): Try next-closest subband when closest is full (#658)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -1634,9 +1634,16 @@ class SmurfTuneMixin(SmurfBase):
     @set_action()
     def assign_channels(self, freq, band=None, bandcenter=None,
             channel_per_subband=4, as_offset=True, min_offset=0.1,
-            new_master_assignment=False):
+            new_master_assignment=False, max_alt_subbands=5):
         """
         Figures out the subbands and channels to assign to resonators
+
+        When ``new_master_assignment=True``, each resonator is placed in
+        its closest subband with available capacity.  If the closest
+        subband is already full, the algorithm falls back to the next
+        closest, up to ``max_alt_subbands`` candidates total.  This
+        prevents silently dropping the higher-frequency resonator when
+        two resonances land in the same subband (issue #658).
 
         Args
         ----
@@ -1655,6 +1662,11 @@ class SmurfTuneMixin(SmurfBase):
         min_offset : float, optional, default 0.1
             The minimum offset between two resonators in MHz.  If
             closer, then both are ignored.
+        max_alt_subbands : int, optional, default 5
+            Maximum number of subbands to try when the closest one is
+            full.  Bounds how far a resonator can drift from its
+            preferred subband when collisions occur.  Only used when
+            ``new_master_assignment=True``.
 
         Returns
         -------
@@ -1710,26 +1722,41 @@ class SmurfTuneMixin(SmurfBase):
             close_idx = d_freq > min_offset
             close_idx = np.logical_and(np.hstack((close_idx, True)),
                                        np.hstack((True, close_idx)))
-            # Assign all frequencies to a subband
+
+            sb_centers = np.asarray(
+                self.get_subband_centers(band, as_offset=as_offset)[1])
+
+            chans_cache = {}
+            sb_used = {}
+
             for idx in range(len(freq)):
-                subbands[idx] = self.get_closest_subband(freq[idx], band,
-                                                     as_offset=as_offset)
-                subband_center = self.get_subband_centers(band,
-                                          as_offset=as_offset)[1][subbands[idx]]
-                offsets[idx] = freq[idx] - subband_center
+                f = freq[idx]
+                sb_order = np.argsort(np.abs(sb_centers - f))
 
-            # Assign unique channel numbers
-            for unique_subband in set(subbands):
-                chans = self.get_channels_in_subband(band, int(unique_subband))
-                mask = np.where(subbands == unique_subband)[0]
-                if len(mask) > channel_per_subband:
-                    concat_mask = mask[:channel_per_subband]
-                else:
-                    concat_mask = mask[:]
+                placed = False
+                for sb in sb_order[:max_alt_subbands]:
+                    sb = int(sb)
+                    if sb not in chans_cache:
+                        chans_cache[sb] = list(
+                            self.get_channels_in_subband(band, sb))
+                        sb_used[sb] = 0
+                    capacity = min(channel_per_subband, len(chans_cache[sb]))
+                    if sb_used[sb] < capacity:
+                        ch = int(chans_cache[sb][sb_used[sb]])
+                        sb_used[sb] += 1
+                        subbands[idx] = sb
+                        channels[idx] = ch
+                        offsets[idx] = f - sb_centers[sb]
+                        placed = True
+                        break
 
-                chans = chans[:len(list(concat_mask))] #I am so sorry
-
-                channels[mask[:len(chans)]] = chans
+                if not placed:
+                    sb = int(sb_order[0])
+                    subbands[idx] = sb
+                    offsets[idx] = f - sb_centers[sb]
+                    self.log(
+                        f'No subband capacity within {max_alt_subbands} '
+                        f'of closest for {f:.2f} MHz; leaving unassigned.')
 
             # Prune channels that are too close
             channels[~close_idx] = -1


### PR DESCRIPTION
## Summary

Closes #658.

When firmware switched to 1 channel per subband / 512 subbands, two resonators spaced less than half a subband (~1.2 MHz) apart land in the same subband and the higher-frequency one gets silently dropped. The reporter sees several-percent yield loss on SO umux chips and an unwelcome ~1 MHz minimum-spacing floor on NIST fab.

This PR makes `assign_channels()` (`new_master_assignment=True` path) fall back to the next-closest subband when the preferred one is full, up to a bounded search radius. Two-pass "assign-then-prune" is replaced with a single greedy pass that tracks per-subband usage as it iterates resonances in sorted-frequency order.

- New kwarg: `max_alt_subbands : int = 5` — bounds how far a resonator can drift from its preferred subband when collisions occur.
- All five existing call sites are unaffected (additive default kwarg).
- Behavior is byte-equivalent to the old algorithm whenever no collisions exist.
- The `min_offset` proximity prune (resonances < 0.1 MHz apart) and the `not new_master_assignment` master-list lookup path are unchanged.

## Verification

- `flake8 --count python/` → 0 (CI lint).
- Offline import smoke test passes (`python3 -c 'import pysmurf.client'`).
- 6 offline unit tests covering: byte-equivalence to old algorithm with no collisions, the exact #658 reproducer (two resonators ~0.5 MHz apart now both placed in adjacent subbands), the old algorithm dropping the higher-freq one in the same scenario, the close-pair (< 0.1 MHz) proximity prune still triggering, old-firmware 4 ch/sb path unchanged, and overflow beyond `max_alt_subbands` correctly leaving excess as `-1`.

## Out of scope

- Reverting to 128 subbands (explicitly rejected by reporter).
- Optimal global assignment (Hungarian-style). The greedy fallback is sufficient for the failure modes seen in the field; can be revisited if real-world data shows greedy is too lossy.
- The `not new_master_assignment` master-list lookup path. The reporter's complaint is about fresh assignments; lookups by definition reuse a prior assignment.

## Test plan

- [ ] Reporter (@dpdutcher) re-runs `setup_notches` with `new_master_assignment=True` on the umux chip from #658 (the one with 0.5 / 0.68 / 0.76 / 0.76 MHz pairs) and confirms all four paired resonators now receive channel assignments.
- [ ] Confirm no regression in tune/relock on a chip that previously had no collisions (assignments should be identical to pre-fix output).