### PR TITLE
fix(smurf_tune): close intermediate figure in full_band_resp to plug memory leak (#121)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -733,7 +733,7 @@ class SmurfTuneMixin(SmurfBase):
             else:
                 plt.ioff()
 
-            fig, ax = plt.subplots(3, figsize=(5,8), sharex=True)
+            fig1, ax = plt.subplots(3, figsize=(5,8), sharex=True)
             f_plot = f / 1.0E6
 
             plot_idx = np.where(np.logical_and(f_plot>-250, f_plot<250))
@@ -753,9 +753,9 @@ class SmurfTuneMixin(SmurfBase):
                     f'{timestamp}_b{band}_full_band_resp_raw.png')
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'response', plot=True)
-                plt.close()
+            plt.close(fig1)
 
-            fig, ax = plt.subplots(1, figsize=(5.5, 3))
+            fig2, ax = plt.subplots(1, figsize=(5.5, 3))
 
             # Log y-scale plot
             ax.plot(f_plot[plot_idx], np.log10(np.abs(resp[plot_idx])))
@@ -776,7 +776,7 @@ class SmurfTuneMixin(SmurfBase):
             if show_plot:
                 plt.show()
             else:
-                plt.close()
+                plt.close(fig2)
 
         if save_data:
             save_name = timestamp + '_{}_full_band_resp.txt'


### PR DESCRIPTION
## Summary
- Closes #121 — the long-standing report that repeated `full_band_resp` calls slow down the pysmurf session.
- The plotting block in `full_band_resp` creates two matplotlib figures via `plt.subplots()` but only closes them on some code paths. Repeated calls leave figures registered in pyplot's figure manager, the textbook cause of the "session gets slower and slower" symptom.
- Three small edits in `python/pysmurf/client/tune/smurf_tune.py`: name the two figures `fig1`/`fig2`, move the intermediate-figure `plt.close()` out of the `if save_plot:` block so the raw debug figure is closed unconditionally, and use the explicit handle in the final `plt.close()` for clarity. `show_plot=True` still leaves the user-facing final plot on screen — that behavior is unchanged.

### Leak matrix (with `make_plot=True`)

| `save_plot` | `show_plot` | Before | After |
|---|---|---|---|
| True  | False | both closed   | both closed |
| True  | True  | fig 2 shown (intentional) | fig 2 shown (intentional) |
| False | False | **fig 1 leaked** | both closed |
| False | True  | **fig 1 leaked** | fig 2 shown (intentional) |

Pattern matches `plot_find_freq_multi_subband` at `python/pysmurf/client/tune/smurf_tune.py:3609-3627`.

## Test plan
- [x] `flake8 --count python/` → 0 (matches CI gate in `.github/workflows/test-or-deploy.yml`)
- [x] `python3 -m py_compile python/pysmurf/client/tune/smurf_tune.py` → OK
- [x] AST check — `fig1` and `fig2` both referenced inside `full_band_resp` (no F841 risk)
- [ ] Hardware verification: run `for _ in range(50): S.full_band_resp(0, make_plot=True, save_plot=False)` and confirm steady process RSS in `top` (or stable `tracemalloc` snapshots) instead of monotonically increasing memory