### PR TITLE
feat(SmurfControl): Dump loaded pysmurf cfg into output_dir on startup (#286)

### DIFF
--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -136,7 +136,7 @@ class SmurfControl(SmurfCommandMixin,
                    make_logfile=True, setup=False,
                    smurf_cmd_mode=False, no_dir=False, publish=False,
                    payload_size=2048, data_path_id=None,
-                   **kwargs):
+                   dump_config=True, **kwargs):
         """Initializes SMuRF system.
 
         Longer description of initialize routine here.
@@ -169,6 +169,13 @@ class SmurfControl(SmurfCommandMixin,
               instances running simultaneously. For instance, if set to
               ``crate1slot2`` the outputs directory will be::
               ``<data_dir>/<date>/crate1slot2/<ctime>/outputs``
+        dump_config : bool, optional, default True
+              Whether to write a copy of the loaded pysmurf
+              configuration into the new output directory at startup.
+              The dumped file is named
+              ``<start_time>_startup_pysmurf_cfg.cfg`` and can be fed
+              back to :class:`SmurfConfig` to reconstruct the pysmurf
+              instance used to take a given dataset.
 
         See Also
         --------
@@ -193,6 +200,14 @@ class SmurfControl(SmurfCommandMixin,
             self.make_dir(self.tune_dir)
             self.make_dir(self.plot_dir)
             self.make_dir(self.status_dir)
+
+            # Dump loaded pysmurf cfg into the new output dir so that
+            # the config used to produce data in this dir can be
+            # recovered later.  See issue #286.
+            if dump_config and self.config is not None:
+                self.config.write(os.path.join(
+                    self.output_dir,
+                    f'{self.start_time}_startup_pysmurf_cfg.cfg'))
 
             # Set logfile
             datestr = time.strftime('%y%m%d_', time.gmtime())
@@ -241,6 +256,14 @@ class SmurfControl(SmurfCommandMixin,
             self.make_dir(self.tune_dir)
             self.make_dir(self.plot_dir)
             self.make_dir(self.status_dir)
+
+            # Dump loaded pysmurf cfg into the new output dir so that
+            # the config used to produce data in this dir can be
+            # recovered later.  See issue #286.
+            if dump_config and self.config is not None:
+                self.config.write(os.path.join(
+                    self.output_dir,
+                    f'{self.start_time}_startup_pysmurf_cfg.cfg'))
 
             # name the logfile and create flags for it
             if make_logfile:


### PR DESCRIPTION
## Summary
- Adds `dump_config=True` kwarg to `SmurfControl.initialize()` so the loaded `SmurfConfig` is written to `<output_dir>/<start_time>_startup_pysmurf_cfg.cfg` immediately after the run output directory is created.
- Applies in both the `smurf_cmd_mode` branch and the standard branch of `initialize()`.
- Uses the existing `SmurfConfig.write()` primitive — no new dependencies, no changes to other call sites.
- Default `True` matches @jlashner's request in #286; opt-out via `dump_config=False` (or by passing through `SmurfControl(..., dump_config=False)` since `__init__` forwards `**kwargs` to `initialize()`).

Closes #286.

## Test plan
- [x] `python -m py_compile python/pysmurf/client/base/smurf_control.py`
- [x] `SmurfConfig` write→read round-trip on `cfg_files/template/template.cfg` (6.7 KB JSON, dict-equal after reload)
- [ ] Smoke test on a real SMuRF carrier: instantiate `SmurfControl(cfg_file=..., setup=False)` and confirm `<output_dir>/<start_time>_startup_pysmurf_cfg.cfg` exists and parses back via `SmurfConfig`
- [ ] Confirm `dump_config=False` suppresses the dump
- [ ] Spot-check that the startup `.cfg` is created even when `setup=True` raises (it is written before the optional `setup()` call)

## Notes
- Out of scope (per @jlashner's clarification on #286): the full rogue tree dump from `dump_state` — that remains a separate concern.
- The dump filename uses `self.start_time` so it correlates with the run name rather than re-timing via `get_timestamp()`.