### PR TITLE
fix(read_adc_data): Warn when ADC samples rail (#210)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -655,11 +655,11 @@ class SmurfTuneMixin(SmurfBase):
             # Take read the ADC data
             try:
                 adc = self.read_adc_data(band, nsamp, hw_trigger=hw_trigger,
-                    save_data=False)
+                    save_data=False, check_if_adc_is_saturated=False)
             except Exception:
                 self.log('ADC read failed. Trying one more time', self.LOG_ERROR)
                 adc = self.read_adc_data(band, nsamp, hw_trigger=hw_trigger,
-                    save_data=False)
+                    save_data=False, check_if_adc_is_saturated=False)
             time.sleep(.05)  # Need to wait, otherwise dac call interferes with adc
 
             try:

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -1670,7 +1670,8 @@ class SmurfUtilMixin(SmurfBase):
            True if ADC is saturated, otherwise False.
         """
         adc = self.read_adc_data(band, data_length=2**12, make_plot=False,
-                  save_data=False, show_plot=False, save_plot=False)
+                  save_data=False, show_plot=False, save_plot=False,
+                  check_if_adc_is_saturated=False)
         adc_max   = int(np.max((adc.real.max(), adc.imag.max())))
         adc_min   = int(np.min((adc.real.min(), adc.imag.min())))
         saturated = ((adc_max > 31000) | (adc_min < -31000))
@@ -1714,7 +1715,8 @@ class SmurfUtilMixin(SmurfBase):
     def read_adc_data(self, band, data_length=2**19,
                       hw_trigger=False, make_plot=False, save_data=True,
                       timestamp=None, show_plot=True, save_plot=True,
-                      plot_ylimits=[None,None]):
+                      plot_ylimits=[None,None],
+                      check_if_adc_is_saturated=True):
         """
         Reads data directly off the ADC.
 
@@ -1741,6 +1743,15 @@ class SmurfUtilMixin(SmurfBase):
             Whether or not to save plot to file.
         plot_ylimits : [float or None, float or None], optional, default [None,None]
             y-axis limit (amplitude) to restrict plotting over.
+        check_if_adc_is_saturated : bool, optional, default True
+            After reading, inspect the I/Q samples and log a red
+            ``LOG_ERROR`` warning if any sample is at the rail
+            (max > 31000 or min < -31000, i.e. within ~5% of the
+            +/-2**15 16-bit ADC limits).  Warns rather than raises
+            so the returned data remains available for diagnostic
+            inspection.  Set to False to suppress the in-line check
+            (e.g. when the caller already runs its own saturation
+            logic).
 
         Returns
         -------
@@ -1758,6 +1769,16 @@ class SmurfUtilMixin(SmurfBase):
         res = self.read_stream_data_daq(data_length, bay=bay,
             hw_trigger=hw_trigger)
         dat = res[1] + 1.j * res[0]
+
+        if check_if_adc_is_saturated:
+            adc_max = int(np.max((dat.real.max(), dat.imag.max())))
+            adc_min = int(np.min((dat.real.min(), dat.imag.min())))
+            if (adc_max > 31000) or (adc_min < -31000):
+                self.log(
+                    f'\033[91mADC{band} is railing '
+                    f'(max={adc_max}, min={adc_min}).  Try increasing '
+                    f'the DC attenuation for this band.\033[00m',
+                    self.LOG_ERROR)
 
         if make_plot:
             if show_plot:


### PR DESCRIPTION
## Summary
- Closes #210. Adds a railing warning directly to `read_adc_data` so direct callers (notebooks, diagnostic scripts, future code paths) get told when 16-bit ADC samples are pinned at the rail.
- New `check_if_adc_is_saturated=True` kwarg on `read_adc_data` (matching the existing pattern on `full_band_resp` / PR #915's `find_freq`). When set, after the read it computes max/min over real and imag and logs a red `LOG_ERROR` if any sample is outside ±31000 (~5% of ±2**15), pointing the user at the DC attenuator. Warns rather than raises so the returned data is still available for diagnostic inspection.
- Internal callers that already do their own saturation logic — `check_adc_saturation` and the two `read_adc_data` calls inside `full_band_resp` — pass `check_if_adc_is_saturated=False` to avoid duplicate log lines. Their existing behavior (max/min log + `ValueError` raise from `full_band_resp` on rail) is preserved unchanged, so `tune_band_serial`'s railing report (which goes through `full_band_resp`) is unaffected.

## Issue scope assessment
The issue (filed 2019-12-15) called out both `read_adc_data` and `tune_band_serial`:
- **`tune_band_serial`** has been functionally addressed since commit `6e94b045` added `check_if_adc_is_saturated=True` to `full_band_resp` — it raises `ValueError` with a "Try increasing the DC attenuation" message on rail.
- **`read_adc_data`** itself was the remaining gap — it returned raw counts with no warning, even at hard ±2**15 rail. This PR closes that gap.

## Out of scope (intentionally)
- **`read_dac_data`**: issue #210 is scoped to ADC; `check_dac_saturation` already exists for DAC-side users.
- **The orphaned UC-attenuator state in `tune_band_serial` when `full_band_resp` raises** (sets `att_uc=0`, restore line is skipped on exception). Real but separate bug.
- **A firmware-side saturation register read during eta scan** (suggested by @swh76 in the issue thread). Requires Rogue/firmware changes.

## Test plan
- [x] `flake8 --count python/` → 0 errors (matches CI invocation in `.github/workflows/test-or-deploy.yml`).
- [x] Offline numpy sanity check of the threshold: clean / boundary-equal / in-range arrays correctly do not trigger; real-rails-high, imag-rails-low, just-over-31001, and hard ±2**15 cases all correctly do trigger.
- [ ] Hardware regression on a SMuRF system:
  - `S.read_adc_data(band, ...)` at deliberately too-low DC attenuation → confirm the red railing warning fires with sensible max/min counts; re-run at nominal attenuation → confirm no warning.
  - `S.check_adc_saturation(band)` → confirm only one set of log lines (no duplicated railing warning from the inner read).
  - `S.full_band_resp(band)` at saturating drive → confirm the existing `ValueError` still fires with no extra duplicate warning preceding it.
  - `S.tune_band_serial(band)` at saturating drive → confirm the `ValueError` propagates (existing behavior preserved).