### PR TITLE
fix(relock): Rename eta_mag to eta_mag_scaled and clarify etaMag docs (#416)

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -2118,6 +2118,11 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_eta_mag_array(self, band, val, **kwargs):
         """
+        Sets the band-array etaMag firmware register. Despite the name,
+        this register holds *scaled* etaMag values, i.e.
+        eta_mag / subband_half_width, where
+        subband_half_width = digitizer_frequency_mhz / n_subbands.
+        Pass eta_mag_scaled values, not unscaled eta_mag.
         """
         self._caput(
             self._cryo_root(band) + self._eta_mag_array_reg,
@@ -2125,6 +2130,11 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_eta_mag_array(self, band, **kwargs):
         """
+        Returns the band-array etaMag firmware register. Despite the name,
+        the values returned are *scaled* etaMag values, i.e.
+        eta_mag / subband_half_width, where
+        subband_half_width = digitizer_frequency_mhz / n_subbands.
+        Recover unscaled eta_mag by multiplying by subband_half_width.
         """
         return self._caget(
             self._cryo_root(band) + self._eta_mag_array_reg,

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -1944,7 +1944,7 @@ class SmurfTuneMixin(SmurfBase):
         center_freq = np.zeros(n_channels)
         feedback_enable = np.zeros(n_channels)
         eta_phase = np.zeros(n_channels)
-        eta_mag = np.zeros(n_channels)
+        eta_mag_scaled = np.zeros(n_channels)
 
         # Extract frequencies from dictionary
         f = [self.freq_resp[band]['resonances'][k]['freq']
@@ -1985,7 +1985,7 @@ class SmurfTuneMixin(SmurfBase):
                 amplitude_scale[ch] = tone_power
                 feedback_enable[ch] = 1
                 eta_phase[ch] = self.freq_resp[band]['resonances'][k]['eta_phase']
-                eta_mag[ch] = self.freq_resp[band]['resonances'][k]['eta_scaled']
+                eta_mag_scaled[ch] = self.freq_resp[band]['resonances'][k]['eta_scaled']
                 counter += 1
 
         # Set the actual variables
@@ -1997,7 +1997,7 @@ class SmurfTuneMixin(SmurfBase):
             write_log=write_log, log_level=self.LOG_INFO)
         self.set_eta_phase_array(band, eta_phase, write_log=write_log,
             log_level=self.LOG_INFO)
-        self.set_eta_mag_array(band, eta_mag, write_log=write_log,
+        self.set_eta_mag_array(band, eta_mag_scaled, write_log=write_log,
             log_level=self.LOG_INFO)
 
         self.log(


### PR DESCRIPTION
## Summary
- Fixes [#416](https://github.com/slaclab/pysmurf/issues/416). In `relock()`, a local variable named `eta_mag` was populated from `freq_resp[...]['eta_scaled']` and passed to `set_eta_mag_array` — values were correct, name was wrong.
- Renamed the local variable to `eta_mag_scaled` in `relock()` (three sites in `smurf_tune.py`).
- Expanded the empty docstrings on `set_eta_mag_array` / `get_eta_mag_array` to make it explicit that the firmware `etaMag` register actually holds *scaled* values (`eta_mag / subband_half_width`), so the misleading function name is at least documented.
- No behavioral change; values written to the register are unchanged.

## Out of scope
A second instance of the same naming bug exists at `smurf_tune.py:4855` (`band_outputs[band]['eta_mag'] = list(self.get_eta_mag_array(band))`). Renaming that dict key would change the schema of status-dump config files and break any downstream consumer reading the `'eta_mag'` key, so it's left for a follow-up.

## Test plan
- [x] `flake8 --count python/` passes (0 errors) — same command CI runs.
- [ ] CI flake8 / docs / server / client jobs pass on the PR.
- [ ] Spot-check on hardware that `relock()` still tunes channels as expected (pure rename, so behavior is unchanged).