### PR TITLE
feat(take_noise_psd): Save fitted wl and n columns to .txt output (#186)

### DIFF
--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -68,7 +68,11 @@ class SmurfNoiseMixin(SmurfBase):
         make_summary_plot : bool, optional, default True
             Whether to make the summary plots.
         save_data : bool, optional, default False
-            Whether to save the band averaged data as a text file.
+            Whether to save the per-channel summary as a text file. The
+            file has one row per channel and five columns:
+            ``res_freq[MHz]``, ``noise_floor[pA/rtHz]``, ``f_knee[Hz]``,
+            ``wl[pA/rtHz]``, ``n``. Channels for which the noise-model
+            fit was rejected are NaN in the fitted columns.
         show_plot : bool, optional, default False
             Show the plot on the screen.
         datafile : str or None, optional, default None
@@ -140,6 +144,8 @@ class SmurfNoiseMixin(SmurfBase):
         noise_floors = np.full((len(low_freq), n_channel), np.nan)
         f_knees = np.full(n_channel,np.nan)
         res_freqs = np.full(n_channel,np.nan)
+        wls = np.full(n_channel,np.nan)
+        ns = np.full(n_channel,np.nan)
 
         wl_list = []
         f_knee_list = []
@@ -172,6 +178,8 @@ class SmurfNoiseMixin(SmurfBase):
                     f_knee_list.append(f_knee)
                     f_knees[c]=f_knee
                     n_list.append(n)
+                    wls[c]=wl
+                    ns[c]=n
                     good_fit = True
                 if write_log:
                     self.log(f'{c+1}. b{b}ch{ch:03}:' +
@@ -256,7 +264,11 @@ class SmurfNoiseMixin(SmurfBase):
                 # outfn = os.path.join(self.plot_dir, save_name)
                 outfn = os.path.join(self.output_dir, save_name)
 
-                tools.save_to_txt(outfn, np.c_[res_freqs, noise_floors[i], f_knees])
+                tools.save_to_txt(
+                    outfn,
+                    np.c_[res_freqs, noise_floors[i], f_knees, wls, ns],
+                    header=('res_freq[MHz]  noise_floor[pA/rtHz]  '
+                            'f_knee[Hz]  wl[pA/rtHz]  n'))
                 # Publish the data
                 self.pub.register_file(outfn, 'noise_timestream', format='txt')
 


### PR DESCRIPTION
## Summary

Closes #186.

`take_noise_psd` already fits a white-noise + 1/f model (`wl`, `n`, `f_knee`) per channel and renders those values on the per-channel plot, but when `save_data=True` the resulting `.txt` only contained `res_freq`, `noise_floor`, and `f_knee`. Post-processing therefore had to reload the raw timestream and re-run the fit just to recover `wl` and `n`.

This PR appends the fitted `wl` and `n` to the same `.txt`, so the saved file is a complete per-channel summary of the fit:

- New columns at the end: `wl[pA/rtHz]`, `n`.
- Channels whose fit was rejected (`f_knee == 0.`) get `NaN` in all three fitted columns, matching the existing `f_knees` convention — fit-success rows still have finite values everywhere.
- A `#`-prefixed header line is written so the column meaning is self-documenting and `np.loadtxt` continues to read the file cleanly.
- Existing columns 0–2 keep their order, so any consumer reading by index still works.
- Docstring for `save_data` updated to describe the five-column format.
- No API changes, no new arguments, no change to the per-channel `.npy` sidecars or to the `return_noise_params` path.

Diff is `+14 / −2` in a single file (`python/pysmurf/client/debug/smurf_noise.py`).

## Test plan

- [x] `flake8 --count python/` clean (matches CI invocation in `.github/workflows/test-or-deploy.yml`).
- [x] Offline round-trip with synthetic per-channel arrays: file has 5 columns, header is `#`-prefixed, `np.loadtxt` reads `(n_channel, 5)`, NaN preserved for rejected-fit rows, finite for successful rows.
- [ ] On-hardware smoke test: run `S.take_noise_psd(meas_time, save_data=True)` on a SMuRF carrier and verify the produced `.txt` has the new columns and reasonable values for channels with good fits.