### PR TITLE
fix(smurf_iv): np.unwrap IV phase before plot/analyze (#376)

### DIFF
--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -413,7 +413,7 @@ class SmurfIVMixin(SmurfBase):
             self.log(f'Analyzing band {b} channel {ch}')
 
             ch_idx = mask[b, ch]
-            phase = phase_all[ch_idx]
+            phase = np.unwrap(phase_all[ch_idx])
 
             phase_excursion = max(phase) - min(phase)
 


### PR DESCRIPTION
## Summary

Fixes #376.

`analyze_iv_from_file` consumed the per-channel phase array straight out of the streamed file and handed it to the IV plot, to `phase_excursion`, and to `analyze_iv`. The firmware `SmurfProcessor` unwrapper (`src/smurf/core/processors/SmurfProcessor.cpp:590-607`) is a threshold edge-detector at `±0x6000` and can miss a wrap when phase drifts slowly across a frame boundary, leaving a 2π discontinuity in the int16-scaled phase delivered to Python — the visible "kink" in the issue plot.

Apply `np.unwrap` once at extraction (`python/pysmurf/client/debug/smurf_iv.py:416`) so every downstream consumer sees a continuous trace. One-line change.

The pre-existing SC-branch offset kludge at `smurf_iv.py:732-739` already attributed itself to this exact failure mode ("undetected phase wrap at the kink between the superconducting branch and the transition"); it is left in place as a defensive cosmetic.

## Test plan

- [x] `flake8 --count python/` clean (CI command, 0 warnings).
- [x] Synthetic regression: build a smooth ramp with a single 2π step injected at sample 270 000; confirm `np.unwrap` removes the step exactly and that `max - min` matches the physical excursion.
- [ ] **Needs SMuRF operator:** rerun `S.run_iv(...)` on a known-good TES, open the saved `*_IV_stream_b{b}ch{ch}_g{bg}.png` and confirm the phase trace is monotonic with no discrete jumps. Confirm `R_n` / `p_trans` / SC-fit values remain consistent with a pre-fix run on the same channel modulo the corrected offset.

## What is intentionally NOT changed

- `read_stream_data` / `stream_data_reader.pyx`: leaving the generic stream reader untouched avoids forcing IV-specific behavior on noise scripts, tracking-setup tools, and other phase consumers.
- The firmware threshold algorithm in `SmurfProcessor.cpp`: deeper change, would need `validate_unwrapper.py` updates and on-target validation, out of scope for this issue.
- The SC-branch offset subtraction at `smurf_iv.py:738`: cosmetic, harmless when there is no residual offset.