### PR TITLE
feat: Add **kwargs to outward-facing functions for forward-compat (#385)

### DIFF
--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -34,7 +34,7 @@ class SmurfIVMixin(SmurfBase):
                channels=None, band=None, high_current_mode=True,
                overbias_voltage=8., grid_on=True,
                phase_excursion_min=3., bias_line_resistance=None,
-               do_analysis=True):
+               do_analysis=True, **kwargs):
         """Takes a slow IV
 
         Steps the TES bias down slowly. Starts at bias_high to
@@ -177,7 +177,7 @@ class SmurfIVMixin(SmurfBase):
     def partial_load_curve_all(self, bias_high_array, bias_low_array=None,
             wait_time=0.1, bias_step=0.1, show_plot=False, analyze=True,
             make_plot=True, save_plot=True, channels=None, overbias_voltage=None,
-            overbias_wait=1.0, phase_excursion_min=1.):
+            overbias_wait=1.0, phase_excursion_min=1., **kwargs):
         """
         Take a partial load curve on all bias groups. Function will step
         up to bias_high value, then step down. Will NOT change TES bias
@@ -309,7 +309,7 @@ class SmurfIVMixin(SmurfBase):
                              R_op_target=0.007, pA_per_phi0=None,
                              channel=None, band=None, datafile=None,
                              output_dir = None, plot_dir=None,
-                             bias_line_resistance=None):
+                             bias_line_resistance=None, **kwargs):
         """
         Function to analyze a load curve from its raw file. Can be used to
           analyze IV's/generate plots separately from issuing commands.
@@ -971,7 +971,7 @@ class SmurfIVMixin(SmurfBase):
     @set_action()
     def analyze_plc_from_file(self, fn_plc_raw_data, make_plot=True,
             show_plot=False, save_plot=True, R_sh=None,
-            phase_excursion_min=1., channels=None):
+            phase_excursion_min=1., channels=None, **kwargs):
         """
         Function to analyze a partial load curve from its raw
         file. Basically the same as the run_iv analysis but without
@@ -1060,7 +1060,7 @@ class SmurfIVMixin(SmurfBase):
 
     @set_action()
     def estimate_opt_eff(self, iv_fn_hot, iv_fn_cold,t_hot=293.,t_cold=77.,
-            channels = None, dPdT_lim=(0.,0.5)):
+            channels = None, dPdT_lim=(0.,0.5), **kwargs):
         """
         Estimate optical efficiency between two sets of load curves. Returns
           per-channel plots and a histogram.
@@ -1187,7 +1187,7 @@ class SmurfIVMixin(SmurfBase):
                               normal_resistance=None,
                               normal_resistance_frac=.25,
                               show_plot=False, save_plot=True,
-                              make_plot=True):
+                              make_plot=True, **kwargs):
         """
         Attempts to estimate the bias point per bias group. You must run
         identify_bias_group first (or manually input which channels are in

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -42,7 +42,7 @@ class SmurfNoiseMixin(SmurfBase):
                        write_log=True, reset_filter=True,
                        reset_unwrapper=True,
                        return_noise_params=False,
-                       plotname_append=''):
+                       plotname_append='', **kwargs):
         """
         Takes a timestream of noise and calculates its PSD. It also
         attempts to fit a white noise and 1/f component to the data.
@@ -341,7 +341,7 @@ class SmurfNoiseMixin(SmurfBase):
         else:
             return datafile
 
-    def turn_off_noisy_channels(self, band, noise, cutoff=150):
+    def turn_off_noisy_channels(self, band, noise, cutoff=150, **kwargs):
         """
         Turns off channels with noise level above a cutoff.
 
@@ -366,7 +366,7 @@ class SmurfNoiseMixin(SmurfBase):
                       fraction_full_scale=.72, meas_flux_ramp_amp=False,
                       n_phi0=4, make_timestream_plot=True,
                       new_master_assignment=True, from_old_tune=False,
-                      old_tune=None):
+                      old_tune=None, **kwargs):
         """Takes timestream noise at various tone powers.
 
         Operates on one band at a time because it needs to retune
@@ -468,7 +468,7 @@ class SmurfNoiseMixin(SmurfBase):
             overbias_voltage=9., meas_time=30., analyze=False, nperseg=2**13,
             detrend='constant', fs=None, show_plot=False, cool_wait=30.,
             psd_ylim=(10.,1000.), make_timestream_plot=False,
-            only_overbias_once=False, overbias_wait=1):
+            only_overbias_once=False, overbias_wait=1, **kwargs):
         """ This ramps the TES voltage from bias_high to bias_low and takes noise
         measurements. You can make it analyze the data and make plots with the
         optional argument analyze=True. Note that the analysis is a little
@@ -532,7 +532,7 @@ class SmurfNoiseMixin(SmurfBase):
     def noise_vs_amplitude(self, band, amplitude_high=11, amplitude_low=9,
             step_size=1, amplitudes=None, meas_time=30., analyze=False,
             channel=None, nperseg=2**13, detrend='constant', fs=None,
-            show_plot=False, make_timestream_plot=False, psd_ylim=None):
+            show_plot=False, make_timestream_plot=False, psd_ylim=None, **kwargs):
         """
         No description
 
@@ -721,7 +721,7 @@ class SmurfNoiseMixin(SmurfBase):
         return datafiles
 
 
-    def get_biases_from_file(self, fn_biases, dtype=float):
+    def get_biases_from_file(self, fn_biases, dtype=float, **kwargs):
         """
         For, e.g., noise_vs_bias, the list of commanded bias voltages
         is recorded in a txt file. This function simply extracts those
@@ -749,7 +749,7 @@ class SmurfNoiseMixin(SmurfBase):
         return biases
 
 
-    def get_iv_data(self, iv_data_filename, band, high_current_mode=False):
+    def get_iv_data(self, iv_data_filename, band, high_current_mode=False, **kwargs):
         """
         Takes IV data and extracts responsivities as a function of commanded
         bias voltage.
@@ -797,7 +797,7 @@ class SmurfNoiseMixin(SmurfBase):
         return iv_band_data
 
 
-    def get_si_data(self, iv_band_data, b, ch):
+    def get_si_data(self, iv_band_data, b, ch, **kwargs):
         """
         Convenience function for getting the responsivitiy from the IV data.
 
