### PR TITLE
feat(setup): Detect disengaged AMC/RTM handles and raise (#177)

### DIFF
--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -496,6 +496,21 @@ class SmurfControl(SmurfCommandMixin,
                     self.LOG_ERROR)
                 success = False
 
+        # Verify AMC and RTM handles are fully engaged before
+        # touching per-band hardware.  A disengaged handle leaves the
+        # FRU mechanically present but electrically dead; setup would
+        # otherwise complete and only fail later in obscure ways.
+        # Issue #177.
+        if success:
+            disengaged = self.check_amc_rtm_handles()
+            if disengaged:
+                raise RuntimeError(
+                    'Hardware handle(s) not properly engaged: '
+                    f'{", ".join(disengaged)}.  Reseat the listed '
+                    'module(s) (push handle fully closed until it '
+                    'latches) and re-run setup.  See pysmurf issue '
+                    '#177.')
+
         # Only proceed with the rest of setup if defaults were set
         # correctly and basic system checks succeeded, otherwise we
         # risk giving users false hope.

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -7119,6 +7119,53 @@ class SmurfCommandMixin(SmurfBase):
 
         return fru_info_dict
 
+    def check_amc_rtm_handles(self, bays=None, slot_number=None,
+                              shelf_manager=None):
+        r"""Check that AMC and RTM handles are fully engaged.
+
+        A disengaged handle leaves the FRU electrically dead but
+        mechanically present, which `setup()` would otherwise miss.
+        Probes each AMC bay in `bays` plus the RTM via
+        :func:`get_fru_info`; a `None` return means the shelf manager
+        could not see the FRU (handle open, not seated, or shelf
+        wiring fault).
+
+        Args
+        ----
+        bays : list of int or None, optional, default None
+            AMC bays to probe.  If None, defaults to
+            :attr:`~pysmurf.client.base.smurf_control.SmurfControl.bays`.
+        slot_number : int or None, optional, default None
+            The crate slot number to probe.  If None, defaults to the
+            :class:`~pysmurf.client.base.smurf_control.SmurfControl`
+            class attribute
+            :attr:`~pysmurf.client.base.smurf_control.SmurfControl.slot_number`.
+        shelf_manager : str or None, optional, default None
+            Shelf manager ip address.  If None, defaults to the
+            :class:`~pysmurf.client.base.smurf_control.SmurfControl`
+            class attribute
+            :attr:`~pysmurf.client.base.smurf_control.SmurfControl.shelf_manager`.
+
+        Returns
+        -------
+        disengaged : list of str
+            Human-readable identifiers of FRUs whose handle/seating
+            check failed (e.g. ``['AMC bay 0', 'RTM']``).  Empty list
+            means all probed FRUs responded.
+        """
+        if bays is None:
+            bays = self.bays
+        disengaged = []
+        for bay in bays:
+            if self.get_fru_info('amc', bay=bay,
+                                 slot_number=slot_number,
+                                 shelf_manager=shelf_manager) is None:
+                disengaged.append(f'AMC bay {bay}')
+        if self.get_fru_info('rtm', slot_number=slot_number,
+                             shelf_manager=shelf_manager) is None:
+            disengaged.append('RTM')
+        return disengaged
+
     _readout_delay_reg = "readoutDelay"
 
     def get_readout_delay(self, **kwargs):


### PR DESCRIPTION
## Summary
- Closes #177. Detects the AMC/RTM handle-disengaged failure mode during `setup()` instead of letting it fail silently downstream.
- Adds `SmurfCommandMixin.check_amc_rtm_handles()` that probes each AMC bay in `self.bays` plus the RTM via the existing `get_fru_info()` shell wrapper (`cba_amc_init -d` / `cba_rtm_init -d`), which already parses the exact "not present" strings the shelf manager emits when a handle isn't latched.
- Wires the check into `SmurfControl.setup()` between the JESD check and the per-band config; raises `RuntimeError` naming the offending FRU(s) so the user cannot miss it. Matches the recent "raise on hardware misconfig" pattern from 94752acb.

## Design notes
- **Reused existing infrastructure** rather than adding a new probe path — `get_fru_info()` is passive (`-d` = describe), already handles the AMC/RTM/carrier kinds, and already logs the failure mode. Net new code is ~60 lines including the docstring.
- **Scope kept tight**: only AMC bays the user actually configured (`self.bays`) plus the RTM. Carrier check skipped (redundant — if pysmurf is up, the carrier is in M4). No `check_handles=False` opt-out kwarg added; can be added later if a real bench-test use case appears.
- **Did not depend on PR #909** (`health_check` aggregator) — `check_amc_rtm_handles()` is structured so it can be folded into `health_check()` as an unconditional check once that PR lands.
- `atca_monitor` EPICS hot-swap PVs would give explicit M0..M7 state but aren't verified to exist in pysmurf's PV set; deliberately deferred.

## Test plan
Hardware-dependent — no unit test for "the handle is open." Manual on a SMuRF crate:
- [ ] `S.check_amc_rtm_handles()` returns `[]` with all FRUs seated.
- [ ] Open an AMC handle → `'AMC bay <N>'` in returned list; existing `get_fru_info` `LOG_ERROR` line appears once.
- [ ] Open the RTM handle → `'RTM'` in returned list.
- [ ] `S.setup()` runs to completion as before with all handles seated (no new chatter on happy path).
- [ ] `S.setup()` raises `RuntimeError` naming the offending FRU(s) and pointing at issue #177 with a handle disengaged; no per-band registers are written.
- [x] `flake8 --count python/` reports 0 (same invocation as CI).