### PR TITLE
fix(take_debug_data): Clarify error when single_channel_readout=0 with channel set (#415)

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -90,9 +90,14 @@ class SmurfUtilMixin(SmurfBase):
                 self.set_single_channel_readout(band, 0)
                 self.set_single_channel_readout_opt2(band, 1)
             else:
-                self.log('single_channel_readout must be 1 or 2',
-                    self.LOG_ERROR)
-                raise ValueError('single_channel_readout must be 1 or 2')
+                msg = (
+                    f'single_channel_readout must be 1 or 2 when channel '
+                    f'is specified (got channel={channel}, '
+                    f'single_channel_readout={single_channel_readout}). '
+                    f'Pass channel=None to disable single-channel readout.'
+                )
+                self.log(msg, self.LOG_ERROR)
+                raise ValueError(msg)
             self.set_readout_channel_select(band, channel, write_log=write_log)
         else: # exit single channel otherwise
             self.set_single_channel_readout(band, 0, write_log=write_log)


### PR DESCRIPTION
## Summary
- Improve the `ValueError` raised by `take_debug_data` when called with a non-None `channel` and `single_channel_readout` outside `{1, 2}`.
- New message names both offending arguments and tells the user that `channel=None` is how to disable single-channel readout.
- No behavior change on the success path; only the error/log text changes.

Fixes #415.

## Test plan
- [x] `flake8 --count python/` clean (CI command).
- [x] `python -c "import ast; ast.parse(...)"` parses the modified file.
- [ ] On hardware, run `S.take_debug_data(band, channel=19, IQstream=False, single_channel_readout=0, nsamp=2**25)` and confirm the new ValueError text appears.