@@ -820,7 +820,7 @@ class SmurfNoiseMixin(SmurfBase):
         return iv_band_data[b][ch]['v_bias'], iv_band_data[b][ch]['si']
 
 
-    def get_NEI_to_NEP_factor(self, iv_band_data, b, ch, v_bias):
+    def get_NEI_to_NEP_factor(self, iv_band_data, b, ch, v_bias, **kwargs):
         """
         This function uses the IV curve to estimate dI/dP. It interpolates
         between IV points to get the value at the desired v_bias. Returns the
@@ -859,7 +859,7 @@ class SmurfNoiseMixin(SmurfBase):
             show_legend=True, freq_range_summary=None, R_sh=None,
             high_current_mode=True, iv_data_filename=None, NEP_ylim=(10.,1000.),
             f_center_GHz=150., bw_GHz=32., xlabel_override=None,
-            unit_override=None):
+            unit_override=None, **kwargs):
         """ Analysis script associated with noise_vs_bias. Will convert to NEP
         if an IV curve is given (use optional argument iv_data_filename).
 
@@ -1436,7 +1436,7 @@ class SmurfNoiseMixin(SmurfBase):
 
     def analyze_psd(
             self, f, Pxx, fs=None, p0=None, flux_ramp_freq=None,
-            filter_a=None, filter_b=None):
+            filter_a=None, filter_b=None, **kwargs):
         """
         Return model fit for a PSD.
         p0 (float array): initial guesses for model fitting: [white-noise level
@@ -1482,7 +1482,7 @@ class SmurfNoiseMixin(SmurfBase):
         if fs is None:
             fs = self.get_sample_frequency()
 
-        def noise_model(freq, wl, n, f_knee):
+        def noise_model(freq, wl, n, f_knee, **kwargs):
             """
             Crude model for noise modeling.
 
@@ -1526,7 +1526,7 @@ class SmurfNoiseMixin(SmurfBase):
         return popt, pcov, f_fit, Pxx_fit
 
 
-    def noise_all_vs_noise_solo(self, band, meas_time=10.0):
+    def noise_all_vs_noise_solo(self, band, meas_time=10.0, **kwargs):
         """
         Measures the noise with all the resonators on, then measures
         every channel individually.
@@ -1566,7 +1566,7 @@ class SmurfNoiseMixin(SmurfBase):
         return ret
 
     def analyze_noise_all_vs_noise_solo(self, ret, fs=None, nperseg=2**10,
-            make_channel_plot=False):
+            make_channel_plot=False, **kwargs):
         """
         Analyzes the data from noise_all_vs_noise_solo
 
@@ -1619,7 +1619,7 @@ class SmurfNoiseMixin(SmurfBase):
 
 
     def NET_CMB(self, NEI, V_b, R_tes, opt_eff, f_center=150e9, bw=32e9,
-            R_sh=None, high_current_mode=False):
+            R_sh=None, high_current_mode=False, **kwargs):
         """
         Converts current spectral noise density to NET in uK rt(s). Assumes NEI
         is white-noise level.
@@ -1668,7 +1668,7 @@ class SmurfNoiseMixin(SmurfBase):
             nperseg=2**13, detrend='constant', fs=None, save_plot=True,
             show_plot=False, make_timestream_plot=False, data_timestamp=None,
             psd_ylim=(10.,1000.), bias_group=None, smooth_len=11,
-            show_legend=True, freq_range_summary=None):
+            show_legend=True, freq_range_summary=None, **kwargs):
         """ Analysis script associated with noise_vs_tone. Writes outputs
         and plots to output_dir and plot_dir respectively.
 
@@ -1917,7 +1917,7 @@ class SmurfNoiseMixin(SmurfBase):
             tone_power=None, nsamp=2**25, nperseg=2**18, make_plot=True,
             show_plot=False, save_plot=True, band_off=True,
             run_serial_gradient_descent=True, run_serial_eta_scan=True,
-            save_psd=False):
+            save_psd=False, **kwargs):
         """
         This script is shamelessly stolen from Max. This tunes up a single
         resonator and takes data in single_channel_readout mode, with is 2.4 MHz.
@@ -2050,7 +2050,7 @@ class SmurfNoiseMixin(SmurfBase):
         return ff, pxx
 
 
-    def noise_svd(self, d, mask, mean_subtract=True):
+    def noise_svd(self, d, mask, mean_subtract=True, **kwargs):
         """
         Calculates the SVD modes of the input data.
         Only uses the data called out by the mask
@@ -2083,7 +2083,7 @@ class SmurfNoiseMixin(SmurfBase):
 
 
     def plot_svd_summary(self, u, s, save_plot=False,
-            save_name=None, show_plot=False):
+            save_name=None, show_plot=False, **kwargs):
         """
         Requires seaborn to be installed. Plots a heatmap
         of the coefficients and the log10 of the amplitudes.
@@ -2141,7 +2141,7 @@ class SmurfNoiseMixin(SmurfBase):
 
 
     def plot_svd_modes(self, vh, n_row=4, n_col=5, figsize=(10,7.5),
-            save_plot=False, save_name=None, show_plot=False, sharey=True):
+            save_plot=False, save_name=None, show_plot=False, sharey=True, **kwargs):
         """
         Plots the first N modes where N is n_row x n_col.
 
@@ -2198,7 +2198,7 @@ class SmurfNoiseMixin(SmurfBase):
             plt.close()
 
 
-    def remove_svd(self, d, mask, u, s, vh, modes=3):
+    def remove_svd(self, d, mask, u, s, vh, modes=3, **kwargs):
         """
         Removes the requsted SVD modes
 

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -40,7 +40,7 @@ class SmurfTuneMixin(SmurfBase):
              retune=False, f_min=.02, f_max=.3, df_max=.03,
              fraction_full_scale=None, make_plot=False,
              save_plot=True, show_plot=False,
-             new_master_assignment=False, track_and_check=True):
+             new_master_assignment=False, track_and_check=True, **kwargs):
         """
         This runs a tuning, does tracking setup, and prunes bad
         channels using check lock. When this is done, we should
