### PR TITLE
docs(smurf_tune): Document missing args in assign_channels and get_closest_subband (#413)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -1541,6 +1541,9 @@ class SmurfTuneMixin(SmurfBase):
             The frequency to search for a subband.
         band : int
             The band to identify.
+        as_offset : bool, optional, default True
+            Whether to return subband centers as an offset from the band
+            center (passed through to ``get_subband_centers``).
 
         Returns
         -------
@@ -1647,14 +1650,23 @@ class SmurfTuneMixin(SmurfBase):
 
         band : int or None, optional, default None
             The band to assign channels.
-        band_center : float array or None, optional, default None
+        bandcenter : float array or None, optional, default None
             The frequency center of the band. Must supply band or
             subband center.
         channel_per_subband : int, optional, default 4
             The number of channels to assign per subband.
+        as_offset : bool, optional, default True
+            Whether subband centers are computed as offsets from the
+            band center (passed through to ``get_subband_centers`` and
+            ``get_closest_subband``).
         min_offset : float, optional, default 0.1
             The minimum offset between two resonators in MHz.  If
             closer, then both are ignored.
+        new_master_assignment : bool, optional, default False
+            If True, assign each resonator to its closest subband and
+            write a fresh master assignment file for this band. If
+            False (default), match resonators against the existing
+            master assignment loaded via ``get_master_assignment``.
 
         Returns
         -------


### PR DESCRIPTION
## Summary

Closes #413. The issue (open since 2020-04-21) reports that `new_master_assignment` and `as_offset` keyword arguments are not documented in some `smurf_tune.py` functions, naming `S.assign_channels` as an example.

Verified on `main` that two functions in `python/pysmurf/client/tune/smurf_tune.py` still have the missing entries:

| Function | Missing in docstring |
|---|---|
| `get_closest_subband` (line 1534) | `as_offset` |
| `assign_channels` (line 1635) | `as_offset`, `new_master_assignment` |

`assign_channels` also documents the `bandcenter` argument under the wrong label `band_center` (signature has no underscore) — fixed in the same hunk.

### Why not part of #931?

Open PR #931 (`refactor: Discard master/slave jargon (#471)`) renames `new_master_assignment` → `new_channel_assignment` with a deprecation alias and adds a docstring entry for the new name. It does **not** touch `as_offset` in either function, so the core `as_offset` complaint of #413 would survive even if #931 merges first. This PR fixes #413 against the current `main` and is independent — if #931 merges first, the `new_master_assignment` Args entry here can be folded into the deprecation note in a follow-up.

### What's changed

Pure docstring edits, NumPy style, matching the canonical `as_offset` wording from `get_subband_centers` (`python/pysmurf/client/util/smurf_util.py:2600`):

- `get_closest_subband`: added `as_offset` Args entry.
- `assign_channels`: added `as_offset` and `new_master_assignment` Args entries; renamed `band_center` → `bandcenter` to match the actual signature.

13 insertions / 1 deletion. No code-behavior changes.

## Test plan

- [x] `flake8 --count python/` (CI lint command from `.github/workflows/test-or-deploy.yml`) → 0 errors. The `flake8-rst-docstrings` plugin in that command also validates the RST inside the new docstring blocks.
- [x] AST smoke-test (`ast.get_docstring` on both functions) confirms every signature parameter is now listed in the `Args` block.
- [x] `git diff` shows changes only inside `"""..."""` docstring blocks — zero lines outside.
- [ ] CI flake8 / docker / docs jobs.