### PR TITLE
fix(noise_vs_tone): Default fraction_full_scale to None (#355)

### DIFF
--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -363,7 +363,7 @@ class SmurfNoiseMixin(SmurfBase):
 
     def noise_vs_tone(self, band, tones=None, meas_time=30,
                       analyze=False, bias_group=None, lms_freq_hz=None,
-                      fraction_full_scale=.72, meas_flux_ramp_amp=False,
+                      fraction_full_scale=None, meas_flux_ramp_amp=False,
                       n_phi0=4, make_timestream_plot=True,
                       new_master_assignment=True, from_old_tune=False,
                       old_tune=None):
@@ -387,8 +387,10 @@ class SmurfNoiseMixin(SmurfBase):
         lms_freq_hz : float or None, optional, default None
             The tracking frequency in Hz. If None, measures the
             tracking frequency.
-        fraction_full_scale : float, optional, default 0.72
-            The amplitude of the flux ramp.
+        fraction_full_scale : float or None, optional, default None
+            The amplitude of the flux ramp. If None, defaults to the
+            cfg value ``tune_band:fraction_full_scale`` (via
+            ``tracking_setup``).
         meas_flux_ramp_amp : bool or None, optional, default False
             Whether to measure the flux ramp amplitude.
         n_phi0 : float, optional, default 4.0


### PR DESCRIPTION
## Summary

Fixes #355.

`noise_vs_tone` shipped with the magic-number default `fraction_full_scale=.72`, which silently overrode the cfg value `tune_band:fraction_full_scale` whenever a caller did not explicitly pass the argument — defeating the fallback that `tracking_setup` already implements.

- Change `noise_vs_tone` signature default from `fraction_full_scale=.72` to `fraction_full_scale=None` (`python/pysmurf/client/debug/smurf_noise.py:366`).
- Update the docstring to note the cfg fallback.

No body changes were needed — `noise_vs_tone` already passes `fraction_full_scale` straight into `tracking_setup`, and `tracking_setup` (`python/pysmurf/client/tune/smurf_tune.py:2643-2644`) does:

```python
if fraction_full_scale is None:
    fraction_full_scale = self._fraction_full_scale
```

`self._fraction_full_scale` is loaded from `tune_band:fraction_full_scale` in `smurf_config_properties.py:330`.

## Out of scope

The issue also asks to scan for other functions with similarly bad defaults. Findings:

- `optimize_lms_delay` (`smurf_tune.py:4328`) already uses `fraction_full_scale=None` — correct.
- `git grep "fraction_full_scale=\.72"` returns zero library hits after this fix (only `scratch/eyy/debug/nonlinear_lms.py` remains, which is debug code, not the library).
- `n_phi0=4`, `meas_time=30`, `bias_high=1.5`, etc. were debated in the 2020 issue thread (eyyoung24 vs swh76) without resolution. swh76 leaned toward keeping `meas_time` hardcoded but moving `n_phi0` to cfg. `n_phi0` is not currently a cfg property anywhere in `smurf_config_properties.py`; promoting it would require a new cfg key plus updates to `tracking_setup`, `optimize_lms_delay`, and several `noise_vs_*` callers — a separate refactor.

## Test plan

- [x] `flake8 --count python/` (CI lint command) → 0 errors
- [x] `git grep "fraction_full_scale=\.72\|fraction_full_scale=0\.72" -- python/pysmurf/` → no library hits
- [x] Confirmed `noise_vs_tone` body still passes `fraction_full_scale` straight to `tracking_setup` (line 432, unchanged)
- [x] Confirmed `tracking_setup`'s `None` → `self._fraction_full_scale` fallback path is intact
- [ ] CI: docker server/client tests on PR