### PR TITLE
feat(setup): Make payload_size configurable from pysmurf cfg file (#299)

### DIFF
--- a/cfg_files/template/template.cfg
+++ b/cfg_files/template/template.cfg
@@ -291,5 +291,10 @@
 
 "default_data_dir": "/data/smurf_data",
 "tune_dir" : "/data/smurf_data/tune",
-"status_dir" : "/data/smurf_data/status"
+"status_dir" : "/data/smurf_data/status",
+
+# Default payload size used by S.setup() (and S.initialize()).  If
+# omitted, S.setup() falls back to 2048.  Set to 0 to let rogue
+# auto-size the payload from the channel mask.  See issue #299.
+"payload_size" : 2048
 }

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -761,6 +761,17 @@ class SmurfConfig:
                                           lambda f: 0 <= f <= 99)
         #### Done specifying thermal schema
 
+        #### Start payload size schema
+        # Default payload size used by S.setup().  If None or absent,
+        # S.setup() falls back to its built-in default (2048).  A value
+        # of 0 lets rogue auto-size the payload from the channel mask.
+        # See issue #299.
+        schema_dict[
+            Optional('payload_size',
+                     default=None)] = And(Use(int),
+                                          lambda n: 0 <= n <= 4096)
+        #### Done specifying payload size schema
+
         #### Start specifying timing-related schema
         schema_dict["timing"] = {
             # "ext_ref" : internal oscillator locked to an external

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -136,6 +136,7 @@ class SmurfConfigPropertiesMixin:
         self._ultrascale_temperature_limit_degC = None
         self._data_out_mux = None
         self._dsp_enable = None
+        self._payload_size = None
 
         # AMC
         self._amplitude_scale = None
@@ -277,6 +278,7 @@ class SmurfConfigPropertiesMixin:
         ## Carrier
         self.dsp_enable = smurf_init_config['dspEnable']
         self.ultrascale_temperature_limit_degC = config.get('ultrascale_temperature_limit_degC')
+        self.payload_size = config.get('payload_size')
         self.data_out_mux = {
             band:smurf_init_config[f'band_{band}']['data_out_mux']
             for band in bands}
@@ -1925,6 +1927,39 @@ class SmurfConfigPropertiesMixin:
         self._ultrascale_temperature_limit_degC = value
 
     ## End ultrascale_temperature_limit_degC property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start payload_size property definition
+
+    # Getter
+    @property
+    def payload_size(self):
+        """Default payload size used by :func:`SmurfControl.setup`.
+
+        Specified in the pysmurf configuration file as the optional
+        top-level key `payload_size`.  If `None` (key absent),
+        :func:`SmurfControl.setup` falls back to its built-in default
+        of 2048.  A value of `0` lets rogue auto-size the payload from
+        the channel mask.  An explicit `payload_size` kwarg passed to
+        :func:`SmurfControl.setup` or :func:`SmurfControl.initialize`
+        always overrides this value.
+
+        See issue #299.
+
+        See Also
+        --------
+        :func:`~pysmurf.client.command.smurf_command.SmurfCommandMixin.set_payload_size`
+
+        """
+        return self._payload_size
+
+    # Setter
+    @payload_size.setter
+    def payload_size(self, value):
+        self._payload_size = value
+
+    ## End payload_size property definition
     ###########################################################################
 
     ###########################################################################

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -135,7 +135,7 @@ class SmurfControl(SmurfCommandMixin,
     def initialize(self, data_dir=None, name=None,
                    make_logfile=True, setup=False,
                    smurf_cmd_mode=False, no_dir=False, publish=False,
-                   payload_size=2048, data_path_id=None,
+                   payload_size=None, data_path_id=None,
                    **kwargs):
         """Initializes SMuRF system.
 
@@ -161,8 +161,11 @@ class SmurfControl(SmurfCommandMixin,
               Whether to make a skip making a directory.
         publish : bool, optional, default False
               Whether to send messages to the OCS publisher.
-        payload_size : int, optional, default 2048
-              The payload size to set on setup.
+        payload_size : int or None, optional, default None
+              The payload size to set on setup.  If `None`, the value
+              of the top-level `payload_size` key from the pysmurf
+              configuration file is used; if that key is also absent,
+              :func:`setup` falls back to 2048.  See issue #299.
         data_path_id : str, optional, default None
               If set, this will add the path-id to the output and plot dir
               paths to avoid possible collisions between multiple smurf
@@ -314,7 +317,7 @@ class SmurfControl(SmurfCommandMixin,
         # initialize outputs cfg
         self.config.update('outputs', {})
 
-    def setup(self, write_log=True, payload_size=2048, force_configure=False, **kwargs):
+    def setup(self, write_log=True, payload_size=None, force_configure=False, **kwargs):
         r"""Configures SMuRF system.
 
         Sets up the SMuRF system by first loading hardware register
@@ -360,8 +363,12 @@ class SmurfControl(SmurfCommandMixin,
         ----
         write_log : bool, optional, default True
             Whether to write to the log file.
-        payload_size : int, optional, default 2048
-            The starting size of the payload.
+        payload_size : int or None, optional, default None
+            The starting size of the payload.  If `None`, the value of
+            the top-level `payload_size` key from the pysmurf
+            configuration file is used; if that key is also absent,
+            falls back to 2048.  An explicit value always overrides
+            the configuration file.  See issue #299.
         force_configure : bool, optional, default False
             Whether or not to force configure if system has already
             been configured once by the currently running Rogue
@@ -399,6 +406,14 @@ class SmurfControl(SmurfCommandMixin,
 
         success=True
         self.log('Setting up...', (self.LOG_USER))
+
+        # Resolve payload_size precedence: explicit kwarg > pysmurf
+        # config file > built-in fallback of 2048.  See issue #299.
+        if payload_size is None:
+            if self._payload_size is not None:
+                payload_size = self._payload_size
+            else:
+                payload_size = 2048
 
         # If active, disable hardware logging while doing setup.
         if self._hardware_logging_thread is not None:


### PR DESCRIPTION
## Issue
This PR resolves #299.

## Summary
Adds an optional top-level `payload_size` key to the pysmurf configuration file and wires it through `SmurfConfigPropertiesMixin` so `S.setup()` (and `S.initialize()`) use it as the default payload size — fulfilling the second half of #299 that was never addressed (PR #632 only touched `stream_data_on()` for #626).

## Behavior
Precedence at `S.setup()` time:
1. Explicit `payload_size=` kwarg passed by the caller
2. `payload_size` value from the pysmurf cfg file
3. Built-in fallback of `2048` (unchanged behavior when the cfg key is absent)

A value of `0` lets rogue auto-size the payload from the channel mask, matching the convention from #632. Schema validates the value as an int in `[0, 4096]`.

## Files changed
- `python/pysmurf/client/base/smurf_config.py` — `Optional('payload_size', default=None)` schema entry
- `python/pysmurf/client/base/smurf_config_properties.py` — `_payload_size` init, `copy_config_to_properties()` wiring, and getter/setter property
- `python/pysmurf/client/base/smurf_control.py` — `setup()`/`initialize()` defaults changed from `2048` → `None`; precedence resolution added; docstrings updated
- `cfg_files/template/template.cfg` — documented the new optional key

## Verification (offline, before push)
- **Schema** — 6/6 cases pass: template default (2048), explicit override (512), auto-size (0), omitted (→ None), value > 4096 rejected, negative rejected
- **Mixin propagation** — config value flows through `SmurfConfig.get('payload_size')` → `S._payload_size` → `S.payload_size` getter
- **Precedence logic** — 6/6 cases pass, including edge cases (explicit `0` kwarg honored over a non-zero cfg value)
- **Lint** — `flake8 --count python/` (the exact CI command) → 0 errors

## Backward compatibility
- Existing site `.cfg` files (slac, stanford, ucsd, nist, pton, etc.) are not modified.
- The new key is `Optional` with `default=None`; sites that don't set it keep getting `payload_size=2048` from `S.setup()`, identical to today.
- All existing call sites of `S.setup(payload_size=N)` and `S.initialize(payload_size=N)` continue to work unchanged.

## Does this PR break any interface?
- [ ] Yes
- [x] No