### PR TITLE
feat(setup): Add enable_amp_drain option to enable 50K/HEMT Vd (#466)

### DIFF
--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -314,7 +314,8 @@ class SmurfControl(SmurfCommandMixin,
         # initialize outputs cfg
         self.config.update('outputs', {})
 
-    def setup(self, write_log=True, payload_size=2048, force_configure=False, **kwargs):
+    def setup(self, write_log=True, payload_size=2048, force_configure=False,
+              enable_amp_drain=False, **kwargs):
         r"""Configures SMuRF system.
 
         Sets up the SMuRF system by first loading hardware register
@@ -339,7 +340,9 @@ class SmurfControl(SmurfCommandMixin,
           configuration file.
         - Enables data streaming.
         - Sets mask and payload size to a single channel.
-        - Sets RF amplifier biases (without enabling drain voltages).
+        - Sets RF amplifier biases.  By default the drain voltages are
+          left disabled; pass ``enable_amp_drain=True`` to also enable
+          the 50K and HEMT drain voltages from the cfg defaults.
         - Configures timing based on pysmurf configuration file settings.
         - Resumes hardware logging if it was active at beginning.
 
@@ -366,6 +369,14 @@ class SmurfControl(SmurfCommandMixin,
             Whether or not to force configure if system has already
             been configured once by the currently running Rogue
             server.
+        enable_amp_drain : bool, optional, default False
+            If True, also enable the cryocard amplifier drain
+            voltages after setting the gate defaults.  For C02 this
+            enables the HEMT and 50K drain power supplies; for C04
+            this sets each amp's drain voltage to its
+            ``drain_volt_default`` from the cfg file (which
+            automatically enables the LDO).  If False (default), the
+            drains are left disabled and must be enabled manually.
         \**kwargs
             Arbitrary keyword arguments.  Passed to many, but not all,
             of the `_caput` calls.
@@ -673,7 +684,9 @@ class SmurfControl(SmurfCommandMixin,
 
                 # If C02, set the gate voltages to the default.
                 # If C04, also set the drain voltages to zero.
-                self.set_amp_defaults()
+                # If enable_amp_drain=True, also bring the drain
+                # voltages up from the cfg defaults.
+                self.set_amp_defaults(enable_drain=enable_amp_drain)
             except Exception:
                 self.log("Attempts to communicate with a cryocard "
                          "failed!  Will assume no cryostat card is"

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -4619,7 +4619,7 @@ class SmurfCommandMixin(SmurfBase):
 
         return amp_gate_currents
 
-    def set_amp_defaults(self):
+    def set_amp_defaults(self, enable_drain=False):
         """The pysmurf cfg file specifies the default power state, default
         gate voltage for the C02 amplifiers HEMT and 50K. Additionally
         it specifies the default drain voltage for the C04 hemt1,
@@ -4634,6 +4634,16 @@ class SmurfCommandMixin(SmurfBase):
         the current register reports that they are supposedly enabled,
         0x2.
 
+        Args
+        ----
+        enable_drain : bool, optional, default False
+            If True, also enable the amplifier drain voltages after
+            setting the gate defaults.  For C02, this enables the
+            HEMT and 50K drain power supplies.  For C04, this sets
+            each amp's drain voltage to its ``drain_volt_default``
+            from the cfg file (which automatically enables the LDO).
+            If False (default), drains are left disabled and the
+            user must enable them manually.
         """
         major, minor, patch = self.C.get_fw_version()
 
@@ -4647,6 +4657,10 @@ class SmurfCommandMixin(SmurfBase):
             volt = self.config.get('amplifier')['hemt_Vg']
             self.set_amp_gate_voltage('hemt', volt)
 
+            if enable_drain:
+                for amp in self.C.list_of_c02_amps:
+                    self.set_amp_drain_enable(amp, True)
+
         if major == 4:
             for amp in self.C.list_of_c04_amps:
 
@@ -4654,6 +4668,11 @@ class SmurfCommandMixin(SmurfBase):
 
                 gate_volt_default = self.config.config['amplifier'][amp]['gate_volt_default']
                 self.set_amp_gate_voltage(amp, gate_volt_default)
+
+            if enable_drain:
+                for amp in self.C.list_of_c04_amps:
+                    drain_volt_default = self.config.config['amplifier'][amp]['drain_volt_default']
+                    self.set_amp_drain_voltage(amp, drain_volt_default)
 
     def get_amplifier_biases(self):
         """For the C00, C01 and C02, return dictionary of all gate voltages,

--- a/scratch/shawn/scripts/shawnhammerfunctions.sh
+++ b/scratch/shawn/scripts/shawnhammerfunctions.sh
@@ -196,7 +196,14 @@ start_slot_tmux_serial () {
 
 run_pysmurf_setup () {
     slot_number=$1
-    tmux send-keys -t ${tmux_session_name}:${slot_number} 'S.setup()' C-m
+    # If enable_amp_drain=true is set in the startup cfg, ask pysmurf to
+    # bring up the 50K/HEMT drain voltages as part of setup.
+    if [ "$enable_amp_drain" = true ] ; then
+	setup_call='S.setup(enable_amp_drain=True)'
+    else
+	setup_call='S.setup()'
+    fi
+    tmux send-keys -t ${tmux_session_name}:${slot_number} "${setup_call}" C-m
 }
 
 is_slot_pysmurf_setup_complete() {
@@ -219,9 +226,17 @@ is_slot_pysmurf_setup_complete() {
 config_pysmurf_serial () {
     slot_number=$1
     pysmurf_docker=$2
-    
-    tmux send-keys -t ${tmux_session_name}:${slot_number} 'S.setup()' C-m    
-    
+
+    # If enable_amp_drain=true is set in the startup cfg, ask pysmurf to
+    # bring up the 50K/HEMT drain voltages as part of setup.
+    if [ "$enable_amp_drain" = true ] ; then
+	setup_call='S.setup(enable_amp_drain=True)'
+    else
+	setup_call='S.setup()'
+    fi
+
+    tmux send-keys -t ${tmux_session_name}:${slot_number} "${setup_call}" C-m
+
     # wait for setup to complete
     echo "-> Waiting for carrier setup (watching pysmurf docker ${pysmurf_docker})"
 
@@ -236,12 +251,12 @@ config_pysmurf_serial () {
 	echo '-> Carrier failed to configure.  Attach using `tmux a` to view errors.'
 	exit 1
     fi
-    
+
     echo "-> Carrier is configured."
-    
+
     if [ "$double_setup" = true ] ; then
-	sleep 2    
-	tmux send-keys -t ${tmux_session_name}:${slot_number} 'S.setup()' C-m    
+	sleep 2
+	tmux send-keys -t ${tmux_session_name}:${slot_number} "${setup_call}" C-m
 	sleep 5
 	
 	# wait for setup to complete


### PR DESCRIPTION
## Summary

Closes #466.  The issue (open since 2020-07-10) asked for an option in
``setup`` and ``shawnhammer`` to enable the 50K and HEMT drain voltages
during setup.  Until now ``S.setup()`` only programmed the gate DACs and
left the drain LDOs / drain DACs disabled — its docstring even called
this out: *"Sets RF amplifier biases (without enabling drain voltages)."*

This PR threads a new ``enable_amp_drain`` keyword through
``SmurfControl.setup()`` into ``SmurfCommandMixin.set_amp_defaults()``.
When ``True``:

- **C02** (``major == 1`` or ``10``): after the existing gate-voltage
  sets, calls ``self.set_amp_drain_enable(amp, True)`` for each amp in
  ``self.C.list_of_c02_amps`` (``hemt`` and ``50k``).  C02 drains are
  not DAC-programmable, so "enabling Vd" is enabling the LDO.
- **C04** (``major == 4``): after the existing gate-voltage sets, calls
  ``self.set_amp_drain_voltage(amp, drain_volt_default)`` for each amp
  in ``self.C.list_of_c04_amps``.  ``drain_volt_default`` is read from
  the cfg (already validated by ``smurf_config.py``) and
  ``set_amp_drain_voltage`` auto-enables the LDO when ``V > 0``.

Default is ``False`` so existing call sites — including
``SmurfControl.__init__``'s ``self.setup(payload_size=payload_size)`` —
are byte-for-byte unchanged.  The ``shawnhammer`` orchestration script
(``scratch/shawn/scripts/shawnhammerfunctions.sh``) honors a new
``enable_amp_drain=true`` startup-cfg variable in both
``run_pysmurf_setup`` (parallel path) and ``config_pysmurf_serial``
(serial / ``double_setup`` path); when set, the emitted ipython
command becomes ``S.setup(enable_amp_drain=True)``.

Diff: 3 files changed, 59 insertions(+), 12 deletions(-).

## Test plan

- [x] ``flake8 --count python/`` → 0 errors (matches CI in
  ``.github/workflows/test-or-deploy.yml``).
- [x] ``python3 -c "import ast; ast.parse(open('.../smurf_control.py').read()); ast.parse(open('.../smurf_command.py').read())"`` passes.
- [x] ``bash -n scratch/shawn/scripts/shawnhammerfunctions.sh`` passes.
- [x] Default-path regression (read by inspection): ``S.setup()`` with no
  args still calls ``set_amp_defaults()`` with ``enable_drain=False`` and
  takes no new cryocard actions; the new logic is strictly guarded
  under ``if enable_drain:``.
- [ ] CI: flake8, docker definitions, docs build, server/client tests.
- [ ] Manual on hardware (C02): ``S.setup(enable_amp_drain=True)`` →
  ``S.get_amplifier_biases()`` reports ``hemt_enable=True`` and
  ``50k_enable=True``, drain currents non-zero and within nominal range.
- [ ] Manual on hardware (C04): ``S.setup(enable_amp_drain=True)`` →
  ``S.get_amplifier_biases()`` reports each amp's ``*_drain_volt``
  within ~1% of its cfg ``drain_volt_default`` and ``*_enable=True``.
- [ ] Manual: ``S.setup()`` with no args still leaves every amp's
  ``*_enable=False`` (matches pre-change behaviour).
- [ ] Manual on shawnhammer: with ``enable_amp_drain=true`` in the
  startup cfg the slot pane shows ``S.setup(enable_amp_drain=True)``;
  with the variable unset it shows ``S.setup()`` exactly as today.