### PR TITLE
feat(play_tes_bipolar_waveform): Add dc_amp option to play on top of existing DC bias (#184)

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4257,7 +4257,7 @@ class SmurfUtilMixin(SmurfBase):
         return hdr,row
 
     def play_tes_bipolar_waveform(self, bias_group, waveform, do_enable=False,
-            continuous=True, **kwargs):
+            continuous=True, dc_amp=None, **kwargs):
         """ Play a bipolar waveform on the bias group.
 
         Args
@@ -4271,6 +4271,13 @@ class SmurfUtilMixin(SmurfBase):
             for TES bias).
         continuous : bool, optional, default True
             Whether to play the TES waveform continuously.
+        dc_amp : float or None, optional, default None
+            DC voltage added to every sample of ``waveform`` before the
+            LUTs are loaded, so the waveform plays on top of an offset
+            instead of being centered on 0 V. ``None`` (the default)
+            leaves ``waveform`` untouched. To play on top of the bias
+            group's existing DC bias (issue #184), pass
+            ``dc_amp=S.get_tes_bias_bipolar(bias_group)``.
         """
         bias_order = self.bias_group_to_pair[:,0]
         dac_positives = self.bias_group_to_pair[:,1]
@@ -4297,6 +4304,9 @@ class SmurfUtilMixin(SmurfBase):
         if do_enable:
             self.set_rtm_slow_dac_enable(dac_positive, 2, **kwargs)
             self.set_rtm_slow_dac_enable(dac_negative, 2, **kwargs)
+
+        if dc_amp is not None:
+            waveform = np.asarray(waveform) + dc_amp
 
         # Load waveform into each DAC's LUT table.  Opposite sign so
         # they combine coherently


### PR DESCRIPTION
## Summary

Closes #184.

Adds an optional `dc_amp` keyword argument to `play_tes_bipolar_waveform` so the supplied waveform can be played on top of an existing DC bias instead of being centered on 0 V.

- `dc_amp=None` (default) → waveform is loaded into the LUTs unmodified — existing behavior, fully backwards compatible.
- `dc_amp=<float>` → the offset is added to every sample before the LUTs are loaded.

The idiom for the issue's specific use case (play on top of the bias group's currently-programmed DC bias) is:

```python
S.play_tes_bipolar_waveform(bg, wf, dc_amp=S.get_tes_bias_bipolar(bg))
```

The naming and `None`-default convention mirrors the existing `play_sine_tes` higher-level wrapper (`smurf_util.py:3817`), which already pre-sums a `dc_amp` into a cosine waveform before calling `play_tes_bipolar_waveform`. This change pushes that pattern down to the primitive so any waveform — not just a sine wave — can be played on top of a DC offset.

This is independent of and orthogonal to the other open `play_tes_bipolar_waveform` PRs:
- #895 — enable-ordering bug (#678)
- #936 — restore pre-play bias on stop (#425)

No changes to call sites or behavior on the default code path.

## Test plan

- [x] `flake8 --count python/` reports 0 findings (matches the CI invocation in `.github/workflows/test-or-deploy.yml:51`).
- [x] Verified the only in-tree caller (`play_sine_tes` at `smurf_util.py:3864`) uses 2 positional args, so it is unaffected by the new keyword.
- [ ] Hardware smoke test on a SMuRF crate:
  ```python
  S.set_tes_bias_bipolar(bg, 1.0)
  wf = 0.1 * np.cos(2*np.pi*np.arange(2048)/2048)
  # New path: differential output should swing 0.9 V <-> 1.1 V
  S.play_tes_bipolar_waveform(bg, wf, dc_amp=S.get_tes_bias_bipolar(bg))
  S.stop_tes_bipolar_waveform(bg)
  # Regression: existing call shape still swings around 0 V
  S.play_tes_bipolar_waveform(bg, wf)
  ```