### PR TITLE
fix(stop_tes_bipolar_waveform): Restore pre-play TES bias instead of zeroing (#425)

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4285,6 +4285,16 @@ class SmurfUtilMixin(SmurfBase):
         dac_positive = dac_positives[dac_idx]
         dac_negative = dac_negatives[dac_idx]
 
+        # Cache the pre-waveform TES bias before the DAC is disturbed so
+        # stop_tes_bipolar_waveform can restore it (issue #425). Only cache
+        # if no entry exists, so back-to-back play() calls without an
+        # intervening stop() preserve the original pre-play value.
+        if not hasattr(self, '_tes_bipolar_pre_waveform_bias'):
+            self._tes_bipolar_pre_waveform_bias = {}
+        if bias_group not in self._tes_bipolar_pre_waveform_bias:
+            self._tes_bipolar_pre_waveform_bias[bias_group] = \
+                self.get_tes_bias_bipolar(bias_group)
+
         # https://confluence.slac.stanford.edu/display/SMuRF/SMuRF+firmware#SMuRFfirmware-RTMDACarbitrarywaveforms
         # Target the two bipolar DACs assigned to this bias group:
         self.set_dac_axil_addr(0, dac_positive)
@@ -4328,8 +4338,11 @@ class SmurfUtilMixin(SmurfBase):
         # Enable waveform generation (3=on both DACs)
         self.set_rtm_arb_waveform_enable(0)
 
-        # Zero TES biases on this bias group
-        self.set_tes_bias_bipolar(bias_group, 0)
+        # Restore the TES bias to its pre-waveform value (issue #425).
+        # Falls back to 0V when no cached value exists (e.g. stop()
+        # called without a prior play() this session).
+        cache = getattr(self, '_tes_bipolar_pre_waveform_bias', {})
+        self.set_tes_bias_bipolar(bias_group, cache.pop(bias_group, 0))
 
     @set_action()
     def get_sample_frequency(self):


### PR DESCRIPTION
## Summary

Closes #425.

`stop_tes_bipolar_waveform()` previously zeroed the TES bias to 0V (`smurf_util.py:4332`), throwing away whatever bias the user had set before `play_tes_bipolar_waveform()` started. The original implementer noted in the issue thread that the right fix is to cache the DAC setting at play-time and restore it at stop-time — this PR does exactly that.

### Behavior change

| Sequence | Before | After |
|---|---|---|
| `set_bias(1.5)` → `play()` → `stop()` | bias = 0.0V | bias = 1.5V (restored) |
| `stop()` without prior `play()` | bias = 0.0V | bias = 0.0V (fallback preserved) |
| `play()` → `play()` → `stop()` (back-to-back) | bias = 0.0V | bias = pre-first-play (cache is idempotent) |

### Implementation

`python/pysmurf/client/util/smurf_util.py` — two surgical edits:

1. **`play_tes_bipolar_waveform`** — cache `get_tes_bias_bipolar(bias_group)` into a per-bias-group dict on `self`, *before* any DAC-disturbing call (`set_dac_axil_addr`, `set_rtm_arb_waveform_enable`). Lazy `hasattr` init avoids touching the mixin `__init__` chain. Caches only when no entry exists, so back-to-back `play()` calls preserve the original pre-play value.

2. **`stop_tes_bipolar_waveform`** — `cache.pop(bias_group, 0)` reads-and-clears in one call, with a 0V fallback that preserves today's behavior for `stop()`-without-`play()` callers.

`play_sine_tes` and the internal caller `probe_tes_bias_transfer_function` (line ~4434) get the new behavior automatically — both go through `play_tes_bipolar_waveform`.

Diff: 1 file changed, 15 insertions(+), 2 deletions(-). No new public API, no new kwargs, no `__init__` changes.

### Why not the unmerged `issue678` attempt?

Commit `de82b738` on the unmerged `issue678` branch tried `set_tes_bias_bipolar(bg, self.get_tes_bias_bipolar(bg))` inside `stop()`. That reads the live DAC value while the waveform is still active — i.e., the indeterminate sample the issue is about. This PR avoids that pitfall by capturing the value at play-time, before the engine perturbs the DAC.

## Test plan

- [x] `flake8 --count python/` returns 0 (matches `Flake8 Tests` job in `.github/workflows/test-or-deploy.yml`)
- [ ] CI: flake8, docker definitions, docs build
- [ ] Hardware verification on a SMuRF system:
  - `S.set_tes_bias_bipolar(bg, 1.5)` → `S.get_tes_bias_bipolar(bg)` ≈ 1.5
  - `S.play_sine_tes(bg, tone_amp=0.1, tone_freq=10)`
  - `S.stop_tes_bipolar_waveform(bg)` → `S.get_tes_bias_bipolar(bg)` ≈ 1.5 (was 0.0 before this fix)
  - In a fresh session, `S.stop_tes_bipolar_waveform(bg)` without prior `play()` → bias = 0.0V (fallback preserved)