### PR TITLE
feat(tools): Add fix_tmux_display helper to refresh DISPLAY in tmux (#126)

### DIFF
--- a/python/pysmurf/client/util/tools.py
+++ b/python/pysmurf/client/util/tools.py
@@ -14,6 +14,7 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import os
+import subprocess
 
 import numpy as np
 from scipy.optimize import curve_fit
@@ -234,6 +235,46 @@ def utf8_to_str(d):
         The string associated with input d.
     """
     return ''.join([str(s, encoding='UTF-8') for s in d])
+
+def fix_tmux_display():
+    """Sync ``DISPLAY`` from the current tmux session.
+
+    Inside a tmux pane, ``$DISPLAY`` is the value captured when the tmux
+    session was first started. After detaching and reattaching from a
+    different SSH session, ``$DISPLAY`` in existing panes (and in any
+    Python process already running there) is stale, so interactive
+    matplotlib figures are routed to the original X display. This helper
+    queries ``tmux show-environment DISPLAY`` and updates
+    ``os.environ['DISPLAY']`` so subsequent ``plt.show()`` calls open on
+    the current SSH/X11 display. No-op outside tmux, when ``tmux`` is not
+    on ``PATH``, or when tmux has no ``DISPLAY`` recorded.
+
+    Returns
+    -------
+    str or None
+        New ``DISPLAY`` value if updated, otherwise ``None``.
+
+    Notes
+    -----
+    Addresses https://github.com/slaclab/pysmurf/issues/126 .
+    Equivalent shell-side remedy is to add
+    ``set-option -g update-environment " DISPLAY"`` to ``~/.tmux.conf``
+    so newly opened panes inherit the refreshed value.
+    """
+    if 'TMUX' not in os.environ:
+        return None
+    try:
+        out = subprocess.check_output(
+            ['tmux', 'show-environment', 'DISPLAY'],
+            stderr=subprocess.DEVNULL,
+        ).decode().strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    if not out.startswith('DISPLAY='):
+        return None
+    new_display = out.split('=', 1)[1]
+    os.environ['DISPLAY'] = new_display
+    return new_display
 
 def save_to_txt(path: str, data: np.ndarray, overwrite: bool = False, **kwargs):
     """


### PR DESCRIPTION
## Description

Closes #126.

When a tmux session is started inside an SSH session with X11 forwarding, tmux captures the original `$DISPLAY`. After detaching and reconnecting from a different SSH session, every existing tmux pane (and every Python process already running there) keeps the stale value, so `plt.show()` opens windows on an X server that's no longer reachable.

This PR adds a small `fix_tmux_display()` helper in `python/pysmurf/client/util/tools.py` that queries `tmux show-environment DISPLAY` and writes the result into `os.environ['DISPLAY']`. Users call it after re-attaching tmux and before any interactive plotting:

```python
from pysmurf.client.util.tools import fix_tmux_display
fix_tmux_display()
```

Safe no-op outside tmux, when `tmux` is not on `PATH`, or when tmux has no `DISPLAY` recorded (`-DISPLAY` reply).

A complementary user-side remedy that doesn't require any code (and is worth recommending in docs as a follow-up) is adding `set-option -g update-environment " DISPLAY"` to `~/.tmux.conf` so newly opened panes inherit the refreshed value.

### Why a manual helper, not an auto-call from `SmurfControl.__init__`

The bug manifests *after* tmux reattach, by which point `SmurfControl` is typically already constructed. Auto-syncing only at `__init__` would not help that path, and silently rewriting `os.environ['DISPLAY']` on construction is surprising for users who deliberately point pysmurf at Xvfb or a non-default display.

## Jira Issue

ESCRYODET-

## Tests done on this branch

- `flake8 --count python/` reports 0 errors (matches the CI step in `.github/workflows/test-or-deploy.yml`).
- Smoke tests of `fix_tmux_display()` (run by directly importing `tools.py` to bypass the pyrogue import chain on the dev host):
  - Outside tmux (`TMUX` unset): returns `None`, leaves `DISPLAY` unchanged.
  - `TMUX` set but `tmux` binary missing on `PATH`: returns `None`, no exception raised.
  - `tmux show-environment DISPLAY` returns `-DISPLAY` (unset in tmux env): returns `None`, leaves `DISPLAY` unchanged.
  - `tmux show-environment DISPLAY` returns `DISPLAY=localhost:99.0`: updates `os.environ['DISPLAY']` and returns `'localhost:99.0'`.
- The actual reattach-with-stale-display scenario needs a real tmux + SSH X11 setup; that end-to-end check is left for reviewers/users on a SMuRF host.

## Function interfaces that changed

New public function `pysmurf.client.util.tools.fix_tmux_display()`. No existing interfaces are modified.

### What was the interface before the change

`pysmurf.client.util.tools` had no DISPLAY/tmux helper.

### What will be the new interface after the change

```python
def fix_tmux_display() -> str | None:
    """Sync DISPLAY from the current tmux session.

    Returns the new DISPLAY value if updated, otherwise None.
    No-op outside tmux, when tmux is not on PATH, or when tmux has
    no DISPLAY recorded.
    """
```