### PR TITLE
feat(SmurfControl): Add ac_dc_mode cfg option for flux ramp coupling (#510)

### DIFF
--- a/cfg_files/template/template.cfg
+++ b/cfg_files/template/template.cfg
@@ -250,6 +250,10 @@
 "flux_ramp" : {
 	"select_ramp" : 1,
 	"num_flux_ramp_counter_bits" : 32
+	# "ac_dc_mode" : "DC"  # Optional. "AC" or "DC". Sets the cryocard
+	                       # flux ramp coupling relay during setup().
+	                       # If omitted, the relay is left in its
+	                       # current state. See issue #510.
 },
 
 "constant" : {

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -729,7 +729,12 @@ class SmurfConfig:
         #### Start specifying flux ramp-related
         schema_dict["flux_ramp"] = {
             # 20 bits for the C0 RTMs, 32 bits for the C1 RTMs.
-            "num_flux_ramp_counter_bits" : And(int, lambda n: n in (20, 32))
+            "num_flux_ramp_counter_bits" : And(int, lambda n: n in (20, 32)),
+            # Cryocard flux-ramp coupling: "AC" or "DC". Case-insensitive.
+            # If omitted, setup() leaves the relay in whatever state the
+            # hardware is currently in (backwards compatible). Issue #510.
+            Optional('ac_dc_mode', default=None) :
+                And(str, lambda s: s.upper() in ('AC', 'DC'))
         }
         #### Done specifying flux-ramp related
 

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -152,6 +152,7 @@ class SmurfConfigPropertiesMixin:
 
         # RTM
         self._num_flux_ramp_counter_bits = None
+        self._flux_ramp_ac_dc_mode = None
         self._fraction_full_scale = None
         self._reset_rate_khz = None
 
@@ -326,6 +327,7 @@ class SmurfConfigPropertiesMixin:
         ## RTM
         flux_ramp_cfg = config.get('flux_ramp')
         self.num_flux_ramp_counter_bits = flux_ramp_cfg['num_flux_ramp_counter_bits']
+        self.flux_ramp_ac_dc_mode = flux_ramp_cfg.get('ac_dc_mode')
         self.reset_rate_khz = tune_band_cfg.get('reset_rate_khz')
         self.fraction_full_scale = tune_band_cfg.get('fraction_full_scale')
 
@@ -970,6 +972,39 @@ class SmurfConfigPropertiesMixin:
         self._num_flux_ramp_counter_bits = value
 
     ## End num_flux_ramp_counter_bits property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start flux_ramp_ac_dc_mode property definition
+
+    # Getter
+    @property
+    def flux_ramp_ac_dc_mode(self):
+        """Cryocard flux-ramp coupling mode.
+
+        Returns ``"AC"`` or ``"DC"`` if the user specified a value in the
+        pysmurf configuration file, otherwise ``None`` (in which case
+        :func:`setup` leaves the cryocard relay alone). See issue #510.
+
+        Specified in the pysmurf configuration file as
+        ``flux_ramp:ac_dc_mode``.
+
+        See Also
+        --------
+        :func:`get_cryo_card_ac_dc_mode`,
+        :func:`CryoCard.set_ac_dc_relay`
+        """
+        return self._flux_ramp_ac_dc_mode
+
+    # Setter
+    @flux_ramp_ac_dc_mode.setter
+    def flux_ramp_ac_dc_mode(self, value):
+        if value is None:
+            self._flux_ramp_ac_dc_mode = None
+        else:
+            self._flux_ramp_ac_dc_mode = value.upper()
+
+    ## End flux_ramp_ac_dc_mode property definition
     ###########################################################################
 
     ###########################################################################

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -679,6 +679,22 @@ class SmurfControl(SmurfCommandMixin,
                          "failed!  Will assume no cryostat card is"
                          " connected and skip cryocard setup steps.")
 
+            # Apply user-specified flux ramp AC/DC coupling mode if given.
+            # Issue #510. If the cfg did not specify a mode, leave the
+            # cryocard relay in whatever state it is in.
+            if self._flux_ramp_ac_dc_mode is not None:
+                try:
+                    ac_dc = self._flux_ramp_ac_dc_mode
+                    self.C.set_ac_dc_relay(1 if ac_dc == 'AC' else 0)
+                    self.log(
+                        f"Set flux ramp coupling to {ac_dc}.",
+                        self.LOG_USER)
+                except Exception:
+                    self.log(
+                        "Failed to set flux ramp AC/DC coupling - "
+                        "cryocard may not be connected.",
+                        self.LOG_USER)
+
             # Setup how this slot handles timing. To take science data, each
             # SMuRF slot should receive timing from the backplane or RTM fiber
             # cable. Otherwise, the front panel external reference may also


### PR DESCRIPTION
## Summary

Closes #510.

Lets users specify the cryocard flux ramp AC/DC coupling mode from `experiment.cfg`. The hardware control (`CryoCard.set_ac_dc_relay`, added in #706) already existed but was never wired into `setup()` — the relay state was whatever the cryocard powered up with.

- `python/pysmurf/client/base/smurf_config.py` — add `Optional('ac_dc_mode', default=None)` to the `flux_ramp` schema, validated against `"AC"` / `"DC"` (case-insensitive).
- `python/pysmurf/client/base/smurf_config_properties.py` — load and expose as `flux_ramp_ac_dc_mode` property (uppercases on set; `None` when the key is absent).
- `python/pysmurf/client/base/smurf_control.py` — in `setup()`, after the existing cryocard try/except, drive the relay if the user supplied a value. Inside its own `try/except` so it does not abort `setup()` on systems with no cryocard.
- `cfg_files/template/template.cfg` — commented example documenting the new key.

When the cfg key is **absent**, `setup()` does not touch the relay, so every existing cfg file continues to behave exactly as before.

## Example usage

```jsonc
"flux_ramp" : {
    "num_flux_ramp_counter_bits" : 32,
    "ac_dc_mode" : "AC"   // or "DC"
},
```

## Out of scope

- The `select_ramp` cfg key still appears in some cfg files but is not in the schema and is not loaded at runtime. Orthogonal to #510 — left untouched.
- `flux_ramp_setup()` in `smurf_util.py` — AC/DC is a one-time hardware-init concern, not a per-ramp parameter.

## Test plan

- [x] `flake8 --count python/` — 0 findings (matches `.github/workflows/test-or-deploy.yml`)
- [x] Schema round-trip:
  - Cfg with no `ac_dc_mode` validates and `S.flux_ramp_ac_dc_mode is None`
  - `"AC"` / `"DC"` accepted; mixed case (`"Dc"`) accepted (case-insensitive)
  - `"bogus"` rejected as `SchemaError`
- [x] `cfg_files/template/template.cfg` still parses cleanly through the comment-stripping JSON loader
- [ ] Hardware smoke test on a system with a real C02/C04 cryocard:
  - Run `setup()` with `"ac_dc_mode": "AC"`, then `S.get_cryo_card_ac_dc_mode()` returns `"AC"`
  - Run again with `"DC"`, confirm `S.get_cryo_card_ac_dc_mode()` returns `"DC"`
  - With key absent, confirm no AC/DC log line and no relay write