@@ -131,7 +131,7 @@ class SmurfTuneMixin(SmurfBase):
             save_plot=True, save_data=True, make_subband_plot=False,
             n_scan=5, subband_plot_with_slow=False, tone_power=None,
             grad_cut=.05, freq_min=-2.5E8, freq_max=2.5E8, amp_cut=.5,
-            use_slow_eta=False):
+            use_slow_eta=False, **kwargs):
         """
         This does the full_band_resp, which takes the raw resonance data.
         It then finds the where the resonances are. Using the resonance
@@ -273,7 +273,7 @@ class SmurfTuneMixin(SmurfBase):
             freq_max=2.5E8, amp_cut=.25, del_f=.005, tone_power=None,
             new_master_assignment=False, from_old_tune=False,
             old_tune=None, pad=50, min_gap=50,
-            highlight_phase_slip=True, amp_ylim=None):
+            highlight_phase_slip=True, amp_ylim=None, **kwargs):
         """Tunes band using serial_gradient_descent and then
         serial_eta_scan.  This requires an initial guess, which this
         function gets by either loading an old tune or by using the
@@ -434,7 +434,7 @@ class SmurfTuneMixin(SmurfBase):
     @set_action()
     def plot_tune_summary(self, band, eta_scan=False, show_plot=False,
             save_plot=True, eta_width=.3, channels=None,
-            plot_summary=True, plotname_append=''):
+            plot_summary=True, plotname_append='', **kwargs):
         """
         Plots summary of tuning. Requires self.freq_resp to be filled.
         In other words, you must run find_freq and setup_notches
@@ -582,7 +582,7 @@ class SmurfTuneMixin(SmurfBase):
             save_plot=True, show_plot=False, save_data=False, timestamp=None,
             save_raw_data=False, correct_att=True, swap=False, hw_trigger=True,
             write_log=False, return_plot_path=False,
-            check_if_adc_is_saturated=True):
+            check_if_adc_is_saturated=True, **kwargs):
         """
         Injects high amplitude noise with known waveform. The ADC measures it.
         The cross correlation contains the information about the resonances.
@@ -805,7 +805,7 @@ class SmurfTuneMixin(SmurfBase):
             band=None, subband=None, make_subband_plot=False,
             subband_plot_with_slow=False, timestamp=None, pad=50, min_gap=100,
             plot_title=None, grad_kernel_width=8, highlight_phase_slip=True,
-            amp_ylim=None, flip_phase=False, plot_phase=False):
+            amp_ylim=None, flip_phase=False, plot_phase=False, **kwargs):
         """ Find the peaks within a given subband.
 
         Args
@@ -1074,7 +1074,7 @@ class SmurfTuneMixin(SmurfBase):
         return freq[peak]
 
     @set_action()
-    def find_flag_blocks(self, flag, minimum=None, min_gap=None):
+    def find_flag_blocks(self, flag, minimum=None, min_gap=None, **kwargs):
         """
         Find blocks of adjacent points in a boolean array with the
         same value.
@@ -1120,7 +1120,7 @@ class SmurfTuneMixin(SmurfBase):
             return start,end
 
     @set_action()
-    def pad_flags(self, f, before_pad=0, after_pad=0, min_gap=0, min_length=0):
+    def pad_flags(self, f, before_pad=0, after_pad=0, min_gap=0, min_length=0, **kwargs):
         """
         Adds and combines flagging.
 
@@ -1162,7 +1162,7 @@ class SmurfTuneMixin(SmurfBase):
 
     @set_action()
     def plot_find_peak(self, freq, resp, peak_ind, save_plot=True,
-            save_name=None):
+            save_name=None, **kwargs):
         """
         Plots the output of find_freq.
 
@@ -1227,7 +1227,7 @@ class SmurfTuneMixin(SmurfBase):
     def eta_fit(self, freq, resp, peak_freq, delta_freq,
                 make_plot=False, plot_chans=[], save_plot=True,
                 band=None, timestamp=None, res_num=None,
-                use_slow_eta=False):
+                use_slow_eta=False, **kwargs):
         """
         Cyndia's eta finding code.
 
@@ -1365,7 +1365,7 @@ class SmurfTuneMixin(SmurfBase):
     def plot_eta_fit(self, freq, resp, eta=None, eta_mag=None, peak_freq=None,
             eta_phase_deg=None, r2=None, save_plot=True, plotname_append='',
             show_plot=False, timestamp=None, res_num=None, band=None,
-            sk_fit=None, f_slow=None, resp_slow=None, channel=None):
+            sk_fit=None, f_slow=None, resp_slow=None, channel=None, **kwargs):
         """
         Plots the eta parameter fits. This is called by self.eta_fit or
         plot_tune_summary.
@@ -1531,7 +1531,7 @@ class SmurfTuneMixin(SmurfBase):
             plt.close()
 
     @set_action()
-    def get_closest_subband(self, f, band, as_offset=True):
+    def get_closest_subband(self, f, band, as_offset=True, **kwargs):
         """
         Gives the closest subband number for a given input frequency.
 
@@ -1558,7 +1558,7 @@ class SmurfTuneMixin(SmurfBase):
         return idx
 
     @set_action()
-    def check_freq_scale(self, f1, f2):
+    def check_freq_scale(self, f1, f2, **kwargs):
         """
         Makes sure that items are the same frequency scale (ie MHz, kHZ, etc.)
 
@@ -1580,7 +1580,7 @@ class SmurfTuneMixin(SmurfBase):
             return True
 
     @set_action()
-    def load_master_assignment(self, band, filename):
+    def load_master_assignment(self, band, filename, **kwargs):
         """
         By default, pysmurf loads the most recent master assignment.
         Use this function to overwrite the default one.
@@ -1634,7 +1634,7 @@ class SmurfTuneMixin(SmurfBase):
     @set_action()
     def assign_channels(self, freq, band=None, bandcenter=None,
             channel_per_subband=4, as_offset=True, min_offset=0.1,
-            new_master_assignment=False):
+            new_master_assignment=False, **kwargs):
         """
         Figures out the subbands and channels to assign to resonators
 
