### PR TITLE
feat(SmurfConfig): Add `processor` cfg block for rogue4 SmurfProcessor (#444)

### DIFF
--- a/cfg_files/template/template.cfg
+++ b/cfg_files/template/template.cfg
@@ -268,25 +268,24 @@
 
 "fs" : 200.0,
 
-# This section is for smurf_to_mce, the transmission from SMuRF to the
-# Keck GCP. This is mostly depracated.
-"smurf_to_mce" : {
-	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
-	"mask_file" : "/data/smurf2mce_config/mask.txt",
-	"receiver_ip" : "tcp://192.168.3.1:3334",
-	"port_number" : "3334",
-	"filter_freq" : 63,
+# Rogue4 SmurfProcessor (downsampling-filter + downsampler + unwrapper)
+# parameters.  Every key is optional; omitted keys take the schema
+# default shown below.  Replaces the deprecated rogue3-era
+# "smurf_to_mce" block.
+"processor" : {
+	# IIR downsampling filter.  filter_freq + filter_order are
+	# converted to A/B coefficients via scipy.signal.butter at setup.
+	"filter_disable" : false,
+	"filter_freq" : 63.0,
 	"filter_order" : 4,
 	"filter_gain" : 1.0,
-	"file_name_extend" : 1,
-	"data_frames" : 300000,
-	"static_mask" : 0,
-	"num_averages" : 20,
-	# Kludge to account for offset in gcp channel number in early
-	# versios of the DSPv3 fw.  May be different for each band, in
-	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
-	# in fw, so this should be unnecessary soon.
-	"mask_channel_offset" : 0
+	# Downsampler.  "internal" downsamples by an integer factor;
+	# "external" gates the downsampler from the timing-system bitmask.
+	"downsample_mode" : "internal",
+	"downsample_factor" : 20,
+	"downsample_external_bitmask" : 0,
+	# Phase unwrapper.  Disable to bypass.
+	"unwrapper_disable" : false
 },
 
 "default_data_dir": "/data/smurf_data",

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -773,9 +773,49 @@ class SmurfConfig:
         }
         #### Done specifying timing-related schema
 
-        #### Start specifying smurf2mce
+        #### Start specifying processor
         # System should be smart enough to determine fs on the fly.
         schema_dict["fs"] = And(Use(float), lambda f: f > 0)
+
+        # Rogue4 SmurfProcessor: downsampling-filter and unwrapper settings.
+        # All fields optional with defaults that match firmware behavior, so
+        # cfgs without a "processor" block load identically to before.  The
+        # legacy "smurf_to_mce" block is parsed-but-ignored (extra keys).
+        processor_default_dict = {
+            'filter_disable' : False,
+            'filter_freq' : 63.0,
+            'filter_order' : 4,
+            'filter_gain' : 1.0,
+            'downsample_mode' : 'internal',
+            'downsample_factor' : 20,
+            'downsample_external_bitmask' : 0,
+            'unwrapper_disable' : False,
+        }
+        pdd_key = Optional("processor", default=processor_default_dict)
+        schema_dict[pdd_key] = {
+            Optional('filter_disable',
+                     default=processor_default_dict['filter_disable']): bool,
+            Optional('filter_freq',
+                     default=processor_default_dict['filter_freq']):
+                And(Use(float), lambda f: f > 0),
+            Optional('filter_order',
+                     default=processor_default_dict['filter_order']):
+                And(int, lambda n: 1 <= n <= 15),
+            Optional('filter_gain',
+                     default=processor_default_dict['filter_gain']):
+                And(Use(float), lambda f: f > 0),
+            Optional('downsample_mode',
+                     default=processor_default_dict['downsample_mode']):
+                And(str, lambda s: s in ('internal', 'external')),
+            Optional('downsample_factor',
+                     default=processor_default_dict['downsample_factor']):
+                And(int, lambda n: n >= 1),
+            Optional('downsample_external_bitmask',
+                     default=processor_default_dict['downsample_external_bitmask']):
+                And(int, lambda n: n >= 0),
+            Optional('unwrapper_disable',
+                     default=processor_default_dict['unwrapper_disable']): bool,
+        }
 
         def user_has_write_access(dirpath):
             return os.access(dirpath, os.W_OK)

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -129,6 +129,16 @@ class SmurfConfigPropertiesMixin:
         # Reading/writing data
         self._fs = None
 
+        # SMuRF processor (rogue4 SmurfProcessor downsampling-filter chain)
+        self._filter_disable = None
+        self._filter_freq = None
+        self._filter_order = None
+        self._filter_gain = None
+        self._downsample_mode = None
+        self._downsample_factor = None
+        self._downsample_external_bitmask = None
+        self._unwrapper_disable = None
+
         # In fridge
         self._R_sh = None
 
@@ -265,6 +275,20 @@ class SmurfConfigPropertiesMixin:
 
         ## Reading/writing data
         self.fs = config.get('fs')
+
+        ## SMuRF processor
+        # The schema's Optional(...) defaults populate every sub-key when
+        # the user omits the block, so a plain config.get('processor') is
+        # always a fully-populated dict here.
+        processor_cfg = config.get('processor')
+        self.filter_disable = processor_cfg['filter_disable']
+        self.filter_freq = processor_cfg['filter_freq']
+        self.filter_order = processor_cfg['filter_order']
+        self.filter_gain = processor_cfg['filter_gain']
+        self.downsample_mode = processor_cfg['downsample_mode']
+        self.downsample_factor = processor_cfg['downsample_factor']
+        self.downsample_external_bitmask = processor_cfg['downsample_external_bitmask']
+        self.unwrapper_disable = processor_cfg['unwrapper_disable']
 
         ## In fridge
         self.R_sh = config.get('R_sh')
@@ -2594,4 +2618,234 @@ class SmurfConfigPropertiesMixin:
         self._att_dc = value
 
     ## End att_dc property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start filter_disable property definition
+
+    # Getter
+    @property
+    def filter_disable(self):
+        """SMuRF processor downsampling-filter disable bit.
+
+        If True, the rogue4 SmurfProcessor IIR filter is bypassed and
+        incoming data passes straight to the downsampler.
+
+        Specified in the pysmurf configuration file as
+        `processor:filter_disable`.
+
+        See Also
+        --------
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_filter_disable`
+
+        """
+        return self._filter_disable
+
+    # Setter
+    @filter_disable.setter
+    def filter_disable(self, value):
+        self._filter_disable = value
+
+    ## End filter_disable property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start filter_freq property definition
+
+    # Getter
+    @property
+    def filter_freq(self):
+        """SMuRF processor downsampling-filter cutoff frequency, in Hz.
+
+        Used together with :attr:`filter_order` to derive the IIR A/B
+        coefficients via :func:`scipy.signal.butter` at setup time.
+        Normalized against the flux-ramp rate (the filter's input
+        sample rate is one sample per channel per flux-ramp reset).
+
+        Specified in the pysmurf configuration file as
+        `processor:filter_freq`.
+
+        See Also
+        --------
+        :attr:`filter_order`, :attr:`reset_rate_khz`
+
+        """
+        return self._filter_freq
+
+    # Setter
+    @filter_freq.setter
+    def filter_freq(self, value):
+        self._filter_freq = value
+
+    ## End filter_freq property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start filter_order property definition
+
+    # Getter
+    @property
+    def filter_order(self):
+        """SMuRF processor downsampling-filter order.
+
+        Order of the Butterworth filter whose A/B coefficients are
+        loaded into the rogue4 SmurfProcessor.  Must be 1..15 (the
+        firmware register holds 16 taps).
+
+        Specified in the pysmurf configuration file as
+        `processor:filter_order`.
+
+        See Also
+        --------
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_filter_order`
+
+        """
+        return self._filter_order
+
+    # Setter
+    @filter_order.setter
+    def filter_order(self, value):
+        self._filter_order = value
+
+    ## End filter_order property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start filter_gain property definition
+
+    # Getter
+    @property
+    def filter_gain(self):
+        """SMuRF processor downsampling-filter gain.
+
+        Specified in the pysmurf configuration file as
+        `processor:filter_gain`.
+
+        See Also
+        --------
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_filter_gain`
+
+        """
+        return self._filter_gain
+
+    # Setter
+    @filter_gain.setter
+    def filter_gain(self, value):
+        self._filter_gain = value
+
+    ## End filter_gain property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start downsample_mode property definition
+
+    # Getter
+    @property
+    def downsample_mode(self):
+        """SMuRF processor downsampler mode.
+
+        Either ``'internal'`` (downsample by an integer factor) or
+        ``'external'`` (gate the downsampler from the timing system
+        bitmask).
+
+        Specified in the pysmurf configuration file as
+        `processor:downsample_mode`.
+
+        See Also
+        --------
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_downsample_mode`
+
+        """
+        return self._downsample_mode
+
+    # Setter
+    @downsample_mode.setter
+    def downsample_mode(self, value):
+        self._downsample_mode = value
+
+    ## End downsample_mode property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start downsample_factor property definition
+
+    # Getter
+    @property
+    def downsample_factor(self):
+        """SMuRF processor internal downsample factor.
+
+        Only used when :attr:`downsample_mode` is ``'internal'``.
+
+        Specified in the pysmurf configuration file as
+        `processor:downsample_factor`.
+
+        See Also
+        --------
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_downsample_factor`
+
+        """
+        return self._downsample_factor
+
+    # Setter
+    @downsample_factor.setter
+    def downsample_factor(self, value):
+        self._downsample_factor = value
+
+    ## End downsample_factor property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start downsample_external_bitmask property definition
+
+    # Getter
+    @property
+    def downsample_external_bitmask(self):
+        """SMuRF processor external downsampler bitmask.
+
+        Only used when :attr:`downsample_mode` is ``'external'``.
+
+        Specified in the pysmurf configuration file as
+        `processor:downsample_external_bitmask`.
+
+        See Also
+        --------
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_downsample_external_bitmask`
+
+        """
+        return self._downsample_external_bitmask
+
+    # Setter
+    @downsample_external_bitmask.setter
+    def downsample_external_bitmask(self, value):
+        self._downsample_external_bitmask = value
+
+    ## End downsample_external_bitmask property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start unwrapper_disable property definition
+
+    # Getter
+    @property
+    def unwrapper_disable(self):
+        """SMuRF processor unwrapper disable bit.
+
+        If True, the rogue4 SmurfProcessor unwrapper is bypassed.
+
+        Specified in the pysmurf configuration file as
+        `processor:unwrapper_disable`.
+
+        See Also
+        --------
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_unwrapper_disable`
+
+        """
+        return self._unwrapper_disable
+
+    # Setter
+    @unwrapper_disable.setter
+    def unwrapper_disable(self, value):
+        self._unwrapper_disable = value
+
+    ## End unwrapper_disable property definition
     ###########################################################################

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -20,6 +20,7 @@ import os
 import time
 
 import numpy as np
+import scipy.signal as signal
 
 from pysmurf.client.base.smurf_config import SmurfConfig
 from pysmurf.client.base.smurf_config_properties import SmurfConfigPropertiesMixin
@@ -661,6 +662,55 @@ class SmurfControl(SmurfCommandMixin,
             # Set payload size and mask to a single channel
             self.set_payload_size(payload_size)
             self.set_channel_mask([0])
+
+            # Configure the rogue4 SmurfProcessor (filter + downsampler +
+            # unwrapper).  Each property is None when no `processor` cfg
+            # block is loaded (e.g. SmurfControl was constructed without a
+            # cfg file); skip those so we leave the firmware defaults in
+            # place.
+            if self._unwrapper_disable is not None:
+                self.set_unwrapper_disable(self._unwrapper_disable,
+                                           write_log=write_log)
+            if self._filter_disable is not None:
+                self.set_filter_disable(self._filter_disable,
+                                        write_log=write_log)
+            if self._filter_order is not None:
+                self.set_filter_order(self._filter_order,
+                                      write_log=write_log)
+            if self._filter_gain is not None:
+                self.set_filter_gain(self._filter_gain,
+                                     write_log=write_log)
+            if (self._filter_freq is not None and
+                    self._filter_order is not None and
+                    self._reset_rate_khz is not None):
+                # The SmurfProcessor IIR filter sees one sample per
+                # channel per flux-ramp reset, so its input sample rate
+                # equals the flux ramp rate.  scipy.signal.butter takes
+                # cutoff normalized to Nyquist (= fs/2), hence the
+                # 2*freq/fs scaling.  Coefficient arrays are padded out
+                # to the firmware register length of 16 with zeros
+                # (matches the rogue4 GeneralAnalogFilter shape).  Same
+                # math as SmurfUtilMixin.set_filter_params at
+                # python/pysmurf/client/util/smurf_util.py:3380.
+                filter_input_rate = self._reset_rate_khz * 1.0e3
+                b, a = signal.butter(
+                    self._filter_order,
+                    2 * self._filter_freq / filter_input_rate)
+                a_padded = list(a) + [0.0] * (16 - len(a))
+                b_padded = list(b) + [0.0] * (16 - len(b))
+                self.set_filter_a(a_padded, write_log=write_log)
+                self.set_filter_b(b_padded, write_log=write_log)
+            if self._downsample_mode is not None:
+                self.set_downsample_mode(self._downsample_mode)
+                if self._downsample_mode == 'internal':
+                    if self._downsample_factor is not None:
+                        self.set_downsample_factor(
+                            self._downsample_factor,
+                            write_log=write_log)
+                elif self._downsample_mode == 'external':
+                    if self._downsample_external_bitmask is not None:
+                        self.set_downsample_external_bitmask(
+                            self._downsample_external_bitmask)
 
             try:
                 ## Removed this because better error handling for cc

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -6313,6 +6313,36 @@ class SmurfCommandMixin(SmurfBase):
             self.smurf_processor + self._unwrapper_reset_reg,
             1, **kwargs)
 
+    _unwrapper_disable_reg = 'Unwrapper.Disable'
+
+    def set_unwrapper_disable(self, disable_status, **kwargs):
+        """
+        If Disable is set to True, then the unwrapper is bypassed and
+        incoming data passes through to the next processing block
+        unchanged.
+
+        Args
+        ----
+        bool
+            The status of the Disable bit.
+        """
+        self._caput(
+            self.smurf_processor + self._unwrapper_disable_reg,
+            bool(disable_status), **kwargs)
+
+    def get_unwrapper_disable(self, **kwargs):
+        """
+        If Disable is set to True, then the unwrapper is bypassed.
+
+        Returns
+        -------
+        bool
+            The status of the Disable bit.
+        """
+        return self._caget(
+            self.smurf_processor + self._unwrapper_disable_reg,
+            **kwargs)
+
     _filter_reset_reg = 'Filter.reset'
 
     def set_filter_reset(self, **kwargs):
@@ -7217,7 +7247,7 @@ class SmurfCommandMixin(SmurfBase):
             # disable downstream filtering
             S.set_filter_disable(True)
             S.set_downsample_factor(1)
-            S._caput(S.smurf_processor + "Unwrapper:Disable",1)
+            S.set_unwrapper_disable(True)
 
             # select IQ streaming mode
             # bypasses CORDIC, send I and Q over both bays
@@ -7253,7 +7283,7 @@ class SmurfCommandMixin(SmurfBase):
             # disable downstream filtering
             S.set_filter_disable(True)
             S.set_downsample_factor(1)
-            S._caput(S.smurf_processor + "Unwrapper:Disable",1)
+            S.set_unwrapper_disable(True)
 
             # select IQ streaming mode
             # bypasses CORDIC, send I and Q over both bays


### PR DESCRIPTION
## Summary

Closes #444.

Replaces the deprecated rogue3-era `smurf_to_mce` cfg block (parsed-but-ignored ever since the rogue4 migration) with a new `processor` block that maps directly onto the rogue4 SmurfProcessor filter / downsampler / unwrapper chain. Fields are exposed as `SmurfConfigPropertiesMixin` properties and applied during `SmurfControl.setup()`.

- **Schema** (`smurf_config.py`): new optional `processor` block with 8 optional fields and firmware-matching defaults — `filter_disable`, `filter_freq`, `filter_order`, `filter_gain`, `downsample_mode`, `downsample_factor`, `downsample_external_bitmask`, `unwrapper_disable`. The deprecated `smurf_to_mce` block is still tolerated via `ignore_extra_keys=True`, so cfgs without a `processor` block load identically to before.
- **Properties** (`smurf_config_properties.py`): 8 new `@property` getter/setter pairs and a `processor` block read in `copy_config_to_properties`.
- **Setup wiring** (`smurf_control.py`): after `set_channel_mask`, applies each property via the existing `set_unwrapper_disable` / `set_filter_disable` / `set_filter_order` / `set_filter_gain` / `set_filter_a` / `set_filter_b` / `set_downsample_mode` / `set_downsample_factor` / `set_downsample_external_bitmask` setters. Filter A/B coefficients are derived from `filter_freq + filter_order` via `scipy.signal.butter`, normalized against the flux-ramp rate (the filter's actual input rate, not the post-downsampling `fs`), and zero-padded to the 16-tap firmware register. This mirrors `SmurfUtilMixin.set_filter_params` and reproduces the existing hardcoded firmware A/B exactly when the defaults are used.
- **Helper** (`smurf_command.py`): adds `set_unwrapper_disable` / `get_unwrapper_disable` next to `set_unwrapper_reset`. Replaces two docstring snippets that called raw `_caput(..., "Unwrapper:Disable")` (also fixes a wrong `:` separator that should have been `.`).
- **Template cfg** (`cfg_files/template/template.cfg`): swaps the `smurf_to_mce` block for a documented `processor` block. Site cfgs under `cfg_files/{b33,kx,lab1,nist,pton,rflab,slac,stanford,ucsd}/` are intentionally untouched — they keep loading via `ignore_extra_keys=True`. Lab owners can migrate at their leisure.

## Test plan

- [x] `flake8 --count python/` → 0 (matches CI invocation in `.github/workflows/test-or-deploy.yml`).
- [x] `cd docs && make html` → build succeeded; no warnings on the new docstrings.
- [x] Schema accepts the new template cfg with the `processor` block and yields the expected dict.
- [x] Schema accepts an unmodified legacy site cfg (`cfg_files/b33/experiment_b33_lbOnlyBay0.cfg`) that still has `smurf_to_mce` and no `processor` block; defaults populate correctly.
- [x] `copy_config_to_properties` end-to-end populates all 8 `_*` slots.
- [x] Filter coefficients derived from `filter_freq=63, filter_order=4, flux_ramp_rate=4 kHz` reproduce the existing hardcoded firmware A/B in `_SmurfProcessor.py` exactly (A = `[1.0, -3.7414556..., 5.2572662..., -3.2877659..., 0.7720398...]`).
- [ ] Run on real hardware to confirm the registers latch as expected (best done by a maintainer with a connected SMuRF system).