### PR TITLE
fix(smurf_command.set_read_all): Use LOG_USER for consistency (#472)

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -668,7 +668,7 @@ class SmurfCommandMixin(SmurfBase):
         This call is necessary to read register with pollIntervale=0.
         """
         self._caput('AMCc.ReadAll', 1, wait_after=20, **kwargs)
-        self.log('ReadAll sent', self.LOG_INFO)
+        self.log('ReadAll sent', self.LOG_USER)
 
     def run_pwr_up_sys_ref(self,bay, **kwargs):
         """


### PR DESCRIPTION
## Summary

Closes #472.

`set_read_all` and the adjacent `run_pwr_up_sys_ref` in `smurf_command.py` both log a one-shot \"PV sent\" confirmation, but they used different verbosity flags — `LOG_INFO` vs. `LOG_USER`. The issue (open since 2020-07-21) asks for them to be made consistent.

This PR aligns `set_read_all` to `LOG_USER`. That direction matches:

- The dominant convention in `smurf_command.py` itself: 7 explicit `LOG_USER` + 65 default (level=0) calls vs. the single `LOG_INFO` outlier being fixed.
- Sibling files (`smurf_iv.py`, `smurf_tune.py`) which use `LOG_USER` for "operation done" confirmations and reserve `LOG_INFO` for verbose configuration/data dumps.
- Behaviour: at default ``verbose=0`` users will now see ``ReadAll sent`` the same way they already see ``PwrUpSysRef sent``. The opposite direction would have silently hidden a message users currently see.

Diff: 1 file changed, 1 insertion(+), 1 deletion(-).

## Test plan

- [x] `flake8 --count python/` → 0 errors (matches CI in `.github/workflows/test-or-deploy.yml`).
- [x] `grep -n 'self\.log(.*LOG_INFO' python/pysmurf/client/command/smurf_command.py` → no matches.
- [ ] CI: flake8, docker definitions, docs build.
- [ ] Manual on hardware: with default verbosity, calling ``S.set_read_all()`` prints ``ReadAll sent`` (previously hidden behind ``verbose>=1``).