### PR TITLE
fix(find_freq): Default to firmware-processed subbands (#482)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3452,11 +3452,11 @@ class SmurfTuneMixin(SmurfBase):
             The scan start frequency in MHz (from band center)
         stop_freq : float, optional, default 250
             The scan stop frequency in MHz (from band center)
-        subband : deprecated, use start_freq/stop_freq.
-            numpy.ndarray of int or None, optional, default None
-            An int array for the subbands.  If None, set to all
-            processed subbands =numpy.arange(13,115).
-            Takes precedent over start_freq/stop_freq.
+        subband : numpy.ndarray of int or None, optional, default None
+            An int array of subbands to sweep.  If None, defaults to
+            the intersection of the start_freq/stop_freq range with
+            the firmware's processed subbands (see
+            get_processed_subbands).
         tone_power : int or None, optional, default None
             The drive amplitude.  If None, takes from cfg.
         n_read : int, optional, default 2
@@ -3495,6 +3495,11 @@ class SmurfTuneMixin(SmurfBase):
             if stop_subband < start_subband:
                 step = -1
             subband = np.arange(start_subband, stop_subband+1, step)
+            # Restrict to subbands the firmware actually processes (#482).
+            processed = self.get_processed_subbands(band)
+            subband = np.intersect1d(subband, processed)
+            if step == -1:
+                subband = subband[::-1]
         else:
             sb, sbc = self.get_subband_centers(band)
             start_freq = sbc[subband[0]]

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2548,6 +2548,32 @@ class SmurfUtilMixin(SmurfBase):
         return np.sort(self.get_channel_order(
             channel_orderfile=channel_orderfile)[n_cut:-n_cut])
 
+    def get_processed_subbands(self, band):
+        """
+        Returns the subband indices that are actually processed by
+        the firmware (i.e. not trimmed at the band edges).  The cut
+        count is derived from get_number_processed_channels so the
+        result tracks any firmware variant (128- or 512-subband
+        bands).
+
+        Args
+        ----
+        band : int
+            Which band.
+
+        Returns
+        -------
+        processed_subbands : numpy.ndarray of int
+            Sorted array of processed subband indices.
+        """
+        n_subbands = self.get_number_sub_bands(band)
+        n_channels = self.get_number_channels(band)
+        n_proc_channels = self.get_number_processed_channels(band)
+        channels_per_subband = n_channels // n_subbands
+        n_cut_per_side = (
+            ((n_channels - n_proc_channels) // 2) // channels_per_subband)
+        return np.arange(n_cut_per_side, n_subbands - n_cut_per_side)
+
     def get_subband_from_channel(self, band, channel, channelorderfile=None,
             yml=None):
         """Returns subband number given a channel number


### PR DESCRIPTION
## Summary
- Closes #482. When `find_freq` is called with no `subband` argument, it now sweeps only the subbands the firmware actually processes (derived from `get_number_processed_channels`) instead of all 128 / 512 subbands.
- Adds a `get_processed_subbands(band)` helper next to `get_processed_channels` in `smurf_util.py`, scaling firmware-aware: returns `arange(12, 116)` for 128-subband firmware and `arange(48, 464)` for 512-subband firmware (both equal `0.8125 × n_subbands`).
- In `find_freq`, the default branch (`subband=None`) now intersects the `start_freq`/`stop_freq`-derived subband range with the processed-subband list. Behavior with an explicit `subband=` argument is unchanged.
- Replaces the misleading docstring that referenced a hardcoded `numpy.arange(13,115)` and an inverted "takes precedent" note.

## Test plan
- [x] `flake8 --count python/` passes (matches CI invocation in `.github/workflows/test-or-deploy.yml`).
- [x] Offline math check: `get_processed_subbands` returns expected ranges and lengths for both 128/2048 and 512/8192 firmware variants, with symmetric endpoints.
- [ ] On-hardware: run `S.find_freq(band)` (no `subband` arg) on a 128-subband system; confirm `freq_resp[band]['find_freq']['subband']` excludes 0–11 and 116–127, and that `setup_notches` still consumes `freq_resp` correctly.
- [ ] On-hardware: confirm a narrow user-supplied `start_freq`/`stop_freq` with `subband=None` yields the intersection of the user range and the processed range.
- [ ] Regression: pass an explicit `subband=np.arange(20,40)` and confirm behavior is unchanged.