### PR TITLE
feat(run_iv): Add cool_voltage option for cool-wait bias (#563)

### DIFF
--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -30,6 +30,7 @@ class SmurfIVMixin(SmurfBase):
     def run_iv(self, bias_groups=None, wait_time=.1, bias=None,
                bias_high=1.5, bias_low=0, bias_step=.005,
                show_plot=False, overbias_wait=2., cool_wait=30,
+               cool_voltage=None,
                make_plot=True, save_plot=True, plotname_append='',
                channels=None, band=None, high_current_mode=True,
                overbias_voltage=8., grid_on=True,
@@ -64,6 +65,12 @@ class SmurfIVMixin(SmurfBase):
         cool_wait : float, optional, default 30.0
             The time to stay in the low current state after
             overbiasing before taking the IV.
+        cool_voltage : float or None, optional, default None
+            The TES bias voltage to hold during the ``cool_wait``
+            period after overbiasing. If None, defaults to
+            ``np.max(bias)`` (the highest IV bias). Setting a value
+            below ``np.max(bias)`` reduces the heat dissipated during
+            the cool-wait window.
         make_plot : bool, optional, default True
             Whether to make plots.
         save_plot : bool, optional, default True
@@ -111,8 +118,9 @@ class SmurfIVMixin(SmurfBase):
 
         # Overbias the TESs to drive them normal
         if overbias:
+            cool_tes_bias = np.max(bias) if cool_voltage is None else cool_voltage
             self.overbias_tes_all(bias_groups=bias_groups,
-                overbias_wait=overbias_wait, tes_bias=np.max(bias),
+                overbias_wait=overbias_wait, tes_bias=cool_tes_bias,
                 cool_wait=cool_wait, high_current_mode=high_current_mode,
                 overbias_voltage=overbias_voltage)
 


### PR DESCRIPTION
## Summary

Closes #563.

`run_iv` previously hardcoded the post-overbias cool-wait TES bias to `np.max(bias)`. This adds an optional `cool_voltage` kwarg so the caller can hold the TES at a lower voltage during the `cool_wait` window to reduce heat dissipated during cooling. When `cool_voltage=None` (default), behavior is unchanged.

- `python/pysmurf/client/debug/smurf_iv.py` — new kwarg threaded into the `overbias_tes_all` call as `tes_bias=(np.max(bias) if cool_voltage is None else cool_voltage)`, plus a matching docstring entry.

## Out of scope

- Adding `cool_voltage` to `smurf_cmd.py` CLI flags.
- Adding a config-file property — keeping parity with `cool_wait` / `overbias_*` which are kwargs only.
- Touching `overbias_tes` / `overbias_tes_all` semantics.

Reviewers: if any of the above should land in this PR rather than a follow-up, please flag it.

## Test plan

- [x] `flake8 --count python/` — 0 issues (matches `.github/workflows/test-or-deploy.yml`)
- [x] Default path: `run_iv(...)` without `cool_voltage` produces the previous `overbias_tes_all(..., tes_bias=np.max(bias), ...)` call (verified by inspection)
- [x] Override path: `run_iv(..., cool_voltage=1.0)` with `bias_high=4` calls `overbias_tes_all(..., tes_bias=1.0, ...)` (verified by inspection)
- [x] Existing callers in `python/pysmurf/client/command/smurf_cmd.py:418,425` use kwargs only, so adding the new optional kwarg is backwards-compatible
- [ ] Smoke-test on hardware: `S.run_iv(..., cool_voltage=<lower-than-bias_high>)` and confirm the TES holds at the requested voltage during `cool_wait`