@@ -1741,7 +1741,7 @@ class SmurfTuneMixin(SmurfBase):
 
     @set_action()
     def write_master_assignment(self, band, freqs, subbands, channels,
-            bias_groups=None):
+            bias_groups=None, **kwargs):
         '''
         Writes a comma-separated list in the form band, freq (MHz), subband,
         channel, group. Group number defaults to -1. The order of inputs is
@@ -1782,7 +1782,7 @@ class SmurfTuneMixin(SmurfBase):
         self.load_master_assignment(band, fn)
 
     @set_action()
-    def make_master_assignment_from_file(self, band, tuning_filename):
+    def make_master_assignment_from_file(self, band, tuning_filename, **kwargs):
         """
         Makes a master assignment file
 
@@ -1812,7 +1812,7 @@ class SmurfTuneMixin(SmurfBase):
         self.write_master_assignment(band, freqs, subbands, channels)
 
     @set_action()
-    def get_group_list(self, band, group):
+    def get_group_list(self, band, group, **kwargs):
         """
         Returns a list of all the channels in a band and bias
         group. Note that it is possible to have channels that are
@@ -1838,7 +1838,7 @@ class SmurfTuneMixin(SmurfBase):
         return np.array(chs_in_group)
 
     @set_action()
-    def get_group_number(self, band, ch):
+    def get_group_number(self, band, ch, **kwargs):
         """
         Gets the bias group number of a band, channel pair. The
         master_channel_assignment must be filled.
@@ -1905,7 +1905,7 @@ class SmurfTuneMixin(SmurfBase):
     @set_action()
     def relock(self, band, res_num=None, tone_power=None, r2_max=.08,
             q_max=100000, q_min=0, check_vals=False, min_gap=None,
-            write_log=False):
+            write_log=False, **kwargs):
         """
         Turns on the tones. Also cuts bad resonators.
 
@@ -2179,7 +2179,7 @@ class SmurfTuneMixin(SmurfBase):
 
 
     def eta_estimator(self, band, subband, freq, resp, delta_freq=.01,
-                      lock_max_derivative=False):
+                      lock_max_derivative=False, **kwargs):
         """
         Estimates eta parameters using the slow eta_scan.
 
@@ -2223,7 +2223,7 @@ class SmurfTuneMixin(SmurfBase):
 
     @set_action()
     def eta_scan(self, band, subband, freq, tone_power, write_log=False,
-                 sync_group=True):
+                 sync_group=True, **kwargs):
         """Slow eta scan on one subband.
 
         Runs a slow eta scan on one channel.  Uses the first channel
@@ -2312,7 +2312,7 @@ class SmurfTuneMixin(SmurfBase):
     @set_action()
     def flux_ramp_check(self, band, reset_rate_khz=None,
             fraction_full_scale=None, flux_ramp=True, save_plot=True,
-            show_plot=False, setup_flux_ramp=True):
+            show_plot=False, setup_flux_ramp=True, **kwargs):
         """
         Tries to measure the V-phi curve in feedback disable mode.
         You can also run this with flux ramp off to see the intrinsic
@@ -2486,7 +2486,7 @@ class SmurfTuneMixin(SmurfBase):
             fraction_full_scale=None, lms_enable1=True, lms_enable2=True,
             lms_enable3=True, feedback_gain=None, lms_gain=None, return_data=True,
             feedback_start_frac=None,
-            feedback_end_frac=None, setup_flux_ramp=True, plotname_append=''):
+            feedback_end_frac=None, setup_flux_ramp=True, plotname_append='', **kwargs):
         """
         The function to start tracking. Starts the flux ramp and if requested
         attempts to measure the lms (demodulation) frequency. Otherwise this
@@ -2858,7 +2858,7 @@ class SmurfTuneMixin(SmurfBase):
             lms_enable1=True, lms_enable2=True, lms_enable3=True, lms_gain=None,
             f_min=.015, f_max=.2, df_max=.03, toggle_feedback=True,
             relock=True, tracking_setup=True,
-            feedback_start_frac=None, feedback_end_frac=None, setup_flux_ramp=True):
+            feedback_start_frac=None, feedback_end_frac=None, setup_flux_ramp=True, **kwargs):
         """
         This runs tracking setup and check_lock to prune bad channels. This has
         all the same inputs and tracking_setup and check_lock. In particular the
@@ -2956,7 +2956,7 @@ class SmurfTuneMixin(SmurfBase):
 
     @set_action()
     def eta_phase_check(self, band, rot_step_size=30, rot_max=360,
-            reset_rate_khz=None, fraction_full_scale=None, flux_ramp=True):
+            reset_rate_khz=None, fraction_full_scale=None, flux_ramp=True, **kwargs):
         """
         """
         if reset_rate_khz is None:
@@ -3000,7 +3000,7 @@ class SmurfTuneMixin(SmurfBase):
         return ret
 
     @set_action()
-    def analyze_eta_phase_check(self, dat, channel):
+    def analyze_eta_phase_check(self, dat, channel, **kwargs):
         """
         """
         keys = dat['data'].keys()
@@ -3069,7 +3069,7 @@ class SmurfTuneMixin(SmurfBase):
 
     @set_action()
     def set_fixed_flux_ramp_bias(self,fractionFullScale,debug=True,
-            do_config=True):
+            do_config=True, **kwargs):
         """
         No description
 
@@ -3134,7 +3134,7 @@ class SmurfTuneMixin(SmurfBase):
 
     @set_action()
     def flux_ramp_setup(self, reset_rate_khz, fraction_full_scale, df_range=.1,
-            band=2, write_log=False):
+            band=2, write_log=False, **kwargs):
         """
         Set flux ramp sawtooth rate and amplitude.
 
@@ -3440,7 +3440,7 @@ class SmurfTuneMixin(SmurfBase):
             plotname_append='', window=50, rolling_med=True,
             make_subband_plot=False, show_plot=False, grad_cut=.05,
             flip_phase=False, grad_kernel_width=8,
-            amp_cut=.25, pad=2, min_gap=2):
+            amp_cut=.25, pad=2, min_gap=2, **kwargs):
         '''
         Finds the resonances in a band (and specified subbands)
 
