### PR TITLE
refactor(flux_ramp_setup): Use set_flux_ramp_freq instead of duplicating calc (#453)

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -4818,6 +4818,11 @@ class SmurfCommandMixin(SmurfBase):
            produce a train of pulses 1x or 2x 307.2 MHz ticks wide,
            but it will be mostly high.
 
+        Returns
+        -------
+        int
+            The integer ``RampMaxCnt`` value programmed (after rounding).
+
         See Also
         --------
         get_flux_ramp_freq : Gets the flux ramp reset rate.
@@ -4846,6 +4851,7 @@ class SmurfCommandMixin(SmurfBase):
                 f' reset rate to {val_rounded} kHz instead.',
                 self.LOG_ERROR)
         self.set_ramp_max_cnt(cnt_rounded, **kwargs)
+        return cnt_rounded
 
     def get_flux_ramp_freq(self, **kwargs):
         r"""Returns flux ramp reset rate in kHz.

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -3186,9 +3186,10 @@ class SmurfTuneMixin(SmurfBase):
         digitizerFrequencyMHz = self.get_digitizer_frequency_mhz(band)
         dspClockFrequencyMHz=digitizerFrequencyMHz/2
 
-        desiredRampMaxCnt = ((dspClockFrequencyMHz*1e3)/
-            (reset_rate_khz)) - 1
-        rampMaxCnt = np.floor(desiredRampMaxCnt)
+        # Program the flux ramp reset rate via the dedicated setter so the
+        # rounding/precision/warning logic lives in one place (issue #453).
+        rampMaxCnt = self.set_flux_ramp_freq(reset_rate_khz,
+            write_log=write_log)
 
         resetRate = (dspClockFrequencyMHz * 1e6) / (rampMaxCnt + 1)
 
@@ -3250,7 +3251,6 @@ class SmurfTuneMixin(SmurfBase):
         self.set_low_cycle(LowCycle, write_log=write_log)
         self.set_high_cycle(HighCycle, write_log=write_log)
         self.set_k_relay(KRelay, write_log=write_log)
-        self.set_ramp_max_cnt(rampMaxCnt, write_log=write_log)
         self.set_pulse_width(PulseWidth, write_log=write_log)
         self.set_debounce_width(DebounceWidth, write_log=write_log)
         self.set_ramp_slope(RampSlope, write_log=write_log)


### PR DESCRIPTION
## Summary

Closes #453.

`SmurfCommandMixin.set_flux_ramp_freq` had zero production call sites, while `SmurfTuneMixin.flux_ramp_setup` recomputed the same `ramp_max_cnt` inline. The two implementations had also drifted:

| Aspect | `set_flux_ramp_freq` | `flux_ramp_setup` (before) |
| --- | --- | --- |
| Rounding | `round()` | `np.floor()` |
| Digitizer-freq precision workaround (PR #451) | yes (`as_string=True`) | no |
| Warns when requested rate doesn't integer-divide DSP clock | yes | no |

This consolidates the rounding/precision/warning logic in `set_flux_ramp_freq` and has `flux_ramp_setup` call it.

- `set_flux_ramp_freq` now returns the integer `RampMaxCnt` it programmed (additive, non-breaking).
- `flux_ramp_setup` calls `set_flux_ramp_freq(reset_rate_khz, write_log=...)`, captures the return value, and uses it for downstream `resetRate` / `FastSlowStepSize` math. The redundant `set_ramp_max_cnt` write later in the function is removed.

Net diff: +10 / -4 across two files.

`scratch/cyu/tune_scratch.py:2638-2642` has the same legacy calculation but is out-of-tree experimental code not imported by the package — left untouched.

## Test plan

- [x] `flake8 --count python/` reports `0` locally with the same plugin set CI uses (`flake8-rst-docstrings`, `flake8-sfs`, `flake8-import-order`).
- [x] `python -m py_compile` on both edited files.
- [ ] Hardware smoke test on a SMuRF crate: call `flux_ramp_setup(reset_rate_khz=4, fraction_full_scale=0.5, band=0)` and confirm `get_flux_ramp_freq()` returns ~4 kHz with no exceptions.
- [ ] Hardware behavior check for a non-divisor rate (e.g. `reset_rate_khz=7`): the warning previously emitted only by `set_flux_ramp_freq` should now surface from `flux_ramp_setup` too.