### PR TITLE
refactor(read_stream_data): Replace hard-coded 16s with N_TES_BIASES constant (#381)

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -37,6 +37,10 @@ try:
 except ImportError:
     CYTHON_AVAILABLE = False
 
+# Number of TES bias DACs encoded in each SMuRF stream header.
+# Firmware-defined: 40-byte tes_bias field = 16 x 20-bit signed values.
+N_TES_BIASES = 16
+
 class SmurfUtilMixin(SmurfBase):
 
     @set_action()
@@ -1262,7 +1266,7 @@ class SmurfUtilMixin(SmurfBase):
                         t = [header.timestamp]
                         if return_header or return_tes_bias:
                             tmp_tes_bias = np.array(header.tesBias)
-                            tes_bias = np.zeros((0,16))
+                            tes_bias = np.zeros((0, N_TES_BIASES))
 
                         # Get header values if requested
                         if return_header or return_tes_bias:
@@ -1306,11 +1310,11 @@ class SmurfUtilMixin(SmurfBase):
                                                  dtype=type(header_dict[k][0]))
                                 print(np.shape(tes_bias), np.shape(tmp_tes_bias))
                                 tes_bias = np.vstack((tes_bias, tmp_tes_bias))
-                                tmp_tes_bias = np.zeros((0, 16))
+                                tmp_tes_bias = np.zeros((0, N_TES_BIASES))
 
                             elif return_tes_bias:
                                 tes_bias = np.vstack((tes_bias, tmp_tes_bias))
-                                tmp_tes_bias = np.zeros((0, 16))
+                                tmp_tes_bias = np.zeros((0, N_TES_BIASES))
 
                         counter += 1
 

--- a/python/pysmurf/client/util/stream_data_reader.pyx
+++ b/python/pysmurf/client/util/stream_data_reader.pyx
@@ -26,6 +26,10 @@ cnp.import_array()
 cdef int SMURF_HEADER_SIZE = 128
 cdef int ROGUE_HEADER_SIZE = 8
 
+# Number of TES bias DACs encoded in each SMuRF stream header.
+# Firmware-defined: 40-byte tes_bias field = 16 x 20-bit signed values.
+cdef int N_TES_BIASES = 16
+
 # SMuRF Header as NumPy structured dtype
 SMURF_HEADER_DTYPE = np.dtype([
     ('protocol_version', np.uint8),       # Offset 0
@@ -384,10 +388,10 @@ def read_stream_data_cython(str datafile, channel=None, bint IQ_mode=False, bint
 
 def parse_tes_bias_from_headers(headers):
     """
-    Extract TES bias data from headers and parse into 16 TES bias values.
+    Extract TES bias data from headers and parse into N_TES_BIASES TES bias values.
 
-    The tes_bias field contains 40 bytes encoding 16 TES bias values as 20-bit
-    signed integers. Each pair of values fits in 5 bytes:
+    The tes_bias field contains 40 bytes encoding N_TES_BIASES TES bias values as
+    20-bit signed integers. Each pair of values fits in 5 bytes:
     - Even index (0, 2, 4, ...): bytes 0-2, lower 20 bits
     - Odd index (1, 3, 5, ...): bytes 2-4, upper 20 bits (shifted right 4)
 
@@ -398,12 +402,12 @@ def parse_tes_bias_from_headers(headers):
 
     Returns
     -------
-    tes_bias_array : ndarray (int32, shape=[16, n_headers])
-        Parsed TES bias values, 16 values per header
+    tes_bias_array : ndarray (int32, shape=[N_TES_BIASES, n_headers])
+        Parsed TES bias values, N_TES_BIASES values per header
     """
     cdef int n_headers = len(headers)
     cdef int i, j, b
-    cdef cnp.ndarray[cnp.int32_t, ndim=2] tes_bias_array = np.empty((16, n_headers), dtype=np.int32)
+    cdef cnp.ndarray[cnp.int32_t, ndim=2] tes_bias_array = np.empty((N_TES_BIASES, n_headers), dtype=np.int32)
     cdef cnp.ndarray[cnp.uint8_t, ndim=1] raw_bytes
     cdef uint32_t tmp
 
@@ -411,8 +415,8 @@ def parse_tes_bias_from_headers(headers):
     for j in range(n_headers):
         raw_bytes = headers['tes_bias'][j]
 
-        # Parse 16 TES bias values from 40 bytes
-        for i in range(16):
+        # Parse N_TES_BIASES TES bias values from 40 bytes
+        for i in range(N_TES_BIASES):
             b = i // 2  # Which 5-byte group (0-7)
 
             # 2 TES values fit in 5 bytes


### PR DESCRIPTION
## Summary
- Closes #381 — the number of TES bias DACs (16) was hard-coded in three array shapes in the Python fallback of `read_stream_data` (`smurf_util.py:1265, 1309, 1313`) and in two locations in the Cython fast reader's `parse_tes_bias_from_headers` (`stream_data_reader.pyx:406, 415`).
- Promote the magic value to a named `N_TES_BIASES = 16` module-level constant in each module, defined alongside the other frame-format constants (`SMURF_HEADER_SIZE`, `ROGUE_HEADER_SIZE`). The firmware-defined 40-byte / 16 × 20-bit layout is now documented once at the constant.
- No behavior change: `parse_tes_bias_from_headers` still returns shape `(16, n_headers)`; the Python fallback still allocates `(0, 16)` sentinel arrays.

## Out of scope
- `SmurfFileReader.py:87` (`range(16)`) — separate module, private parser internals, not referenced by the issue.
- `header_to_tes_bias` already exposes `n_tes_bias` as a parameter; its default of `15` is a pre-existing question unrelated to #381.

## Test plan
- [x] `flake8 --count python/` (CI lint command) — 0 errors
- [x] Cython rebuild via `hatch_build.py` configuration — clean build
- [x] `parse_tes_bias_from_headers` shape sanity: returns `(16, n_headers)` for arbitrary header counts
- [x] Two's-complement decoding still correct: `0xFFFFF → -1`, `0x00000 → 0`
- [x] No bare `16` remains as a TES bias count in `read_stream_data` or `parse_tes_bias_from_headers`
- [ ] CI: docker server/client tests on PR