@@ -3570,7 +3570,7 @@ class SmurfTuneMixin(SmurfBase):
 
     @set_action()
     def plot_find_freq(self, f=None, resp=None, subband=None, filename=None,
-            save_plot=True, save_name='amp_sweep.png', show_plot=False):
+            save_plot=True, save_name='amp_sweep.png', show_plot=False, **kwargs):
         '''
         Plots the response of the frequency sweep. Must input f and
         resp, or give a path to a text file containing the data for
@@ -3627,7 +3627,7 @@ class SmurfTuneMixin(SmurfBase):
                 plt.close()
 
     @set_action()
-    def full_band_ampl_sweep(self, band, subband, tone_power, n_read, n_step=31):
+    def full_band_ampl_sweep(self, band, subband, tone_power, n_read, n_step=31, **kwargs):
         """sweep a full band in amplitude, for finding frequencies
 
         Args
@@ -3706,7 +3706,7 @@ class SmurfTuneMixin(SmurfBase):
             freq_max=2.5E8, make_plot=False, save_plot=True,
             show_plot=False, plotname_append='',
             band=None, make_subband_plot=False, subband_plot_with_slow=False,
-            timestamp=None, pad=2, min_gap=2, plot_phase=False):
+            timestamp=None, pad=2, min_gap=2, plot_phase=False, **kwargs):
         """
         find the peaks within each subband requested from a fullbandamplsweep
 
@@ -3794,7 +3794,7 @@ class SmurfTuneMixin(SmurfBase):
 
     @set_action()
     def fast_eta_scan(self, band, subband, freq, n_read, tone_power,
-            make_plot=False):
+            make_plot=False, **kwargs):
         """copy of fastEtaScan.m from Matlab. Sweeps quickly across a
         range of freq and gets I, Q response
 
@@ -3860,7 +3860,7 @@ class SmurfTuneMixin(SmurfBase):
                       sweep_width=.3, df_sweep=.002, min_offset=0.1,
                       delta_freq=None, new_master_assignment=False,
                       lock_max_derivative=False,
-                      scan_unassigned=False):
+                      scan_unassigned=False, **kwargs):
         """
         Does a fine sweep over the resonances found in find_freq. This
         information is used for placing tones onto resonators. It is
@@ -4111,7 +4111,7 @@ class SmurfTuneMixin(SmurfBase):
     def calculate_eta_svd(self, band, channel,
             nsamp=2**15, filter=True, N=4, Wn=50000, btype='lowpass',
             method='gust', make_plot=True, show_plot=False, save_plot=True,
-            subtract_median=True, update_eta_phase=True):
+            subtract_median=True, update_eta_phase=True, **kwargs):
         """
         Takes I and Q data at attempts to calculate the eta parameters by
         maximizing the noise in Q. This uses SVD to calculate the rotation.
@@ -4253,7 +4253,7 @@ class SmurfTuneMixin(SmurfBase):
         return savedir + ".npy"
 
     @set_action()
-    def load_tune(self, filename=None, override=True, last_tune=True, band=None):
+    def load_tune(self, filename=None, override=True, last_tune=True, band=None, **kwargs):
         """
         Loads the tuning information (self.freq_resp) from tuning directory
 
@@ -4331,7 +4331,7 @@ class SmurfTuneMixin(SmurfBase):
             meas_lms_freq=False, feedback_start_frac=.2,
             feedback_end_frac=.98, meas_flux_ramp_amp=True, n_phi0=4,
             make_plot=False, show_plot=False, save_plot=True,
-            df_bins=None):
+            df_bins=None, **kwargs):
         """
         Loops over multiple LMS delays and measures df. Looks for the minima
         of the median of the df terms for all the channels that are on. It is
@@ -4472,7 +4472,7 @@ class SmurfTuneMixin(SmurfBase):
     def estimate_lms_freq(self, band, reset_rate_khz,
                           fraction_full_scale=None,
                           channel=None,
-                          make_plot=False):
+                          make_plot=False, **kwargs):
         """
         Attempts to estimate the carrier (phi0) rate for all channels
         on in the requested 500 MHz band (0..7) using the flux_mod2
@@ -4518,7 +4518,7 @@ class SmurfTuneMixin(SmurfBase):
 
     @set_action()
     def estimate_flux_ramp_amp(self, band, n_phi0, write_log=True,
-                               reset_rate_khz=None, channel=None):
+                               reset_rate_khz=None, channel=None, **kwargs):
         """
         This is like estimate_lms_freq, except it changes the
         flux ramp amplitude instead of the flux ramp frequency.
@@ -4575,7 +4575,7 @@ class SmurfTuneMixin(SmurfBase):
 
     @set_action()
     def flux_mod2(self, band, df, sync, min_scale=0, make_plot=False,
-            channel=None, threshold=.5):
+            channel=None, threshold=.5, **kwargs):
         """
         Attempts to find the number of phi0s in a tracking_setup.
         Takes df and sync from a tracking_setup with feedback off.
@@ -4708,7 +4708,7 @@ class SmurfTuneMixin(SmurfBase):
 
     @set_action()
     def flux_mod(self, df, sync, threshold=.4, minscale=.02,
-                 min_spectrum=.9, make_plot=False):
+                 min_spectrum=.9, make_plot=False, **kwargs):
         """
         Joe made this
         """
@@ -4815,7 +4815,7 @@ class SmurfTuneMixin(SmurfBase):
         return mod_median
 
 
-    def dump_state(self, output_file=None, return_screen=False):
+    def dump_state(self, output_file=None, return_screen=False, **kwargs):
         """
         Dump the current tuning info to config file and write to disk
 
@@ -4869,7 +4869,7 @@ class SmurfTuneMixin(SmurfBase):
             return self.config.config
 
     @set_action()
-    def fake_resonance_dict(self, freqs, save_sweeps=False):
+    def fake_resonance_dict(self, freqs, save_sweeps=False, **kwargs):
         """
         Takes a list of resonance frequencies and fakes a resonance dictionary
         so that we can run setup_notches on a subset without find_freqs

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -42,7 +42,7 @@ class SmurfUtilMixin(SmurfBase):
     @set_action()
     def take_debug_data(self, band, channel=None, nsamp=2**19, filename=None,
             IQstream=1, single_channel_readout=1, debug=False, rf_iq=False,
-            write_log=True):
+            write_log=True, **kwargs):
         """Takes raw debugging data.
 
         Args
@@ -193,7 +193,7 @@ class SmurfUtilMixin(SmurfBase):
         alpha=np.cos(thetac)-1.+np.sqrt(np.cos(thetac)**2-4.*np.cos(thetac)+3.)
         return alpha
 
-    def set_debug_data_filter_cutoff(self,band,fcut_hz):
+    def set_debug_data_filter_cutoff(self,band,fcut_hz, **kwargs):
         r"""Sets the debug data filter cut-off frequency in Hz.
 
         The debug data filter is implemented as digital exponential
@@ -282,7 +282,7 @@ class SmurfUtilMixin(SmurfBase):
     @set_action()
     def estimate_phase_delay(self, band, nsamp=2**19, make_plot=True,
             show_plot=True, save_plot=True, save_data=True, n_scan=5,
-            timestamp=None, uc_att=None, dc_att=None, freq_min=-2.4E6, freq_max=2.4E6):
+            timestamp=None, uc_att=None, dc_att=None, freq_min=-2.4E6, freq_max=2.4E6, **kwargs):
         """Estimates total system latency for requested band.
 
         Measures the analog and digital (=processing) phase delay (or
@@ -598,7 +598,7 @@ class SmurfUtilMixin(SmurfBase):
 
         return dsp_delay_us, dsp_corr_delay_us
 
-    def process_data(self, filename, dtype=np.uint32):
+    def process_data(self, filename, dtype=np.uint32, **kwargs):
         """ Reads a file taken with take_debug_data and processes it into data
         and header.
 
@@ -648,7 +648,7 @@ class SmurfUtilMixin(SmurfBase):
         return header, data
 
     @set_action()
-    def decode_data(self, filename, swapFdF=False, recast=True, truncate=True):
+    def decode_data(self, filename, swapFdF=False, recast=True, truncate=True, **kwargs):
         """ Take a dataset from take_debug_data and spit out results.
 
         Args
@@ -760,7 +760,7 @@ class SmurfUtilMixin(SmurfBase):
         return f, df, flux_ramp_strobe
 
     @set_action()
-    def decode_single_channel(self, filename, swapFdF=False):
+    def decode_single_channel(self, filename, swapFdF=False, **kwargs):
         """
         decode take_debug_data file if in singlechannel mode
 
@@ -821,7 +821,7 @@ class SmurfUtilMixin(SmurfBase):
                          write_log=True, update_payload_size=True,
                          reset_unwrapper=True, reset_filter=True,
                          return_data=False, make_freq_mask=True,
-                         register_file=False, IQ_mode=False):
+                         register_file=False, IQ_mode=False, **kwargs):
         """
         Takes streaming data for a given amount of time
 
@@ -941,7 +941,7 @@ class SmurfUtilMixin(SmurfBase):
                        update_payload_size=True, reset_filter=True,
                        reset_unwrapper=True, make_freq_mask=True,
                        channel_mask=None, make_datafile=True,
-                       filter_wait_time=0.1,IQ_mode=False):
+                       filter_wait_time=0.1,IQ_mode=False, **kwargs):
         """
         Turns on streaming data.
 
@@ -1099,7 +1099,7 @@ class SmurfUtilMixin(SmurfBase):
             return data_filename
 
     @set_action()
-    def stream_data_off(self, write_log=True, register_file=False):
+    def stream_data_off(self, write_log=True, register_file=False, **kwargs):
         """
         Turns off streaming data.
 
@@ -1127,7 +1127,7 @@ class SmurfUtilMixin(SmurfBase):
                          return_header=False,
                          return_tes_bias=False, write_log=True,
                          n_max=2048, make_freq_mask=False,
-                         gcp_mode=False, IQ_mode=False, fast_reader=True):
+                         gcp_mode=False, IQ_mode=False, fast_reader=True, **kwargs):
         """
         Loads data taken with the function stream_data_on.
         Gives back the resonator data in units of phase. Also
@@ -1368,7 +1368,7 @@ class SmurfUtilMixin(SmurfBase):
 
     @set_action()
     def read_stream_data_gcp_save(self, datafile, channel=None,
-            unwrap=True, downsample=1, nsamp=None):
+            unwrap=True, downsample=1, nsamp=None, **kwargs):
         """
         Reads the special data that is designed to be a copy of the GCP data.
         This was the most common data writing mode until the Rogue 4 update.
@@ -1493,7 +1493,7 @@ class SmurfUtilMixin(SmurfBase):
 
     @set_action()
     def header_to_tes_bias(self, header, as_volt=True,
-                           n_tes_bias=15):
+                           n_tes_bias=15, **kwargs):
         """
         Takes the SmurfHeader returned from read_stream_data
         and turns it to a TES bias. The header is a 20 field,
@@ -1556,7 +1556,7 @@ class SmurfUtilMixin(SmurfBase):
         return bias
 
     @set_action()
-    def make_mask_lookup(self, mask_file, make_freq_mask=False):
+    def make_mask_lookup(self, mask_file, make_freq_mask=False, **kwargs):
         """ Makes an n_band x n_channel array where the elements correspond
         to the smurf_to_mce mask number. In other words, mask[band, channel]
         returns the GCP index in the mask that corresonds to band, channel.
@@ -1612,7 +1612,7 @@ class SmurfUtilMixin(SmurfBase):
 
     @set_action()
     def read_stream_data_daq(self, data_length, bay=0, hw_trigger=False,
-            write_log=False):
+            write_log=False, **kwargs):
         """
         Reads the stream data from the DAQ.
 
@@ -1714,7 +1714,7 @@ class SmurfUtilMixin(SmurfBase):
     def read_adc_data(self, band, data_length=2**19,
                       hw_trigger=False, make_plot=False, save_data=True,
                       timestamp=None, show_plot=True, save_plot=True,
-                      plot_ylimits=[None,None]):
+                      plot_ylimits=[None,None], **kwargs):
         """
         Reads data directly off the ADC.
 
@@ -1818,7 +1818,7 @@ class SmurfUtilMixin(SmurfBase):
     def read_dac_data(self, band, data_length=2**19,
                       hw_trigger=False, make_plot=False, save_data=True,
                       timestamp=None, show_plot=True, save_plot=True,
-                      plot_ylimits=[None,None]):
+                      plot_ylimits=[None,None], **kwargs):
         """
         Read the data directly off the DAC.
 
@@ -1917,7 +1917,7 @@ class SmurfUtilMixin(SmurfBase):
 
     @set_action()
     def setup_daq_mux(self, converter, converter_number, data_length,
-                      band=0, debug=False, write_log=False):
+                      band=0, debug=False, write_log=False, **kwargs):
         """
         Sets up for either ADC or DAC data taking.
 
@@ -1962,7 +1962,7 @@ class SmurfUtilMixin(SmurfBase):
 
     @set_action()
     def set_buffer_size(self, bay, size, debug=False,
-                        write_log=False):
+                        write_log=False, **kwargs):
         """
         Sets the buffer size for reading and writing DAQs
 
@@ -1985,7 +1985,7 @@ class SmurfUtilMixin(SmurfBase):
 
     @set_action()
     def config_cryo_channel(self, band, channel, frequencyMHz, amplitude,
-            feedback_enable, eta_phase, eta_mag):
+            feedback_enable, eta_phase, eta_mag, **kwargs):
         """
         Set parameters on a single cryo channel
 
@@ -2173,7 +2173,7 @@ class SmurfUtilMixin(SmurfBase):
         self.set_feedback_limit(band, desired_feedback_limit_dec, **kwargs)
 
     # if no guidance given, tries to reset both
-    def recover_jesd(self, bay, recover_jesd_rx=True, recover_jesd_tx=True):
+    def recover_jesd(self, bay, recover_jesd_rx=True, recover_jesd_tx=True, **kwargs):
         """
         Attempts to recover the JESDs
 
@@ -2260,7 +2260,7 @@ class SmurfUtilMixin(SmurfBase):
 
         return jesd_decorator_function
 
-    def check_jesd(self, bay, silent_if_valid=False, max_timeout_sec=60):
+    def check_jesd(self, bay, silent_if_valid=False, max_timeout_sec=60, **kwargs):
         """Checks JESD status for requested bay.
 
         Queries the Jesd tx and rx and compares the data_valid and
@@ -2490,7 +2490,7 @@ class SmurfUtilMixin(SmurfBase):
         else:
             return channel_freqs[channel]
 
-    def get_channel_order(self, band=None, channel_orderfile=None):
+    def get_channel_order(self, band=None, channel_orderfile=None, **kwargs):
         """ produces order of channels from a user-supplied input file
 
         Args
@@ -2549,7 +2549,7 @@ class SmurfUtilMixin(SmurfBase):
             channel_orderfile=channel_orderfile)[n_cut:-n_cut])
 
     def get_subband_from_channel(self, band, channel, channelorderfile=None,
-            yml=None):
+            yml=None, **kwargs):
         """Returns subband number given a channel number
 
         Args
@@ -2590,7 +2590,7 @@ class SmurfUtilMixin(SmurfBase):
         return int(subband)
 
     def get_subband_centers(self, band, as_offset=True, hardcode=False,
-            yml=None):
+            yml=None, **kwargs):
         """ returns frequency in MHz of subband centers
 
         Args
@@ -2621,7 +2621,7 @@ class SmurfUtilMixin(SmurfBase):
 
         return subbands, subband_centers
 
-    def get_channels_in_subband(self, band, subband, channelorderfile=None):
+    def get_channels_in_subband(self, band, subband, channelorderfile=None, **kwargs):
         """
         Returns channels in subband
 
@@ -2930,7 +2930,7 @@ class SmurfUtilMixin(SmurfBase):
 
     def overbias_tes(self, bias_group, overbias_voltage=19.9, overbias_wait=1.,
                      tes_bias=19.9, cool_wait=20., high_current_mode=False,
-                     flip_polarity=False, actually_overbias=True):
+                     flip_polarity=False, actually_overbias=True, **kwargs):
         """
         Overbiases requested bias group at overbias_voltage in high current mode
         for overbias_wait seconds. If high_current_mode=False,
@@ -2991,7 +2991,7 @@ class SmurfUtilMixin(SmurfBase):
 
     def overbias_tes_all(self, bias_groups=None, overbias_voltage=19.9,
             overbias_wait=1.0, tes_bias=19.9, cool_wait=20.,
-            high_current_mode=False, actually_overbias=True):
+            high_current_mode=False, actually_overbias=True, **kwargs):
         """
         Overbiases all requested bias groups (specified by the
         bias_groups array) at overbias_voltage in high current mode
@@ -3067,7 +3067,7 @@ class SmurfUtilMixin(SmurfBase):
         self.log('Done waiting.', self.LOG_USER)
 
 
-    def set_tes_bias_high_current(self, bias_group, write_log=False):
+    def set_tes_bias_high_current(self, bias_group, write_log=False, **kwargs):
         """
         Sets all bias groups to high current mode. Note that the bias group
         number is not the same as the relay number. It also does not matter,
@@ -3118,7 +3118,7 @@ class SmurfUtilMixin(SmurfBase):
             self._pic_to_bias_group[:,1]==bias_group)])[0]
         return (relay>>r) & 1
 
-    def set_tes_bias_low_current(self, bias_group, write_log=False):
+    def set_tes_bias_low_current(self, bias_group, write_log=False, **kwargs):
         """
         Sets all bias groups to low current mode. Note that the bias group
         number is not the same as the relay number. It also does not matter,
@@ -3280,7 +3280,7 @@ class SmurfUtilMixin(SmurfBase):
         self.log(aph)
         return (aph)
 
-    def make_channel_mask(self, band=None, smurf_chans=None, IQ_mode=False):
+    def make_channel_mask(self, band=None, smurf_chans=None, IQ_mode=False, **kwargs):
         """
         Makes the channel mask. Only the channels in the
         mask will be streamed or written to disk.
@@ -3360,7 +3360,7 @@ class SmurfUtilMixin(SmurfBase):
         return freqs
 
 
-    def set_downsample_filter(self, filter_order, cutoff_freq, write_log=False):
+    def set_downsample_filter(self, filter_order, cutoff_freq, write_log=False, **kwargs):
         """
         Sets the downsample filter. This is anti-alias filter
         that filters data at the flux_ramp reset rate, which is
@@ -3429,7 +3429,7 @@ class SmurfUtilMixin(SmurfBase):
 
     @set_action()
     def make_gcp_mask(self, band=None, smurf_chans=None,
-                      gcp_chans=None, read_gcp_mask=True):
+                      gcp_chans=None, read_gcp_mask=True, **kwargs):
         """
         THIS FUNCTION WAS USED FOR BKUMUX DATA ACQUISITION.  IT'S
         COMPLETELY BROKEN NOW, POST ROGUE4 MIGRATION.
@@ -3490,7 +3490,7 @@ class SmurfUtilMixin(SmurfBase):
                   skip_samp_start=10, high_current_mode=True,
                   skip_samp_end=10, plot_channels=None,
                   gcp_mode=False, gcp_wait=0.5, gcp_between=1.0,
-                  dat_file=None, offset_percentile=2):
+                  dat_file=None, offset_percentile=2, **kwargs):
         """
         Toggles the TES bias high and back to its original state. From this, it
         calculates the electrical responsivity (sib), the optical responsivity (siq),
@@ -3766,7 +3766,7 @@ class SmurfUtilMixin(SmurfBase):
         return (gcp_num*16)%528 + gcp_num//33
 
 
-    def smurf_channel_to_gcp_num(self, band, channel):
+    def smurf_channel_to_gcp_num(self, band, channel, **kwargs):
         """
         Converts from smurf channel (band and channel) to a gcp number
 
@@ -3814,7 +3814,7 @@ class SmurfUtilMixin(SmurfBase):
         return int(mask[mask_num]//n_channels), int(mask[mask_num]%n_channels)
 
 
-    def play_sine_tes(self, bias_group, tone_amp, tone_freq, dc_amp=None):
+    def play_sine_tes(self, bias_group, tone_amp, tone_freq, dc_amp=None, **kwargs):
         """
         Play a sine wave on the bias group pair.
 
@@ -3864,7 +3864,7 @@ class SmurfUtilMixin(SmurfBase):
         self.play_tes_bipolar_waveform(bias_group, sig)
 
 
-    def play_tone_file(self, band, tone_file=None, load_tone_file=True):
+    def play_tone_file(self, band, tone_file=None, load_tone_file=True, **kwargs):
         """
         Plays the specified tone file on this band.  If no path provided
         for tone file, assumes the path to the correct tone file has
@@ -3940,7 +3940,7 @@ class SmurfUtilMixin(SmurfBase):
         return ret
 
 
-    def set_fixed_tone(self, freq_mhz, tone_power, write_log=False):
+    def set_fixed_tone(self, freq_mhz, tone_power, write_log=False, **kwargs):
         """
         Places a fixed tone at the requested frequency.  Asserts
         without doing anything if the requested resonator frequency
@@ -4080,7 +4080,7 @@ class SmurfUtilMixin(SmurfBase):
     _hardware_logging_thread=None
     __hardware_logging_stop_event=None
 
-    def start_hardware_logging(self,filename=None,wait_btw_sec=5.0):
+    def start_hardware_logging(self,filename=None,wait_btw_sec=5.0, **kwargs):
         """Starts hardware logging in external thread.
 
         Args
@@ -4348,7 +4348,7 @@ class SmurfUtilMixin(SmurfBase):
     def identify_bias_groups(self, bias_groups=None,
             probe_freq=2.5, probe_time=3, probe_amp=.1, make_plot=False,
             show_plot=False, save_plot=True, cutoff_frac=.05,
-            update_channel_assignment=True, high_current_mode=True):
+            update_channel_assignment=True, high_current_mode=True, **kwargs):
         """ Identify bias groups of all the channels that are on. Plays
         a sine wave on a bias group and looks for a response. Does
         this with the TESs superconducting so it can look for an
@@ -4555,7 +4555,7 @@ class SmurfUtilMixin(SmurfBase):
 
     def find_probe_tone_gap(self, band, n_tone=2, n_scan=5,
                           make_plot=True,
-                          save_plot=True, show_plot=False):
+                          save_plot=True, show_plot=False, **kwargs):
         """
         This finds the larges n_tone gaps in the band. These
         are used for finding gaps to put probe tones for checking
@@ -4879,7 +4879,7 @@ class SmurfUtilMixin(SmurfBase):
         # Timing configuration not recognized, return None
         return None
 
-    def set_timing_mode(self, mode, write_log=False):
+    def set_timing_mode(self, mode, write_log=False, **kwargs):
         r"""Sets timing mode.
 
         Use this function to configure the system's timing mode.  The


### PR DESCRIPTION
## Summary
- Closes #385
- Adds `**kwargs` to 112 high-level user-entry points across the four user-facing mixins (`smurf_tune.py`, `smurf_util.py`, `smurf_iv.py`, `smurf_noise.py`)
- Future feature branches can introduce new optional arguments to these functions without breaking older callers — exactly the design described in the issue
- Signature-only change. Zero behavior change. Each function silently absorbs unknown kwargs (matches the existing pattern in `check_lock`, `noise_vs`, `toggle_feedback`, `band_off`)

## Coverage by file (public methods, AST-verified)
| File | Before (with kwargs) | After (with kwargs) |
|---|---|---|
| `smurf_tune.py` | 2 / 63 | 46 / 63 |
| `smurf_util.py` | 13 / 95 | 54 / 95 |
| `smurf_iv.py` | 1 / 7 | 7 / 7 |
| `smurf_noise.py` | 1 / 24 | 22 / 24 |

Combined with `smurf_command.py` (already 92% covered since 2020) and `smurf_atca_monitor.py` (100%), all major user-facing entry points now accept `**kwargs`.

## Out of scope (deliberately)
- `smurf_command.py` — already 92% covered; the remaining 35 are mostly deprecation shims being phased out in adjacent PRs
- Thin PV getters with ≤1 arg
- Pure math/converter helpers (`freq_to_band`, `channel_to_freq`, etc.) — they don't accumulate parameters over time, so `**kwargs` adds no value and only masks typos
- `smurf_control.py` low-level utilities (`make_dir`, `get_timestamp`, `add_output`, `write_output`)

## Test plan
- [x] `flake8 --count python/` passes (0 errors, full CI invocation)
- [x] `python -m py_compile` on all 4 files succeeds
- [x] AST coverage check: all 112 target methods now have `**kwargs`
- [ ] Hardware-dependent tests in `python/pysmurf/client/test/` require a live cryostat — not run here. Risk is zero because the change is signature-only.