### PR TITLE
fix(SmurfControl): Don't override caller-supplied log/logfile (#188)

### DIFF
--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -83,6 +83,10 @@ class SmurfBase:
 
         # Set up logging
         self.log = log
+        # Track whether caller explicitly supplied a logger or logfile path.
+        # Subclasses (e.g., SmurfControl) consult this to avoid overriding
+        # user-supplied log destinations. See pysmurf issue #188.
+        self._log_user_supplied = (log is not None) or ('logfile' in kwargs)
         if self.log is None:
             self.log = self.init_log(**kwargs)
         else:

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -198,7 +198,8 @@ class SmurfControl(SmurfCommandMixin,
             datestr = time.strftime('%y%m%d_', time.gmtime())
             self.log_file = os.path.join(self.output_dir, 'logs', datestr +
                 'smurf_cmd.log')
-            self.log.set_logfile(self.log_file)
+            if not self._log_user_supplied:
+                self.log.set_logfile(self.log_file)
         else:
             # define data dir
             if data_dir is not None:
@@ -245,8 +246,9 @@ class SmurfControl(SmurfCommandMixin,
             # name the logfile and create flags for it
             if make_logfile:
                 self.log_file = os.path.join(self.output_dir, name + '.log')
-                self.log.set_logfile(self.log_file)
-            else:
+                if not self._log_user_supplied:
+                    self.log.set_logfile(self.log_file)
+            elif not self._log_user_supplied:
                 self.log.set_logfile(None)
 
             # Which bays were enabled on pysmurf server startup?


### PR DESCRIPTION
## Summary
- Closes #188.
- `SmurfControl.initialize()` was calling `self.log.set_logfile(...)` unconditionally after `super().__init__()` already set up the logger, which silently clobbered any `log=<logger>` or `logfile=<path>` the caller passed through to `SmurfBase`.
- `SmurfBase.__init__` now records `self._log_user_supplied = (log is not None) or ('logfile' in kwargs)`. Both `set_logfile` call sites in `SmurfControl.initialize()` (smurf_cmd_mode branch and normal branch) are gated on that flag, so a user-supplied destination is preserved.
- Default behavior (no kwargs → auto-named logfile in `output_dir`, or `make_logfile=False` → stdout) is unchanged. No public API change; `make_logfile` kwarg stays for back-compat.

## Behavior matrix
| Caller passes | Old | New |
|---|---|---|
| nothing | auto-named logfile | unchanged |
| `make_logfile=False` | logger → stdout | unchanged |
| `logfile='/tmp/x.log'` | overridden | **stays at /tmp/x.log** |
| `log=<my_logger>` | logger's file replaced | **logger's file preserved** |
| `log=<logger>, make_logfile=False` | forced to stdout | **logger's file preserved** |

## Test plan
- [x] `flake8 --count python/` (CI's exact command) — 0 errors.
- [x] Direct unit test of `SmurfBase` flag for the three input cases (default, `logfile=...`, `log=<custom>`) — all pass.
- [ ] End-to-end check on a host with `pyrogue` installed: instantiate `SmurfControl(offline=True, ...)` for each case in the matrix above and confirm `s.log.logfile` matches expectations. (Couldn't run locally because `smurf_command.py` does `from pyrogue import VariableWait` unconditionally.)