### PR TITLE
docs(template.cfg): Comprehensive parameter reference (closes #365)

### DIFF
--- a/README.config_file.md
+++ b/README.config_file.md
@@ -2,73 +2,180 @@ The configuration file defines basic default parameters that are implementation 
 
 # Organization
 
-The configuration files are stored in the `cfg_files` folder in the pysmurf git repository ([https://github.com/slaclab/pysmurf/tree/main/cfg_files](https://github.com/slaclab/pysmurf/tree/main/cfg_files)). There are subfolders for each institution/site. Some subdirectories also have a README file that describes the config file. We encourage this to be included so the specific details of the files can be understood in the future. 
+The configuration files are stored in the `cfg_files` folder in the pysmurf git repository ([https://github.com/slaclab/pysmurf/tree/main/cfg_files](https://github.com/slaclab/pysmurf/tree/main/cfg_files)). There are subfolders for each institution/site. Some subdirectories also have a README file that describes the config file. We encourage this to be included so the specific details of the files can be understood in the future.
 
 # Quick Start
 
-1. If it does not exist, make a directory for your site. 
-2. Copy the template config file from `cfg_files/template/template.cfg` into your directory you created in step 1. 
-3. Update the amplifier values if needed.
-4. If you know it, update the `bias_line_resistance` and `R_sh` fields.
-5. Save
+1. If it does not exist, make a directory for your site under `cfg_files/`.
+2. Copy the template config file from `cfg_files/template/template.cfg` into your site directory.
+3. Update the `amplifier` values to match your cryostat-card calibration.
+4. If you know them, update the `bias_line_resistance` and `R_sh` fields.
+5. Save.
 
-You should be able to call this config file when you instantiate your `SmurfControl` object. One of the first steps you'll do is run `estimate_phase_delay`. You can save the outputs into your config file so you will not need to run it in the future. 
+You should be able to call this config file when you instantiate your `SmurfControl` object. One of the first steps you'll do is run `S.estimate_phase_delay(band)` for each band; save its output into the per-band `bandDelayUs` field of your config file so you do not need to re-run it later.
 
-# Important Variables
+The file is JSON, with one extension: any line beginning with `#`, and any text following a `#` on a line, is stripped before parsing (see `SmurfConfig.read_json`). The schema lives in `python/pysmurf/client/base/smurf_config.py` (`SmurfConfig.validate_config`); unknown top-level keys are tolerated (`ignore_extra_keys=True`) but ignored.
+
+# Parameter Reference
+
+For each parameter below: `key` — type, range/units, default, short description. "Required" means schema validation rejects the file if the key is missing. "Optional" means the schema fills in the listed default.
 
 ## init
 
-### band_#
+DSP initialisation, per 500 MHz band.
 
-- `refPhaseDelay` - The phase delay parameter. Solve for this using the function `S.estimate_phase_delay(band)`
-- `refPhaseDelayFine` - The fine phase delay parameter. Solve for this using the function `S.estimate_phase_delay(band)`
-- `att_uc` - The upconverter (DAC) attenuator
-- `att_dc` - The downconverter (ADC) attenuator
-- `amplitude_scale` - The probe tone power.
+- `dspEnable` — int (0/1), optional, default `1`. Force-enables DSP during pysmurf setup.
+- `band_N` — dict (N in 0..7), at least one required. Each band block accepts:
+
+| Key | Type / range | Default | Description |
+| --- | --- | --- | --- |
+| `feedbackGain` | int, `[0, 2^16)` | required | Global tracking-feedback gain. |
+| `feedbackLimitkHz` | float kHz, > 0 | required | Tracking-feedback bandwidth limit. |
+| `att_uc` | int, `[0, 32)` | required | Up-converter (DAC) RF attenuator, 0.5 dB steps. |
+| `att_dc` | int, `[0, 32)` | required | Down-converter (ADC) RF attenuator, 0.5 dB steps. |
+| `amplitude_scale` | int, `[0, 16)` | required | Probe-tone amplitude, 3 dB steps. |
+| `trigRstDly` | int, `[0, 128)` | required | Flux-ramp counter reset delay, 2.4 MHz ticks. |
+| `lmsGain` | int, `[0, 8)` | required | LMS gain, powers of 2. |
+| `iq_swap_in` | int (0/1) | `0` | Swap I/Q on input. |
+| `iq_swap_out` | int (0/1) | `0` | Swap I/Q on output. |
+| `feedbackEnable` | int (0/1) | `1` | Enable tracking feedback. |
+| `feedbackPolarity` | int (0/1) | `1` | Tracking-feedback sign. |
+| `bandDelayUs` | float, `[0, 30)` µs | `null` | Total round-trip delay; measure with `S.estimate_phase_delay(band)`. Replaces the deprecated `refPhaseDelay`/`refPhaseDelayFine` pair. |
+| `data_out_mux` | list[int, int] in `[0, 9]`, distinct | per-band default | DSP data-out mux selection. Defaults: bands 0/4 → `[2,3]`, 1/5 → `[0,1]`, 2/6 → `[6,7]`, 3/7 → `[8,9]`. |
+| `lmsDelay` | int, `[0, 64)` | falls back to `refPhaseDelay` | LMS feedback latency match. |
+| `refPhaseDelay` | int, `[0, 32)` | `0` | **DEPRECATED** — use `bandDelayUs`. |
+| `refPhaseDelayFine` | int, `[0, 256)` | `0` | **DEPRECATED** — use `bandDelayUs`. |
 
 ## bad_mask
 
-A list of bad channels. Resonators in the bad mask will not be turned on. The bad mask is defined by frequency. Below is a bad mask that excludes resonators between 5000-5100 MHz and 5171.64-5171.74 MHz.  
+Optional, default `{}`. Frequency intervals (in MHz) where resonator candidates are ignored during relock. Keys are arbitrary unique strings; values are `[f_low, f_high]` with `f_low < f_high` and both in `[4000, 8000]`.
 
 ```yaml
 "bad_mask": {
-"0": [
-	5000,
-  5100
-      ],
-"1": [
-	5171.64,
-	5171.74
-]
+  "0": [5000, 5100],
+  "1": [5171.64, 5171.74]
 }
 ```
 
 ## amplifier
 
-The 4K and 50K amplifier bias values. This also holds the conversion between volts and DAC bits.
+4K HEMT and 50K LNA bias values plus calibration constants.
 
-## pic_to_bias_group
+| Key | Type / units | Default | Description |
+| --- | --- | --- | --- |
+| `hemt_Vg` | float, V | required | 4K HEMT gate voltage. |
+| `bit_to_V_hemt` | float V/bit, > 0 | required | HEMT gate DAC scale. |
+| `hemt_Id_offset` | float, mA | required | HEMT drain-current regulator offset, subtracted from the measured value. |
+| `LNA_Vg` | float, V | required | 50K LNA gate voltage. |
+| `50k_Id_offset` | float, mA | required | 50K LNA drain-current regulator offset. |
+| `dac_num_50k` | int, `[1, 32]` | required | RTM DAC wired to the 50K LNA gate. C02 cards use `32`; some early C01s use `2`. |
+| `bit_to_V_50k` | float V/bit, > 0 | required | 50K gate DAC scale. |
+| `hemt_gate_min_voltage` / `hemt_gate_max_voltage` | float, V | required | Software clamps for `set_hemt_gate_voltage`. |
+| `hemt_Vd_series_resistor` | float Ω, > 0 | `200.0` | Inline drain-current sense resistor (R44 on C02 cards). |
+| `50K_amp_Vd_series_resistor` | float Ω, > 0 | `10.0` | Inline drain-current sense resistor (R54 on C02 cards). |
+| `hemt`, `50k` | dict | C02 defaults | Cryocard PIC enable wiring per amp rail. Required field if present: `gate_dac_num`. |
+| `hemt1`, `hemt2`, `50k1`, `50k2` | dict | C02 defaults | Dual-amplifier crate descriptors. If a block is present, **all 14 fields** are required (see `smurf_config.py:523-663`): `drain_conversion_b/m`, `drain_dac_num`, `drain_offset`, `drain_opamp_gain`, `drain_pic_address`, `drain_resistor`, `drain_volt_default/min/max`, `gate_bit_to_volt`, `gate_volt_default/min/max`, `power_bitmask` (and `gate_dac_num` for `hemt2`/`50k1`/`50k2`). |
 
-The relation between PIC on the cryocard and bias group pair. See the documentation [here](https://confluence.slac.stanford.edu/pages/viewpage.action?spaceKey=SMuRF&title=Cryostat+board).
+## attenuator
 
-## bias_group_to_pair
+Mapping from each of the four UC/DC RF attenuators to a band index in `[0, 4)`. The same mapping applies to bay 0 (bands 0-3) and bay 1 (bands 4-7).
 
-The TES bias uses a bipolar pair of DACs. This defines the pair of DACs that form a bias group.
+```yaml
+"attenuator": { "att1": 0, "att2": 1, "att3": 2, "att4": 3 }
+```
+
+## chip_to_freq
+
+Mux-chip number → `[f_min_GHz, f_max_GHz]` covered by that chip. Used by tune helpers when assigning resonators to chips. Keys are stringified chip numbers; values are length-2 float lists.
+
+## pic_to_bias_group / bias_group_to_pair
+
+The relation between PIC channel on the cryocard and TES bias group. See the [cryostat-board documentation](https://confluence.slac.stanford.edu/pages/viewpage.action?spaceKey=SMuRF&title=Cryostat+board).
+
+`bias_group_to_pair` defines the bipolar RTM DAC pair `[pos, neg]` driving each TES bias group. Validation enforces:
+
+- No DAC may appear in more than one pair.
+- The DAC named in `amplifier.dac_num_50k` may not appear in any pair.
+
+## TES electrical parameters
+
+Top-level keys, all required and `> 0` unless noted.
+
+- `R_sh` — float, Ω. TES shunt resistance (assumed identical for every channel).
+- `bias_line_resistance` — float, Ω. Round-trip TES bias-line resistance in low-current mode (cryostat-card + cable + cold resistors).
+- `high_low_current_ratio` — float, `>= 1`. Current ratio between low- and high-current modes.
+- `high_current_mode_bool` — int (0/1), optional, default `0`. If `1`, biasing is *always* high-current.
+- `all_bias_groups` — list[int] in `[0, 16)`. TES bias groups in use.
+
+## tune_band
+
+Resonator tuning and tracking parameters.
+
+| Key | Type / range / units | Notes |
+| --- | --- | --- |
+| `fraction_full_scale` | float, `(0, 1]` | Flux-ramp DAC swing as a fraction of full scale. |
+| `reset_rate_khz` | float, `[0, 100]` kHz | Flux-ramp reset rate. |
+| `default_tune` | path string, optional | Saved tune file loaded on construction. |
+| `lms_freq` | dict, per-band, float Hz, > 0 | Tracking sideband frequency. |
+| `delta_freq` | dict, per-band, float MHz, > 0 | Span around each resonator probed during tracking. |
+| `feedback_start_frac` | dict, per-band, `[0, 1]` | Fraction of cycle where feedback turns on. |
+| `feedback_end_frac` | dict, per-band, `[0, 1]` | Fraction of cycle where feedback turns off. |
+| `gradient_descent_gain` | dict, per-band, float > 0 | |
+| `gradient_descent_averages` | dict, per-band, int > 0 | |
+| `gradient_descent_converge_hz` | dict, per-band, float Hz, > 0 | |
+| `gradient_descent_step_hz` | dict, per-band, float Hz, > 0 | |
+| `gradient_descent_momentum` | dict, per-band, int >= 0 | |
+| `gradient_descent_beta` | dict, per-band, `[0, 1]` | |
+| `eta_scan_averages` | dict, per-band, int > 0 | |
+| `eta_scan_del_f` | dict, per-band, int Hz, > 0 | |
+| `eta_scan_amplitude` | dict, per-band, int | Probe amplitude. |
+
+Per-band dicts must contain one entry per band declared in `init`. Keys are stringified band indices (`"0"`, `"1"`, ...).
+
+## flux_ramp
+
+- `num_flux_ramp_counter_bits` — `20` (C0 RTM) or `32` (C1 RTM).
 
 ## constant
 
-- `pA_per_phi0` - The conversion between units oh phi0 and pA. This is number depends on the resonator/mulitplexing chips installed.
+Optional, default `{ "pA_per_phi0": 9e6 }`.
+
+- `pA_per_phi0` — float, pA / Φ₀. TES current per Φ₀ of demodulated SQUID phase. Depends on the installed mux-chip generation.
 
 ## timing
 
-This defines which timing master to use. The available values are "ext_ref" and "backplane". 
+- `timing_reference` — one of `"ext_ref"`, `"backplane"`, `"fiber"`.
+  - `"ext_ref"` — internal oscillator locked to the front-panel reference (`LmkReg_0x0147 : 0x1A`); sets `flux_ramp_start_mode = 0`.
+  - `"backplane"` — timing taken from a timing master via the ATCA backplane; sets `flux_ramp_start_mode = 1`.
+  - `"fiber"` — timing taken from a timing-system fiber input.
 
-## Others
+## fs
 
-These are other variables that are in the top level of the config table. Several of these should probably be moved, but for now just know they exist.
+Float Hz, > 0. SMuRF data sampling frequency. The system reports its actual rate at runtime; this value is used for offline calculations and as a fallback.
 
-- `R_sh` - The resistance of the shunt resistor in Ohms
-- `bias_line_resistance`- The resistance of cabling from cryocard to the TES.
-- `tune_dir`- The directory where the tuning files are stored. Tuning files define the resonator frequencies and the channel assignments
-- `default_data_dir`- The directory where the output data is stored. Output data can include anything from eta-scans to tracked resonator timestreams
-- `high_low_current_ratio` - The ratio between the high current mode (no filtering) and low current mode (with lowpass filter)
+## Output directories
+
+All optional. Each path must exist with write permission for the running user (validated on load).
+
+- `default_data_dir` — default `/data/smurf_data` (raw/output data).
+- `smurf_cmd_dir` — default `/data/smurf_data/smurf_cmd` (remote-command files).
+- `tune_dir` — default `/data/smurf_data/tune` (saved tunings).
+- `status_dir` — default `/data/smurf_data/status` (run-status files).
+
+## ultrascale_temperature_limit_degC
+
+Optional, default `null`. Ultrascale FPGA over-temperature protection threshold in degC, range `[0, 99]`. If `null`, pysmurf does not engage OT protection. Some crates have been observed to drop the carrier mid-enable sequence; newer firmware enables OT protection in firmware instead.
+
+# Deprecated Keys
+
+Documented for back-compat with older site configs. Avoid in new files.
+
+- `init.band_N.refPhaseDelay`, `init.band_N.refPhaseDelayFine` — superseded by `bandDelayUs`. Migrate by measuring `bandDelayUs` with `S.estimate_phase_delay(band)` and removing both legacy keys. Validation still accepts them (defaults `0`).
+- `smurf_to_mce` — block driving the SMuRF → Keck GCP transmit path. Mostly retired; some legacy fields are still consumed by `python/pysmurf/client/util/smurf_util.py`. Replaced by the `processor` block in PR #444. Not validated by the schema (`ignore_extra_keys=True`).
+- `init.band_N.lmsDelay` — retained for offline analysis and back-compat; new configs should rely on `bandDelayUs`-derived defaults.
+- `init.dspEnable` — legacy override; production systems set this through `defaults.yml`.
+
+Configuration keys present in older site configs but **not** recognised by the current schema (silently ignored):
+
+- `epics_root` — only referenced in `scratch/cyu/cryochannel.py`; not loaded by the active client.
+- `flux_ramp.select_ramp` — `set_select_ramp` is hard-coded to `0x1` in `python/pysmurf/client/base/smurf_control.py:646`; the config value is never read.

--- a/cfg_files/template/template.cfg
+++ b/cfg_files/template/template.cfg
@@ -1,90 +1,221 @@
+# =============================================================================
+# pysmurf configuration file template
+# -----------------------------------------------------------------------------
+# Copy this file to cfg_files/<your_site>/<your_setup>.cfg, then edit values
+# to match your hardware.  Lines starting with '#' (and any text following a
+# '#' on a line) are stripped before JSON parsing by SmurfConfig.read_json.
+#
+# The authoritative schema lives in
+#   python/pysmurf/client/base/smurf_config.py  (SmurfConfig.validate_config)
+# Any key not listed in the schema is silently ignored
+# (`ignore_extra_keys=True`).
+#
+# Sections below:
+#   1. ACTIVE CONFIG    - keys validated and consumed by pysmurf today
+#   2. OPTIONAL BLOCKS  - hardware-variant configs (commented-out reference)
+#   3. DEPRECATED/LEGACY - keys retained for back-compat with older configs
+# =============================================================================
 {
-"epics_root" : "test_epics",
+
+# =============================================================================
+# === 1. ACTIVE CONFIG ========================================================
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# init - DSP initialisation per 500 MHz band
+# -----------------------------------------------------------------------------
+# Schema requires at least one `band_N` block (N in 0..7).  Bands 4-7 use the
+# same field set; copy a band_N block and change the per-band values.  If you
+# only populate bands 0-3, AMC bay 1 will not be initialised.
 "init": {
 
+	# 0 or 1.  Force-enables the DSP during pysmurf setup.  Optional;
+	# defaults to 1.  Usually controlled by defaults.yml instead.
 	"dspEnable": 1,
 
 	"band_0" : {
+		# 0 or 1.  Swap I/Q channels on input/output.  Default 0.
 		"iq_swap_in" : 0,
 		"iq_swap_out" : 0,
+
+		# Total round-trip delay compensation in microseconds, range [0, 30).
+		# Replaces refPhaseDelay/refPhaseDelayFine.  Measure with
+		# S.estimate_phase_delay(band).
 		"bandDelayUs" : 8.8,
-		"trigRstDly" : 15, # 0xF
-		"feedbackEnable": 1,
-		"feedbackGain" : 256,
-		"feedbackPolarity" : 1,
-		"feedbackLimitkHz": 225,
-		"lmsGain": 5,
-		"att_uc": 24,
-		"att_dc": 0,
-		"amplitude_scale": 12
+
+		# trigRstDly in 2.4 MHz ticks, range [0, 2^7).  Adjust so the
+		# flux-ramp counter resets at the flux-ramp glitch.  15 = 0xF.
+		"trigRstDly" : 15,
+
+		# Global tracking-feedback controls.
+		"feedbackEnable" : 1,        # 0 or 1
+		"feedbackPolarity" : 1,      # 0 or 1
+		"feedbackGain" : 256,        # int, range [0, 2^16)
+		"feedbackLimitkHz" : 225,    # float kHz, > 0
+
+		# LMS gain.  Powers of 2; integer in [0, 2^3).
+		"lmsGain" : 5,
+
+		# RF attenuators on the SMuRF carrier, in 0.5 dB steps.  Range [0, 2^5).
+		# UC = up-converter (DAC side), DC = down-converter (ADC side).
+		"att_uc" : 24,
+		"att_dc" : 0,
+
+		# Probe-tone amplitude.  Integer in [0, 2^4); 3 dB steps.
+		"amplitude_scale" : 12
+
+		# --- Optional per-band keys ----------------------------------------
+		# "data_out_mux" : [2, 3],   # list of two distinct ints in [0, 9].
+		#                            # Defaults: band 0/4=[2,3], 1/5=[0,1],
+		#                            # 2/6=[6,7], 3/7=[8,9].
+		# "lmsDelay" : 24            # int in [0, 2^6).  Defaults to
+		#                            # refPhaseDelay if not provided.
 	},
 
 	"band_1" : {
 		"iq_swap_in" : 0,
 		"iq_swap_out" : 0,
 		"bandDelayUs" : 8.8,
-		"trigRstDly" : 15, # 0xF
-		"feedbackEnable": 1,
-		"feedbackGain" : 256,
+		"trigRstDly" : 15,
+		"feedbackEnable" : 1,
 		"feedbackPolarity" : 1,
-		"feedbackLimitkHz": 225,
-		"lmsGain": 5,
-		"att_uc": 24,
-		"att_dc": 0,
-		"amplitude_scale": 12
+		"feedbackGain" : 256,
+		"feedbackLimitkHz" : 225,
+		"lmsGain" : 5,
+		"att_uc" : 24,
+		"att_dc" : 0,
+		"amplitude_scale" : 12
 	},
 
 	"band_2" : {
 		"iq_swap_in" : 0,
 		"iq_swap_out" : 0,
 		"bandDelayUs" : 8.8,
-		"trigRstDly" : 15, # 0xF
-		"feedbackEnable": 1,
-		"feedbackGain" : 256,
+		"trigRstDly" : 15,
+		"feedbackEnable" : 1,
 		"feedbackPolarity" : 1,
-		"feedbackLimitkHz": 225,
-		"lmsGain": 5,
-		"att_uc": 24,
-		"att_dc": 0,
-		"amplitude_scale": 12
+		"feedbackGain" : 256,
+		"feedbackLimitkHz" : 225,
+		"lmsGain" : 5,
+		"att_uc" : 24,
+		"att_dc" : 0,
+		"amplitude_scale" : 12
 	},
 
 	"band_3" : {
 		"iq_swap_in" : 0,
 		"iq_swap_out" : 0,
 		"bandDelayUs" : 8.8,
-		"trigRstDly" : 15, # 0xF
-		"feedbackEnable": 1,
-		"feedbackGain" : 256,
+		"trigRstDly" : 15,
+		"feedbackEnable" : 1,
 		"feedbackPolarity" : 1,
-		"feedbackLimitkHz": 225,
-		"lmsGain": 5,
-		"att_uc": 24,
-		"att_dc": 0,
-		"amplitude_scale": 12
+		"feedbackGain" : 256,
+		"feedbackLimitkHz" : 225,
+		"lmsGain" : 5,
+		"att_uc" : 24,
+		"att_dc" : 0,
+		"amplitude_scale" : 12
 	}
+
+	# --- Bays 1 high-band example (uncomment + fill if AMC bay 1 is fitted)
+	# "band_4" : { ... },
+	# "band_5" : { ... },
+	# "band_6" : { ... },
+	# "band_7" : { ... }
 },
 
-"bad_mask": {
-	"0": [5000, 5100],
-	"1": [5171.64, 5171.74]
+# -----------------------------------------------------------------------------
+# bad_mask - frequency intervals to ignore during relock
+# -----------------------------------------------------------------------------
+# Optional, defaults to {}.  Keys are arbitrary unique strings; values are
+# [f_low, f_high] in MHz with f_low < f_high and both in [4000, 8000].
+"bad_mask" : {
+	"0" : [5000.00, 5100.00],
+	"1" : [5171.64, 5171.74]
 },
 
-"amplifier": {
-	     "hemt_Vg" : 0.28,
-	     "bit_to_V_hemt" : 1.93e-06,
-	     "hemt_Id_offset" : 0.2643,
-	     "LNA_Vg" : -0.79,
-	     "50k_Id_offset" : 0.0,
-	     # 32 if using a C02 cryostat card.  Some C01s were
-	     # kludged to provide a 50k gate voltage for ASU 50K LNAs
-	     # in early testing.  For those, use 2.
-	     "dac_num_50k" : 30,
-	     "bit_to_V_50k" : 3.38e-06,
-	     "hemt_gate_min_voltage" : -1.0,
-	     "hemt_gate_max_voltage" :  1.0
+# -----------------------------------------------------------------------------
+# amplifier - 4K HEMT and 50K LNA bias / calibration
+# -----------------------------------------------------------------------------
+"amplifier" : {
+	"hemt_Vg"               : 0.28,    # 4K HEMT gate voltage [V]
+	"bit_to_V_hemt"         : 1.93e-6, # HEMT gate DAC scale [V/bit] (>0)
+	"hemt_Id_offset"        : 0.2643,  # HEMT drain-current offset [mA]
+	"LNA_Vg"                : -0.79,   # 50K LNA gate voltage [V]
+	"50k_Id_offset"         : 0.0,     # 50K drain-current offset [mA]
+
+	# RTM DAC wired to the 50K LNA gate.  Integer in [1, 32].  32 for
+	# C02 cryostat cards; 2 for early C01s kludged with an ASU 50K LNA
+	# gate path.
+	"dac_num_50k"           : 30,
+
+	"bit_to_V_50k"          : 3.38e-6, # 50K gate DAC scale [V/bit] (>0)
+
+	# Software clamps applied to set_hemt_gate_voltage [V].
+	"hemt_gate_min_voltage" : -1.0,
+	"hemt_gate_max_voltage" :  1.0
+
+	# --- Optional inline drain-current sense resistors [ohm] ------------
+	# Default values match the C02 cryostat card (R44 / R54).
+	# "hemt_Vd_series_resistor"     : 200.0,
+	# "50K_amp_Vd_series_resistor"  : 10.0,
+
+	# --- Optional cryocard-controlled amplifier blocks ------------------
+	# `hemt` / `50k` describe how the cryocard PIC enables each amplifier
+	# rail.  Defaults match the C02 cryostat card.  Override only if your
+	# cryocard wiring differs.
+	# "hemt" : {
+	#     "gate_dac_num"      : 31,    # required if block is present
+	#     "drain_pic_address" : 3,
+	#     "drain_opamp_gain"  : 1,
+	#     "power_bitmask"     : 1
+	# },
+	# "50k" : {
+	#     "gate_dac_num"      : 30,
+	#     "drain_pic_address" : 4,
+	#     "drain_opamp_gain"  : 1,
+	#     "power_bitmask"     : 2
+	# },
+
+	# --- Optional dual-amplifier crates (hemt1/hemt2/50k1/50k2) ---------
+	# Used on systems with two 4K HEMTs and two 50K LNAs per cryocard.
+	# All 14 fields below are required if the block is present (see
+	# defaults in smurf_config.py:523-663).  Voltages [V], resistors
+	# [ohm], `gate_bit_to_volt` [V/bit].
+	# "hemt1" : {
+	#     "drain_dac_num"       : 31,
+	#     "drain_pic_address"   : 3,
+	#     "drain_opamp_gain"    : 3.874,
+	#     "drain_resistor"      : 50.0,
+	#     "drain_conversion_m"  : -0.259491,
+	#     "drain_conversion_b"  : 1.74185,
+	#     "drain_offset"        : 0,
+	#     "drain_volt_default"  : 0.5,
+	#     "drain_volt_min"      : 0,
+	#     "drain_volt_max"      : 2,
+	#     "gate_bit_to_volt"    : 3.86936e-6,
+	#     "gate_volt_default"   : 0.265,
+	#     "gate_volt_min"       : 0,
+	#     "gate_volt_max"       : 2.03,
+	#     "power_bitmask"       : 1
+	# },
+	# "hemt2" : { ... gate_dac_num=27, drain_dac_num=29, drain_pic_address=10,
+	#                 power_bitmask=4, otherwise as hemt1 ... },
+	# "50k1"  : { ... drain_dac_num=32, drain_pic_address=4, gate_dac_num=30,
+	#                 drain_resistor=12.0, drain_volt_default=5.0,
+	#                 drain_volt_min=3.5, drain_volt_max=5.5,
+	#                 drain_opamp_gain=9.929,
+	#                 drain_conversion_m=-0.224968, drain_conversion_b=5.59815,
+	#                 power_bitmask=2, otherwise as hemt1 ... },
+	# "50k2"  : { ... drain_dac_num=28, drain_pic_address=11, gate_dac_num=26,
+	#                 power_bitmask=8, otherwise as 50k1 ... }
 },
 
+# -----------------------------------------------------------------------------
+# attenuator - mapping from the four UC/DC RF attenuators to bands 0-3
+# -----------------------------------------------------------------------------
+# Each value is the band index served by that attenuator; integer in [0, 4).
+# The same mapping applies to bays 0 (bands 0-3) and 1 (bands 4-7).
 "attenuator" : {
 	"att1" : 0,
 	"att2" : 1,
@@ -92,204 +223,235 @@
 	"att4" : 3
 },
 
+# -----------------------------------------------------------------------------
+# chip_to_freq - mux-chip number to [f_min_GHz, f_max_GHz] mapping
+# -----------------------------------------------------------------------------
+# Keys are stringified chip numbers; values are [low_GHz, high_GHz] for the
+# RF coverage of that chip.  Used by tune helpers to map resonators to chips.
 "chip_to_freq" : {
-	"9" :  [4.94150, 5.05],
-	"10" : [5.05, 5.17550 ],
-	"11" : [5.20150, 5.28250 ],
-	"12" : [5.28250, 5.41050 ],
-	"13" : [5.42050, 5.54550 ],
-	"14" : [5.55150, 5.67650 ],
-	"15" : [5.66650, 5.79150 ],
-	"16" : [5.79050, 5.91550 ]
+	"9"  : [4.94150, 5.05000],
+	"10" : [5.05000, 5.17550],
+	"11" : [5.20150, 5.28250],
+	"12" : [5.28250, 5.41050],
+	"13" : [5.42050, 5.54550],
+	"14" : [5.55150, 5.67650],
+	"15" : [5.66650, 5.79150],
+	"16" : [5.79050, 5.91550]
 },
 
-# Set for C02 cryostat card.  See
-#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
-"pic_to_bias_group": {
-        "0" : 0,
-        "1" : 1,
-        "2" : 2,
-        "3" : 3,
-        "4" : 4,
-        "5" : 5,
-        "6" : 6,
-        "7" : 7,
-        "8" : 8,
-        "9" : 9,
-        "10" : 10,
-        "11" : 11,
-        "12" : 12,
-        "13" : 13,
-        "14" : 14,
-        "15" : 15
+# -----------------------------------------------------------------------------
+# pic_to_bias_group / bias_group_to_pair - cryostat-card TES bias topology
+# -----------------------------------------------------------------------------
+# Set for C02 cryostat cards; see
+#   https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+# pic_to_bias_group keys are stringified PIC channel numbers; values are TES
+# bias-group indices.
+"pic_to_bias_group" : {
+	"0"  : 0,  "1"  : 1,  "2"  : 2,  "3"  : 3,
+	"4"  : 4,  "5"  : 5,  "6"  : 6,  "7"  : 7,
+	"8"  : 8,  "9"  : 9,  "10" : 10, "11" : 11,
+	"12" : 12, "13" : 13, "14" : 14, "15" : 15
 },
 
-# Set for C02 cryostat card.  See
-#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+# bias_group_to_pair: TES bias-group index -> bipolar RTM DAC pair [pos, neg].
+# No DAC may appear in more than one pair, and the dac_num_50k DAC may not
+# appear in any pair (validated by smurf_config.py:828-852).
 "bias_group_to_pair" : {
-        "0" : [1,2],
-        "1" : [3,4],
-        "2" : [5,6],
-        "3" : [7,8],
-        "4" : [9,10],
-        "5" : [11,12],
-        "6" : [13,14],
-        "7" : [15,16],
-        "8" : [17,18],
-        "9" : [19,20],
-        "10" : [21,22],
-        "11" : [23,24]
+	"0"  : [1, 2],   "1"  : [3, 4],   "2"  : [5, 6],   "3"  : [7, 8],
+	"4"  : [9, 10],  "5"  : [11, 12], "6"  : [13, 14], "7"  : [15, 16],
+	"8"  : [17, 18], "9"  : [19, 20], "10" : [21, 22], "11" : [23, 24]
 },
 
+# -----------------------------------------------------------------------------
+# TES electrical parameters
+# -----------------------------------------------------------------------------
+# All required and >0.  R_sh: TES shunt resistance [ohm].
 "R_sh" : 390e-6,
+
+# Round-trip TES bias-line resistance in low-current mode [ohm], including
+# cryostat-card and cable resistance.
 "bias_line_resistance" : 15800,
+
+# Low-current / high-current mode current ratio (>= 1).
 "high_low_current_ratio" : 6.08,
 
-"high_current_mode_bool": 0,
+# 0 or 1 (optional, default 0).  If 1, TES biasing is *always* high-current.
+"high_current_mode_bool" : 0,
 
-"all_bias_groups": [7],
+# List of TES bias-group indices in use.  Each int in [0, 16).
+"all_bias_groups" : [7],
 
+# -----------------------------------------------------------------------------
+# tune_band - resonator tuning + tracking parameters
+# -----------------------------------------------------------------------------
+# fraction_full_scale: flux-ramp DAC swing as a fraction of full scale, (0, 1].
+# reset_rate_khz: flux-ramp reset rate [kHz], in [0, 100].
+# All `*_freq`, `*_frac`, `gradient_descent_*`, `eta_scan_*` keys are dicts
+# keyed by stringified band index; one entry required for each band declared
+# in `init` above.
 "tune_band" : {
-	"n_samples" : 262144,
-	"grad_cut" : 0.05,
-	"amp_cut" : 0.25,
-	"freq_max" : 250000000,
-	"freq_min" : -250000000,
-	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
-	# modified for high current) RTM
-	"fraction_full_scale": 0.489,
-	"reset_rate_khz": 4.0,
-	"delta_freq": {
-		    "0" : 0.02,
-		    "1" : 0.02,
-		    "2" : 0.02,
-		    "3" : 0.02
-        },
-	"lms_freq": {
-		    "0" : 16500,
-		    "1" : 19945,
-		    "2" : 19986,
-		    "3" : 20218
-        },
-	# The fraction of each flux ramp cycle above which we start
-	# applying feedback, within each cycle.  Must be >0.  If >1,
-	# then You want this to be large enough to mask the transient
-	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"n_samples"            : 262144,
+	"grad_cut"             : 0.05,
+	"amp_cut"              : 0.25,
+	"freq_max"             :  250000000,
+	"freq_min"             : -250000000,
+
+	# For Stanford 5-6 GHz 528 box in FP29 with a standard (not high-current
+	# modified) RTM.
+	"fraction_full_scale" : 0.489,
+	"reset_rate_khz"      : 4.0,
+
+	# Per-band tracking sideband frequency [Hz], > 0.
+	"lms_freq" : {
+		"0" : 16500, "1" : 19945, "2" : 19986, "3" : 20218
+	},
+
+	# Per-band frequency span around each resonator probed during tracking
+	# [MHz], > 0.
+	"delta_freq" : {
+		"0" : 0.02, "1" : 0.02, "2" : 0.02, "3" : 0.02
+	},
+
+	# Per-band fraction of each flux-ramp cycle at which feedback turns on
+	# / off.  Both in [0, 1].  The on-fraction must be large enough to
+	# mask the post-reset transient; the off-fraction near 1 keeps
+	# feedback applied for most of the cycle.
 	"feedback_start_frac" : {
-		    "0" : 0.05,
-		    "1" : 0.05,
-		    "2" : 0.05,
-		    "3" : 0.05
+		"0" : 0.05, "1" : 0.05, "2" : 0.05, "3" : 0.05
 	},
-	# The fraction of each flux ramp cycle above which we stop
-	# applying feedback, within each cycle.  Must be >0.  If >1,
-	# then feedback over the entire cycle (after feedbackStart).
 	"feedback_end_frac" : {
-		    "0" : 0.98,
-		    "1" : 0.98,
-		    "2" : 0.98,
-		    "3" : 0.98
+		"0" : 0.98, "1" : 0.98, "2" : 0.98, "3" : 0.98
 	},
-	"gradient_descent_gain": {
-		    "0" : 1e-4,
-		    "1" : 1e-4,
-		    "2" : 1e-4,
-		    "3" : 1e-4
-        },
-	"gradient_descent_averages": {
-		    "0" : 1,
-		    "1" : 1,
-		    "2" : 1,
-		    "3" : 1
-        },
-	"gradient_descent_converge_hz":{
-		    "0" : 500,
-		    "1" : 500,
-		    "2" : 500,
-		    "3" : 500
+
+	# Per-band gradient-descent eta-finder controls.
+	"gradient_descent_gain" : {           # float > 0
+		"0" : 1e-4, "1" : 1e-4, "2" : 1e-4, "3" : 1e-4
 	},
-	"gradient_descent_step_hz":{
-		    "0" : 1000,
-		    "1" : 1000,
-		    "2" : 1000,
-		    "3" : 1000
+	"gradient_descent_averages" : {       # int > 0
+		"0" : 1, "1" : 1, "2" : 1, "3" : 1
 	},
-	"gradient_descent_momentum":{
-		    "0" : 1,
-		    "1" : 1,
-		    "2" : 1,
-		    "3" : 1
+	"gradient_descent_converge_hz" : {    # float Hz, > 0
+		"0" : 500, "1" : 500, "2" : 500, "3" : 500
 	},
-	"gradient_descent_beta": {
-		    "0" : 0,
-		    "1" : 0,
-		    "2" : 0,
-		    "3" : 0
+	"gradient_descent_step_hz" : {        # float Hz, > 0
+		"0" : 1000, "1" : 1000, "2" : 1000, "3" : 1000
 	},
-	"eta_scan_del_f": {
-		    "0": 5000,
-		    "1": 5000,
-		    "2": 5000,
-		    "3": 5000
+	"gradient_descent_momentum" : {       # int >= 0
+		"0" : 1, "1" : 1, "2" : 1, "3" : 1
 	},
-	"eta_scan_amplitude":{
-		    "0" : 12,
-		    "1" : 12,
-		    "2" : 12,
-		    "3" : 12
+	"gradient_descent_beta" : {           # float in [0, 1]
+		"0" : 0, "1" : 0, "2" : 0, "3" : 0
 	},
-	"eta_scan_averages": {
-		    "0" : 1,
-		    "1" : 1,
-		    "2" : 1,
-		    "3" : 1
-        }
-	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+
+	# Per-band eta-scan parameters.
+	"eta_scan_del_f" : {                  # int Hz, > 0
+		"0" : 5000, "1" : 5000, "2" : 5000, "3" : 5000
+	},
+	"eta_scan_amplitude" : {              # int probe amplitude
+		"0" : 12, "1" : 12, "2" : 12, "3" : 12
+	},
+	"eta_scan_averages" : {               # int > 0
+		"0" : 1, "1" : 1, "2" : 1, "3" : 1
+	}
+
+	# --- Optional --------------------------------------------------------
+	# "default_tune" : "/data/smurf_data/tune/1558666435_tune.npy"
+	#   Path to a saved tuning file, loaded on construction if set.
 },
 
+# -----------------------------------------------------------------------------
+# flux_ramp - flux-ramp counter configuration
+# -----------------------------------------------------------------------------
+# 20 for C0 RTMs, 32 for C1 RTMs.
 "flux_ramp" : {
-	"select_ramp" : 1,
 	"num_flux_ramp_counter_bits" : 32
 },
 
+# -----------------------------------------------------------------------------
+# constant - calibration constants
+# -----------------------------------------------------------------------------
+# Optional.  pA_per_phi0: TES current per Phi_0 of demodulated SQUID phase
+# [pA / Phi_0].  Depends on the installed mux-chip generation.
 "constant" : {
 	"pA_per_phi0" : 9e6
 },
 
+# -----------------------------------------------------------------------------
+# timing - which timing source the carrier locks to
+# -----------------------------------------------------------------------------
+# timing_reference must be one of:
+#   "ext_ref"  - internal oscillator locked to the front-panel reference
+#                (LmkReg_0x0147 : 0x1A); flux_ramp_start_mode = 0.
+#   "backplane"- timing taken from a timing master via the ATCA backplane;
+#                flux_ramp_start_mode = 1.
+#   "fiber"    - timing taken from a timing-system fiber input.
 "timing" : {
-	# "ext_ref" : internal oscillator locked to an external
-	#   front-panel reference, or unlocked if there is no front
-	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
-	#   flux_ramp_start_mode=0
-	# "backplane" : takes timing from timing master through
-	#   backplane.  Also sets flux_ramp_start_mode=1.
 	"timing_reference" : "ext_ref"
 },
 
+# -----------------------------------------------------------------------------
+# fs - SMuRF data sampling frequency [Hz], > 0
+# -----------------------------------------------------------------------------
+# In production the system reports its actual sample rate; this value is
+# used for offline calculations and as a fallback.
 "fs" : 200.0,
 
-# This section is for smurf_to_mce, the transmission from SMuRF to the
-# Keck GCP. This is mostly depracated.
-"smurf_to_mce" : {
-	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
-	"mask_file" : "/data/smurf2mce_config/mask.txt",
-	"receiver_ip" : "tcp://192.168.3.1:3334",
-	"port_number" : "3334",
-	"filter_freq" : 63,
-	"filter_order" : 4,
-	"filter_gain" : 1.0,
-	"file_name_extend" : 1,
-	"data_frames" : 300000,
-	"static_mask" : 0,
-	"num_averages" : 20,
-	# Kludge to account for offset in gcp channel number in early
-	# versios of the DSPv3 fw.  May be different for each band, in
-	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
-	# in fw, so this should be unnecessary soon.
-	"mask_channel_offset" : 0
-},
+# -----------------------------------------------------------------------------
+# Output directories - all must exist with write permission for the user
+# -----------------------------------------------------------------------------
+# Every directory key below is optional with the listed default.
+"default_data_dir" : "/data/smurf_data",                  # raw/output data
+"smurf_cmd_dir"    : "/data/smurf_data/smurf_cmd",        # remote-command files
+"tune_dir"         : "/data/smurf_data/tune",             # saved tunings
+"status_dir"       : "/data/smurf_data/status"            # run-status files
 
-"default_data_dir": "/data/smurf_data",
-"tune_dir" : "/data/smurf_data/tune",
-"status_dir" : "/data/smurf_data/status"
+# --- Optional thermal protection ---------------------------------------------
+# Ultrascale FPGA over-temperature protection threshold [degC], in [0, 99].
+# Optional; if absent or null, pysmurf does not engage OT protection.  Some
+# crates have been observed to drop the carrier mid-enable sequence; newer
+# firmware enables OT protection in firmware instead.
+# , "ultrascale_temperature_limit_degC" : 80.0
+
+# =============================================================================
+# === 2. OPTIONAL BLOCKS (intentionally empty - see commented examples above)
+# =============================================================================
+# Optional schema-recognised keys are shown as commented-out reference inside
+# the section they belong to, rather than collected here, to keep each option
+# next to its semantic neighbours.
+
+# =============================================================================
+# === 3. DEPRECATED / LEGACY ==================================================
+# =============================================================================
+# Do not use these keys for new configurations.  They are documented here
+# because older site configs (cfg_files/{slac,stanford,...}/*.cfg) still set
+# them and pysmurf still parses them.
+
+# --- DEPRECATED: use bandDelayUs instead ------------------------------------
+# Legacy per-band delay registers, retained for back-compat.  refPhaseDelay
+# is in 2.4 MHz ticks, range [0, 2^5).  refPhaseDelayFine is in 307.2 MHz
+# ticks, range [0, 2^8) and adds time lag (so it subtracts from the total
+# compensated delay).  See smurf_config.py:425-428.  To migrate, measure
+# bandDelayUs with S.estimate_phase_delay(band) and remove these.
+# Example (would live inside an init.band_N block):
+# "init" : { "band_0" : { ..., "refPhaseDelay" : 6, "refPhaseDelayFine" : 0 } }
+
+# --- DEPRECATED: superseded by the `processor` block (see PR #444) ----------
+# smurf_to_mce drove the SMuRF -> Keck GCP transmit path.  Mostly retired;
+# python/pysmurf/client/util/smurf_util.py still reads a couple of fields
+# (e.g. smurf_to_mce_mask_file) for legacy pipelines.  The schema does not
+# validate this block (`ignore_extra_keys=True`).
+# "smurf_to_mce" : {
+#     "smurf_to_mce_file"    : "/data/smurf2mce_config/smurf2mce.cfg",
+#     "mask_file"            : "/data/smurf2mce_config/mask.txt",
+#     "receiver_ip"          : "tcp://192.168.3.1:3334",
+#     "port_number"          : "3334",
+#     "filter_freq"          : 63,
+#     "filter_order"         : 4,
+#     "filter_gain"          : 1.0,
+#     "file_name_extend"     : 1,
+#     "data_frames"          : 300000,
+#     "static_mask"          : 0,
+#     "num_averages"         : 20,
+#     "mask_channel_offset"  : 0
+# }
 }


### PR DESCRIPTION
## Summary

Closes #365.

Reworks `cfg_files/template/template.cfg` and `README.config_file.md` so the template is the authoritative reference for every key the schema in `python/pysmurf/client/base/smurf_config.py` validates — units, ranges, defaults, and intent — as the issue originally requested.

## Changes

### `cfg_files/template/template.cfg`

Reorganised into three labelled sections:

1. **ACTIVE CONFIG** — every required key plus inline comments giving type, range, units, defaults.
2. **OPTIONAL BLOCKS** — schema-recognised optional keys shown as commented-out reference next to the section they belong to (so each example sits beside its semantic neighbours rather than collected at the bottom).
3. **DEPRECATED / LEGACY** — `refPhaseDelay` / `refPhaseDelayFine` and `smurf_to_mce` retained with `DEPRECATED:` headers and migration guidance, so users reading older site configs (e.g. `cfg_files/{slac,stanford,...}/*.cfg`) still find them documented.

Adds previously undocumented schema-recognised keys:

- `init.band_N.data_out_mux`, `init.band_N.lmsDelay`
- top-level `smurf_cmd_dir`, `ultrascale_temperature_limit_degC`
- `amplifier.hemt_Vd_series_resistor`, `amplifier.50K_amp_Vd_series_resistor`
- the optional amplifier sub-blocks `hemt`, `50k`, `hemt1`, `hemt2`, `50k1`, `50k2` (with all 14 required fields each, commented out so they only apply on the relevant hardware variants)

Documents the third valid `timing_reference` option (`"fiber"`).

Removes orphan keys that the active client never reads:

- `epics_root` — only referenced in `scratch/cyu/cryochannel.py`.
- `flux_ramp.select_ramp` — `set_select_ramp` is hard-coded to `0x1` in `python/pysmurf/client/base/smurf_control.py:646`; the config value is never consumed.

### `README.config_file.md`

Expanded from a 75-line starter overview to a full parameter reference. One subsection per top-level config block (`init`, `amplifier`, `attenuator`, `bad_mask`, bias-group topology, `tune_band`, `flux_ramp`, `constant`, `timing`, `fs`, output dirs, thermal). Each row lists `key — type, range/units, default, description`. New "Deprecated Keys" subsection covers the migration path for older site configs.

## Verification

- `SmurfConfig.read_json('cfg_files/template/template.cfg')` parses the file (comment-strip path).
- `SmurfConfig.validate_config(...)` passes (with `os.path.isdir` / `os.access` patched out, since the directory checks require `/data/smurf_data` on the host).
- Cross-checked every schema-named key against the template text — all are mentioned (active or commented-out).
- CI scope: `flake8` runs only on `python/`, so this change set is out of scope; the Sphinx doc build does not import `README.config_file.md`.

## Test plan

- [ ] `python -c "from pysmurf.client.base.smurf_config import SmurfConfig; SmurfConfig('cfg_files/template/template.cfg')"` on a system that has `/data/smurf_data` provisioned.
- [ ] Confirm an existing site config still loads after pulling this branch (no schema regressions).