### PR TITLE
fix(fast_eta_scan): Actually use n_read by averaging multiple scans

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3834,20 +3834,18 @@ class SmurfTuneMixin(SmurfBase):
         self.set_eta_scan_channel(band, subchan)
         self.set_eta_scan_dwell(band, 0)
 
-        self.set_run_eta_scan(band, 1)
+        resp_accum = np.zeros((int(n_read), len(freq)), dtype=complex)
+        for n in range(int(n_read)):
+            self.set_run_eta_scan(band, 1)
 
-        I = self.get_eta_scan_results_real(band, count=len(freq))
-        Q = self.get_eta_scan_results_imag(band, count=len(freq))
+            I = self.get_eta_scan_results_real(band, count=len(freq))
+            Q = self.get_eta_scan_results_imag(band, count=len(freq))
+
+            resp_accum[n] = np.asarray(I) + 1j*np.asarray(Q)
+
+        response = np.mean(resp_accum, axis=0)
 
         self.band_off(band)
-
-        response = np.zeros((len(freq), ), dtype=complex)
-
-        for index in range(len(freq)):
-            Ielem = I[index]
-            Qelem = Q[index]
-
-            response[index] = Ielem + 1j*Qelem
 
         if make_plot:
             # To do : make plotting


### PR DESCRIPTION
## Summary
- `fast_eta_scan` accepted `n_read` in its signature and docstring but never used it — every call did exactly one scan regardless of the requested count. The only production caller (`eta_fit`, smurf_tune.py:1312) hardcodes `n_read=2`, so users have silently been getting one scan where the API promises two.
- Lifts the four `set_eta_scan_*` setters out of the read path (they don't vary between reads), loops `set_run_eta_scan` + I/Q readback `n_read` times into a `(n_read, len(freq))` complex accumulator, and averages with `np.mean(axis=0)`. Same idiom as the recent `full_band_ampl_sweep` fix (009b8623) and `full_band_resp`.
- Vectorizes the previous per-element `for index in range(len(freq))` complex construction into one `np.asarray(I) + 1j*np.asarray(Q)`, folded into the loop body.
- `n_read=1` is bit-exact with prior behavior (`np.mean` over a length-1 axis is the identity).

Closes #450

## Test plan
- [ ] CI flake8 passes (locally `flake8 --count python/pysmurf/client/tune/smurf_tune.py` → 0)
- [ ] CI client/server docker tests pass
- [ ] On hardware: run `eta_fit` with `use_slow_eta=True` (the production path that calls `fast_eta_scan(..., 2, ...)`) and confirm the eta estimator behaves as before — averaging two reads should reduce noise vs. a single read.
- [ ] On hardware: spot-check `fast_eta_scan` directly with `n_read=1` and confirm the returned `response` matches a single-scan reference.