### PR TITLE
perf(set_tes_bias_bipolar): Use array write for +/- DAC pair (#426)

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2710,7 +2710,13 @@ class SmurfUtilMixin(SmurfBase):
         volts.  Asserts if the requested bias group is not defined in
         the pysmurf configuration file.  The positive DAC in the bias
         group is set to +volt/2, while the negative DAC in the bias
-        group is set to -volt/2.
+        group is set to -volt/2.  The +/- DAC pair is updated using a
+        single pyrogue array write so both DACs land in one register
+        transaction (one SPI burst), eliminating the latency between
+        the positive and negative DAC settles.  Only the two DACs
+        assigned to the requested TES bias group are touched; the
+        enable status and output voltage of all other DACs are
+        maintained.
 
         Args
         ----
@@ -2751,12 +2757,20 @@ class SmurfUtilMixin(SmurfBase):
             volts_pos *= -1
             volts_neg *= -1
 
-        if do_enable:
-            self.set_rtm_slow_dac_enable(dac_positive, 2, **kwargs)
-            self.set_rtm_slow_dac_enable(dac_negative, 2, **kwargs)
+        # Read-modify-write the full 32-DAC array so the +/- pair is
+        # written in a single block transaction.  DAC IDs in
+        # bias_group_to_pair are 1-indexed; the array is 0-indexed.
+        dac_volt_array = self.get_rtm_slow_dac_volt_array()
+        dac_volt_array[dac_positive - 1] = volts_pos
+        dac_volt_array[dac_negative - 1] = volts_neg
 
-        self.set_rtm_slow_dac_volt(dac_positive, volts_pos, **kwargs)
-        self.set_rtm_slow_dac_volt(dac_negative, volts_neg, **kwargs)
+        if do_enable:
+            dac_enable_array = self.get_rtm_slow_dac_enable_array()
+            dac_enable_array[dac_positive - 1] = 2
+            dac_enable_array[dac_negative - 1] = 2
+            self.set_rtm_slow_dac_enable_array(dac_enable_array, **kwargs)
+
+        self.set_rtm_slow_dac_volt_array(dac_volt_array, **kwargs)
 
     def set_tes_bias_bipolar_array(self, bias_group_volt_array, do_enable=False,
                                    **kwargs):


### PR DESCRIPTION
## Summary

Resolves #426.

`set_tes_bias_bipolar` previously set the +/- DACs of a TES bias group with **two serial `set_rtm_slow_dac_volt` calls**, producing a visible inter-DAC settle gap on scope traces — each call is a full pysmurf → rogue → AXI-lite → SPI round trip.

This PR switches to a read-modify-write of the full 32-DAC array and dispatches via `set_rtm_slow_dac_volt_array`, so the +/- pair lands in a single block transaction (one SPI burst). Same treatment for the optional `do_enable=True` path (now uses `set_rtm_slow_dac_enable_array`). The pattern mirrors what `set_tes_bias_bipolar_array` has done all along.

Only the two DACs assigned to the requested bias group are touched; other DACs (e.g. camera-card slow DACs) are preserved by the read-back.

- 1 file changed, 19 insertions(+), 5 deletions(-)
- No new helpers; reuses `get_rtm_slow_dac_volt_array` / `set_rtm_slow_dac_volt_array` / `get_rtm_slow_dac_enable_array` / `set_rtm_slow_dac_enable_array` already defined in `smurf_command.py`.
- Docstring updated to call out the single-transaction behavior and preservation of other DACs.

## Caller-impact note

`set_tes_bias_bipolar` is called inside `bias_bump` GCP mode (`smurf_util.py:3592-3604`) with `wait_done=False`. After this change each call adds a `get_rtm_slow_dac_volt_array` read (default `wait_done=True`) before the array write. Inter-group timing in GCP mode is gated by `gcp_wait`/`gcp_between` sleeps that dominate any read overhead, and the non-GCP path already uses `set_tes_bias_bipolar_array` with the same read-modify-write — so the precedent for \"read is acceptable\" is established. The +/- skew within each group (the actual issue) is removed.

## Test plan

- [x] `flake8 --count python/` → 0 errors (matches `.github/workflows/test-or-deploy.yml`)
- [ ] **Hardware bench-test** (UCSD or SLAC): repeat the scope-trace measurement from #426 — trigger on a `set_tes_bias_bipolar(bias_group, V)` call, probe the +/- DAC outputs, and confirm the +/- skew has collapsed to roughly one CPLD-sequential-clock interval (per Mitch's note in the issue thread) instead of the inter-rogue-transaction gap shown in the original trace.
- [ ] **Cryostat smoke test**: run `overbias_tes` and `bias_bump` in both GCP and non-GCP modes; confirm bias readback matches commanded values and no IV/overbias regressions.