### PR TITLE
feat(offline): Read register values from rogue state dump (#364)

### DIFF
--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -48,6 +48,12 @@ class SmurfBase:
     offline : bool, optional, default False
         Whether to run in offline mode (no rogue) or not. This
         will break many things. Default is False.
+    state_file : str or None, optional, default None
+        Path to a rogue ``SaveState`` YAML dump (``.yml`` or
+        ``.yml.gz``) to back ``_caget`` calls in offline mode.  Only
+        consulted when ``offline`` is True.  When loaded, recorded
+        register values take precedence over the per-method offline
+        hard-coded fallbacks; missing keys yield ``None``.
     pub_root : str or None, optional, default None
         Root of environment vars to set publisher options. If
         None, the default root will be `SMURFPUB_`.
@@ -77,7 +83,8 @@ class SmurfBase:
     """
 
     def __init__(self, log=None, server_addr="localhost", server_port=9000, atca_port=9100,
-                 atca_monitor=False, offline=False, pub_root=None, script_id=None, **kwargs):
+                 atca_monitor=False, offline=False, state_file=None, pub_root=None,
+                 script_id=None, **kwargs):
         """
         """
 
@@ -124,6 +131,15 @@ class SmurfBase:
         self.offline = offline
         if self.offline is True:
             self.log('Offline mode')
+
+        # Optional rogue SaveState YAML dump used to back _caget calls
+        # in offline mode.  Populated either here from the state_file
+        # constructor argument, or later via SmurfCommandMixin.load_state().
+        self._offline_state = None
+        if offline and state_file is not None:
+            from pysmurf.client.util import tools
+            self._offline_state = tools.load_state_yaml(state_file)
+            self.log(f'Offline state loaded from {state_file}')
 
         # Setting paths for easier commands - Is there a better way to
         # do this than just hardcoding paths? This needs to be cleaned

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -64,6 +64,10 @@ class SmurfControl(SmurfCommandMixin,
        Whether to run the setup step.
     offline : bool, optional, default False
        Whether or not to instantiate in offline mode.
+    state_file : str, optional, default None
+       Path to a rogue ``SaveState`` YAML dump (``.yml`` or ``.yml.gz``)
+       to back ``_caget`` calls in offline mode.  Only consulted when
+       ``offline`` is True.  See :class:`SmurfBase` for details.
     smurf_cmd_mode : bool, optional, default False
        This mode tells the system that the input is coming in from the
        command line (rather than a python session).  Everything
@@ -91,7 +95,7 @@ class SmurfControl(SmurfCommandMixin,
     """
 
     def __init__(self, cfg_file=None, data_dir=None, name=None, make_logfile=True,
-                 setup=False, offline=False, smurf_cmd_mode=False,
+                 setup=False, offline=False, state_file=None, smurf_cmd_mode=False,
                  shelf_manager='shm-smrf-sp01', no_dir=False, validate_config=True,
                  data_path_id=None, **kwargs):
         """Constructor for the SmurfControl class.
@@ -124,7 +128,7 @@ class SmurfControl(SmurfCommandMixin,
         # Save shelf manager - Should this be in the config?
         self.shelf_manager = shelf_manager
 
-        super().__init__(offline=offline, **kwargs)
+        super().__init__(offline=offline, state_file=state_file, **kwargs)
 
         if cfg_file is not None or data_dir is not None:
             self.initialize(data_dir=data_dir,

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -173,6 +173,12 @@ class SmurfCommandMixin(SmurfBase):
             return ret
 
         if not execute or self.offline:
+            if self.offline and self._offline_state is not None:
+                val = tools.state_lookup(self._offline_state, pvname)
+                if val is not None:
+                    if write_log:
+                        self.log(f'OFFLINE state-dump caget {pvname} = {val}', log_level)
+                    return val
             self.log(f"Not executing caget for {pvname} (execute={execute}, offline={self.offline})", log_level)
             # don't perform the read
             return None
@@ -508,7 +514,7 @@ class SmurfCommandMixin(SmurfBase):
         int
             The number of subbands in the band.
         """
-        if self.offline:
+        if self.offline and self._offline_state is None:
             return 128
 
         if band is None:
@@ -540,7 +546,7 @@ class SmurfCommandMixin(SmurfBase):
         int
             The number of channels in the band.
         """
-        if self.offline:
+        if self.offline and self._offline_state is None:
             return 512  # Hard coded offline mode 512
 
         if band is None:
@@ -934,6 +940,24 @@ class SmurfCommandMixin(SmurfBase):
 
     # alias older rogue 3 write_state function to save_state
     write_state = save_state
+
+    def load_state(self, filename):
+        """Load a rogue ``SaveState`` YAML dump for offline reads.
+
+        Replaces any previously loaded dump.  Only effective when
+        ``self.offline`` is True; the loaded state backs subsequent
+        ``_caget`` calls so they return recorded register values
+        instead of ``None`` or per-method hard-coded fallbacks.
+
+        Args
+        ----
+        filename : str
+            Path to the YAML file produced by :func:`save_state` or
+            equivalently by rogue's ``AMCc.SaveState`` command.  Both
+            ``.yml`` and ``.yml.gz`` are accepted.
+        """
+        self._offline_state = tools.load_state_yaml(filename)
+        self.log(f'Offline state loaded from {filename}')
 
     # name changed in Rogue 4 from WriteConfig to SaveConfig.  Keeping
     # the write_config function for backwards compatibilty.
@@ -2463,7 +2487,7 @@ class SmurfCommandMixin(SmurfBase):
         """
         Returns the center frequency of the band in MHz
         """
-        if self.offline:
+        if self.offline and self._offline_state is None:
             bc = (4250 + band*500)
             return bc
         else:
@@ -2499,7 +2523,7 @@ class SmurfCommandMixin(SmurfBase):
             # list of bands specified in experiment.cfg.
             band = self._bands[0]
 
-        if self.offline:
+        if self.offline and self._offline_state is None:
             return 2.4
         else:
             return self._caget(
@@ -2526,7 +2550,7 @@ class SmurfCommandMixin(SmurfBase):
         float
             The digitizer frequency for this band in MHz.
         """
-        if self.offline:
+        if self.offline and self._offline_state is None:
             return 614.4
 
         if band is None:
@@ -4873,7 +4897,7 @@ class SmurfCommandMixin(SmurfBase):
         set_flux_ramp_freq : Sets the flux ramp reset rate.
         get_ramp_max_cnt : Gets the flux ramp trigger repetition rate.
         """
-        if self.offline: # FIX ME - this is a stupid hard code
+        if self.offline and self._offline_state is None: # FIX ME - this is a stupid hard code
             return 4.0
         else:
             # the digitizer frequency is 2x the default fw rate
@@ -6348,7 +6372,7 @@ class SmurfCommandMixin(SmurfBase):
         coef : list
             The filter A coefficients.
         """
-        if self.offline:  # FIX ME - STUPPID HARDCODE
+        if self.offline and self._offline_state is None:  # FIX ME - STUPPID HARDCODE
             return np.array(
                 [ 1., -3.74145562,  5.25726624,
                   -3.28776591, 0.77203984])
@@ -6382,7 +6406,7 @@ class SmurfCommandMixin(SmurfBase):
         coef : list
             The filter B coefficients.
         """
-        if self.offline:
+        if self.offline and self._offline_state is None:
             return np.array(
                 [5.28396689e-06, 2.11358676e-05, 3.17038014e-05,
                  2.11358676e-05, 5.28396689e-06])
@@ -6536,7 +6560,7 @@ class SmurfCommandMixin(SmurfBase):
         int
             The down-sampling factor.
         """
-        if self.offline:
+        if self.offline and self._offline_state is None:
             self.log("get_downsample_factor: offline is True, SmurfProcessor.cpp is not running..")
             return 20
 

--- a/python/pysmurf/client/test/test_offline_state.py
+++ b/python/pysmurf/client/test/test_offline_state.py
@@ -1,0 +1,185 @@
+"""Offline-mode state-dump tests for issue #364.
+
+These tests do not require a live rogue server, hardware, or a pysmurf
+configuration file.  They exercise the path:
+
+    SmurfBase(offline=True, state_file=...) -> _caget() -> tools.state_lookup
+
+and verify that the per-method hard-coded offline returns yield to the
+loaded state dump where one is provided.
+"""
+import gzip
+import os
+import tempfile
+
+import numpy as np
+import pytest
+import yaml
+
+from pysmurf.client.command.smurf_command import SmurfCommandMixin
+from pysmurf.client.util import tools
+
+
+def _state_dump(values):
+    """Build a nested dict mirroring the rogue tree under
+    ``AMCc.FpgaTopLevel.AppTop.AppCore.SysgenCryo.Base[band]``.
+
+    ``values`` is ``{band_index: {register_name: value}}``.
+    """
+    base = {}
+    for band, regs in values.items():
+        base[f'Base[{band}]'] = dict(regs)
+    return {
+        'AMCc': {
+            'FpgaTopLevel': {
+                'AppTop': {
+                    'AppCore': {
+                        'SysgenCryo': base,
+                    },
+                },
+            },
+        },
+    }
+
+
+def _write_yaml(state, suffix='.yml'):
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    os.close(fd)
+    if suffix.endswith('.gz'):
+        with gzip.open(path, 'wt') as f:
+            yaml.safe_dump(state, f)
+    else:
+        with open(path, 'w') as f:
+            yaml.safe_dump(state, f)
+    return path
+
+
+def _silent_log(*_, **__):
+    pass
+
+
+def _make_offline(state_file=None):
+    """Construct a bare offline SmurfCommandMixin without needing a cfg."""
+    S = SmurfCommandMixin(offline=True, state_file=state_file,
+                          log=_silent_log)
+    # _bands is normally populated by SmurfConfigPropertiesMixin; for the
+    # band-aware getters we only need a populated default.
+    S._bands = [0, 1, 2, 3]
+    return S
+
+
+# -- tools helpers ---------------------------------------------------------
+
+def test_state_lookup_walks_dotted_path():
+    state = _state_dump({0: {'numberChannels': 528}})
+    val = tools.state_lookup(
+        state,
+        'AMCc.FpgaTopLevel.AppTop.AppCore.SysgenCryo.Base[0].numberChannels')
+    assert val == 528
+
+
+def test_state_lookup_missing_returns_default():
+    state = _state_dump({0: {'numberChannels': 528}})
+    assert tools.state_lookup(state, 'AMCc.NotPresent') is None
+    assert tools.state_lookup(state, 'AMCc.NotPresent', default='x') == 'x'
+    assert tools.state_lookup(None, 'AMCc.Anything') is None
+
+
+def test_load_state_yaml_handles_gzip(tmp_path):
+    state = _state_dump({0: {'numberChannels': 528}})
+    plain = _write_yaml(state, suffix='.yml')
+    gz = _write_yaml(state, suffix='.yml.gz')
+    try:
+        assert tools.load_state_yaml(plain) == state
+        assert tools.load_state_yaml(gz) == state
+    finally:
+        os.unlink(plain)
+        os.unlink(gz)
+
+
+# -- offline _caget -------------------------------------------------------
+
+def test_caget_returns_none_when_no_state_dump_loaded():
+    S = _make_offline()
+    assert S._offline_state is None
+    assert S._caget('AMCc.SomeRegister') is None
+
+
+def test_caget_reads_from_state_dump_when_loaded():
+    state = _state_dump({0: {'digitizerFrequencyMHz': 614.4}})
+    path = _write_yaml(state, suffix='.yml.gz')
+    try:
+        S = _make_offline(state_file=path)
+        assert S._offline_state is not None
+        val = S._caget(
+            'AMCc.FpgaTopLevel.AppTop.AppCore.SysgenCryo.Base[0]'
+            '.digitizerFrequencyMHz')
+        assert val == 614.4
+    finally:
+        os.unlink(path)
+
+
+def test_load_state_swaps_dump_at_runtime():
+    first = _write_yaml(_state_dump({0: {'numberChannels': 100}}))
+    second = _write_yaml(_state_dump({0: {'numberChannels': 200}}))
+    try:
+        S = _make_offline(state_file=first)
+        assert S.get_number_channels(0) == 100
+        S.load_state(second)
+        assert S.get_number_channels(0) == 200
+    finally:
+        os.unlink(first)
+        os.unlink(second)
+
+
+# -- per-method hardcoded offline returns yield to the dump --------------
+
+def test_hardcodes_used_when_no_dump():
+    S = _make_offline()
+    assert S.get_number_sub_bands(0) == 128
+    assert S.get_number_channels(0) == 512
+    assert S.get_band_center_mhz(2) == 4250 + 2 * 500
+    assert S.get_channel_frequency_mhz(0) == 2.4
+    assert S.get_digitizer_frequency_mhz(0) == 614.4
+    assert S.get_flux_ramp_freq() == 4.0
+    assert S.get_downsample_factor() == 20
+    np.testing.assert_array_equal(
+        S.get_filter_a(),
+        np.array([1., -3.74145562, 5.25726624, -3.28776591, 0.77203984]))
+
+
+def test_dump_overrides_hardcodes():
+    state = _state_dump({0: {
+        'numberSubBands': 64,
+        'numberChannels': 528,
+        'bandCenterMHz': 4321.0,
+        'channelFrequencyMHz': 1.2,
+        'digitizerFrequencyMHz': 700.0,
+    }})
+    path = _write_yaml(state)
+    try:
+        S = _make_offline(state_file=path)
+        assert S.get_number_sub_bands(0) == 64
+        assert S.get_number_channels(0) == 528
+        assert S.get_band_center_mhz(0) == 4321.0
+        assert S.get_channel_frequency_mhz(0) == 1.2
+        assert S.get_digitizer_frequency_mhz(0) == 700.0
+    finally:
+        os.unlink(path)
+
+
+def test_dump_missing_key_returns_none_without_falling_back_to_hardcode():
+    # Document the documented tradeoff: a loaded dump that lacks a key
+    # yields None rather than the legacy hardcode.  Callers opted in.
+    state = _state_dump({0: {'numberChannels': 528}})
+    path = _write_yaml(state)
+    try:
+        S = _make_offline(state_file=path)
+        assert S.get_number_channels(0) == 528
+        assert S.get_digitizer_frequency_mhz(0) is None
+    finally:
+        os.unlink(path)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/python/pysmurf/client/util/tools.py
+++ b/python/pysmurf/client/util/tools.py
@@ -217,6 +217,84 @@ def yaml_parse(yml, cmd):
     return get_val(yml, cmd)
 
 
+def load_state_yaml(filename):
+    """Load a rogue ``SaveState`` YAML dump into a nested dict.
+
+    Transparently handles both plain ``.yml`` files and gzip-compressed
+    ``.yml.gz`` files (rogue's default ``saveYaml`` output uses
+    ``autoCompress=True``).
+
+    Args
+    ----
+    filename : str
+        Path to the YAML file produced by ``S.save_state(...)`` or
+        equivalently by rogue's ``AMCc.SaveState`` command.
+
+    Returns
+    -------
+    dict
+        Nested dict mirroring the rogue tree.
+    """
+    import gzip
+    import yaml
+
+    opener = gzip.open if filename.endswith('.gz') else open
+    with opener(filename, 'rt') as f:
+        return yaml.safe_load(f)
+
+
+def state_lookup(state, pvname, default=None):
+    """Walk a dot-separated rogue PV path through a nested state dict.
+
+    Indexed segments such as ``Base[0]`` are matched first against a
+    literal ``Base[0]`` dict key (rogue's typical ``saveYaml`` form),
+    and otherwise fall back to descending into a ``Base`` dict followed
+    by either ``[0]`` as a string key or index 0 of a list.
+
+    Args
+    ----
+    state : dict or None
+        Nested state dict from :func:`load_state_yaml`.  ``None`` is
+        accepted and yields ``default``.
+    pvname : str
+        Dot-separated rogue path, e.g.
+        ``AMCc.FpgaTopLevel.AppTop.AppCore.SysgenCryo.Base[0].digitizerFrequencyMHz``.
+    default : any, optional
+        Value returned when any segment is missing.  Defaults to
+        ``None`` to match the existing offline ``_caget`` contract.
+
+    Returns
+    -------
+    any
+        The looked-up value, or ``default`` if any segment is missing.
+    """
+    import re
+
+    if state is None:
+        return default
+    node = state
+    for seg in pvname.split('.'):
+        if not isinstance(node, dict):
+            return default
+        if seg in node:
+            node = node[seg]
+            continue
+        m = re.match(r'^([^\[]+)\[(\d+)\]$', seg)
+        if not m or m.group(1) not in node:
+            return default
+        node = node[m.group(1)]
+        idx = int(m.group(2))
+        if isinstance(node, list):
+            if idx >= len(node):
+                return default
+            node = node[idx]
+        elif isinstance(node, dict) and f'[{idx}]' in node:
+            node = node[f'[{idx}]']
+        else:
+            return default
+    return node
+
+
 def utf8_to_str(d):
     """
     Many of the rogue variables are returned as UTF8 formatted byte


### PR DESCRIPTION
## Summary

Closes #364 (open since 2020-03-26). Pysmurf offline mode previously returned `None` from `_caget` and relied on a handful of per-method hard-coded constants (two are literally commented `# FIX ME - STUPPID HARDCODE`). The issue asks for pysmurf to read a rogue `SaveState` YAML dump and *"treat it like it's a rogue server"* so offline development can exercise more gets.

This PR plumbs a captured state dump into offline mode end-to-end:

- `tools.load_state_yaml(filename)` — loads a rogue SaveState dump, transparently handling `.yml` and `.yml.gz` (rogue's `saveYaml(..., autoCompress=True)` default).
- `tools.state_lookup(state, pvname, default=None)` — walks a dot-separated rogue PV path through the nested dict; handles indexed segments like `Base[0]` as either a literal key or a list/dict index, since rogue versions vary.
- `SmurfBase.__init__(..., state_file=None, ...)` — new kwarg loads the dump on construction into `self._offline_state`.
- `SmurfControl.__init__(..., state_file=None, ...)` — passes through.
- `SmurfCommandMixin.load_state(filename)` — runtime loader symmetric with the existing `save_state`.
- `_caget` offline branch consults the dump first; falls back to the existing `None` return when the key is missing or no dump is loaded.
- 9 hard-coded `if self.offline:` sites guarded with `and self._offline_state is None` so a loaded dump preempts the constant:

  | File | Method | Hardcode |
  |---|---|---|
  | smurf_command.py | `get_number_sub_bands`        | 128 |
  | smurf_command.py | `get_number_channels`         | 512 |
  | smurf_command.py | `get_band_center_mhz`         | 4250 + band*500 |
  | smurf_command.py | `get_channel_frequency_mhz`   | 2.4 |
  | smurf_command.py | `get_digitizer_frequency_mhz` | 614.4 |
  | smurf_command.py | `get_flux_ramp_freq`          | 4.0 |
  | smurf_command.py | `get_filter_a`                | 5-elt ndarray |
  | smurf_command.py | `get_filter_b`                | 5-elt ndarray |
  | smurf_command.py | `get_downsample_factor`       | 20 |

Backward compatible: with no `state_file`, behavior is byte-identical to today.

## Usage

```python
S = SmurfControl(offline=True,
                 cfg_file='cfg/experiment.cfg',
                 state_file='/data/state.dat.yml.gz')
S.get_digitizer_frequency_mhz(0)   # recorded value, not 614.4
S.load_state('/data/newer.yml.gz')  # swap at runtime
```

## Tradeoff (documented on `state_file`)

A loaded dump that lacks a key yields `None` rather than the legacy hardcode. Intentional — the user opted into the dump, and a missing key is a real signal. If this proves brittle in practice, a follow-up can add a per-method fallback.

## Test plan

- [x] New `python/pysmurf/client/test/test_offline_state.py` — 9 tests: `state_lookup` walk, missing-key default, gzip/plain loading, `_caget` returns `None` without dump, reads from dump with one, `load_state` swaps at runtime, hardcodes used without a dump, dump overrides hardcodes, missing-key returns `None` (documented). All pass; no pyrogue / hardware required.
- [x] `flake8 --count python/` → 0 (matches CI invocation).
- [ ] CI flake8 / docs / server / client jobs pass on the PR.
- [ ] Manual hardware regression — operator captures a real `state.*.yml.gz` via `S.save_state(...)` on a live system, restarts pysmurf with `offline=True, state_file=<that file>`, and confirms `_caget`-backed methods return recorded values. (Out of scope to capture here.)

## Out of scope

- Removing `tools.yaml_parse` (dead code: splits on `:` while pysmurf pvnames use `.`; zero call sites). Left untouched to avoid breaking any external script that may still import it.
- Refactoring the 9 hard-coded methods to fully delegate to `_caget`. The single-line guard preserves the legacy hardcode when no dump is loaded; a follow-up PR can fold the constants into `_caget`-backed defaults if desired.