### PR TITLE
fix(full_band_resp): Disable noise file even when data read fails (#131)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -643,37 +643,41 @@ class SmurfTuneMixin(SmurfBase):
             self.set_trigger_hw_arm(bay, 0, write_log=write_log)
 
             self.set_noise_select(band, 1, wait_done=True, write_log=write_log)
-            # if true, checks whether or not playing noise file saturates the ADC.
-            #If ADC is saturated, throws an exception.
-            if check_if_adc_is_saturated:
-                adc_is_saturated = self.check_adc_saturation(band)
-                if adc_is_saturated:
-                    raise ValueError('Playing the noise file saturates the '+
-                        f'ADC for band {band}.  Try increasing the DC '+
-                        'attenuation for this band.')
-
-            # Take read the ADC data
             try:
-                adc = self.read_adc_data(band, nsamp, hw_trigger=hw_trigger,
-                    save_data=False)
-            except Exception:
-                self.log('ADC read failed. Trying one more time', self.LOG_ERROR)
-                adc = self.read_adc_data(band, nsamp, hw_trigger=hw_trigger,
-                    save_data=False)
-            time.sleep(.05)  # Need to wait, otherwise dac call interferes with adc
+                # if true, checks whether or not playing noise file saturates the ADC.
+                #If ADC is saturated, throws an exception.
+                if check_if_adc_is_saturated:
+                    adc_is_saturated = self.check_adc_saturation(band)
+                    if adc_is_saturated:
+                        raise ValueError('Playing the noise file saturates the '+
+                            f'ADC for band {band}.  Try increasing the DC '+
+                            'attenuation for this band.')
 
-            try:
-                dac = self.read_dac_data(
-                    band, nsamp, hw_trigger=hw_trigger,
-                    save_data=False)
-            except BaseException:
-                self.log('ADC read failed. Trying one more time', self.LOG_ERROR)
-                dac = self.read_dac_data(
-                    band, nsamp, hw_trigger=hw_trigger,
-                    save_data=False)
-            time.sleep(.05)
+                # Take read the ADC data
+                try:
+                    adc = self.read_adc_data(band, nsamp, hw_trigger=hw_trigger,
+                        save_data=False)
+                except Exception:
+                    self.log('ADC read failed. Trying one more time', self.LOG_ERROR)
+                    adc = self.read_adc_data(band, nsamp, hw_trigger=hw_trigger,
+                        save_data=False)
+                time.sleep(.05)  # Need to wait, otherwise dac call interferes with adc
 
-            self.set_noise_select(band, 0, wait_done=True, write_log=write_log)
+                try:
+                    dac = self.read_dac_data(
+                        band, nsamp, hw_trigger=hw_trigger,
+                        save_data=False)
+                except BaseException:
+                    self.log('ADC read failed. Trying one more time', self.LOG_ERROR)
+                    dac = self.read_dac_data(
+                        band, nsamp, hw_trigger=hw_trigger,
+                        save_data=False)
+                time.sleep(.05)
+            finally:
+                # Always disable the noise file, even if the data read above
+                # raised, so the band is not left streaming broadband noise
+                # (issue #131).
+                self.set_noise_select(band, 0, wait_done=True, write_log=write_log)
 
             # Account for the up and down converter attenuators
             if correct_att:


### PR DESCRIPTION
## Summary

- Closes #131. `full_band_resp` enables the broadband noise file with `set_noise_select(band, 1)` then disables it after reading ADC/DAC data; on any intervening exception the disable was skipped, leaving the band streaming noise into subsequent measurements.
- Wrap the noise-on → noise-off body in `try`/`finally` so the disable runs on every exit path. Same pattern used by `estimate_phase_delay` in #926 (fix for #469).
- Success path is byte-identical aside from indentation.

## Failure modes covered

- `check_adc_saturation` raises `ValueError` when the ADC saturates
- `read_adc_data` retries once and re-raises on the second failure
- `read_dac_data` retries once and re-raises on the second failure
- `KeyboardInterrupt` (or any other exception) during `time.sleep`

## Test plan

- [x] `flake8 --count python/pysmurf/client/tune/smurf_tune.py` → 0 (matches the CI invocation in `.github/workflows/test-or-deploy.yml`)
- [x] AST parse of the modified file
- [ ] Hardware-level verification of `full_band_resp` was not possible in the dev environment — `python/pysmurf/client/test/test_loopback.py` requires a live `smurf_control`. Reviewers with hardware access: please confirm a single scan and an interrupted scan both leave `noise_select == 0`.