### PR TITLE
docs(tracking_setup): Document return values and return_data flag (#463)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2571,7 +2571,11 @@ class SmurfTuneMixin(SmurfBase):
             registers and contribute to incrased noise.
             Too high of lms_gain will overflow the register and greatly incrase noise.
         return_data : bool, optional, default True
-            Whether or not to return f, df, sync.
+            If True, take debug data (via take_debug_data) and
+            return (f, df, sync).  If False AND make_plot is also
+            False, the debug data acquisition is skipped entirely,
+            saving time.  Used internally by track_and_check, which
+            does not need the returned arrays.
         feedback_start_frac : float or None, optional, default None
             The fraction of the full flux ramp at which to stop
             applying feedback in each flux ramp cycle.  Must be in
@@ -2584,6 +2588,23 @@ class SmurfTuneMixin(SmurfBase):
             Whether to setup the flux ramp.
         plotname_append : str, optional, default ''
             Optional string to append plots with.
+
+        Returns
+        -------
+        f : float array or None
+            The frequency response per channel from take_debug_data.
+            Only returned when return_data=True.  None on the early
+            error path (both meas_lms_freq and meas_flux_ramp_amp
+            requested).
+        df : float array or None
+            The frequency error per channel.  Same conditions as f.
+        sync : float array or None
+            The sync count from the flux ramp.  Same conditions as f.
+
+        Notes
+        -----
+        When return_data=False this function returns None (no
+        tuple).
         """
         if reset_rate_khz is None:
             reset_rate_khz = self._reset_rate_khz


### PR DESCRIPTION
## Summary

Closes #463 (open since 2020-07-10).

The issue reports two problems with `tracking_setup` in `python/pysmurf/client/tune/smurf_tune.py`:

1. The docstring has no `Returns` section.
2. The reporter asks whether the `return_data` argument can be eliminated.

This PR is a **docstring-only** change addressing both:

- Adds a `Returns` section documenting `f`, `df`, `sync` — descriptions mirror `take_debug_data` (`python/pysmurf/client/util/smurf_util.py:69-76`), since that's the function that actually produces those arrays.
- Rewrites the `return_data` arg description to explain *why* it's optional: it gates the expensive `take_debug_data` call (`smurf_tune.py:2723` — `if return_data or make_plot:`). `track_and_check` (`smurf_tune.py:2937`) calls `tracking_setup(..., return_data=False)` to skip the data take entirely. So the argument has a real performance purpose and cannot simply be removed without regressing `track_and_check`.
- Adds a `Notes` block clarifying that `return_data=False` returns `None` (no tuple), distinct from the early-error path that returns `(None, None, None)`.

Diff: 1 file changed, +22/-1 lines. No executable code is touched.

## Test plan

- [x] `flake8 --count python/` → 0 errors (matches CI in `.github/workflows/test-or-deploy.yml`).
- [x] AST parse of the modified docstring confirms the `Returns` and `Notes` sections render correctly.
- [ ] CI: flake8, docker definitions, docs build.