### PR TITLE
docs(README): Add Configuration section linking cfg-file docs (#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,28 @@ cd pysmurf/
 pip3 install .
 ```
 
+## Configuration
+
+pysmurf is driven by a per-hardware-setup configuration (`.cfg`) file. Site
+configs live under [`cfg_files/<site>/`](cfg_files); start from
+[`cfg_files/template/template.cfg`](cfg_files/template/template.cfg) when
+adding a new setup.
+
+- See [README.config_file.md](README.config_file.md) for the cfg file format,
+  the per-band `init` block, `bad_mask`, `amplifier`, `pic_to_bias_group`,
+  `bias_group_to_pair`, and the other top-level fields.
+- See [README.Docker.md](README.Docker.md) for running the server/client
+  containers; the cfg file is passed to the client via `-c <config_file>` and
+  the host data directory is mounted with `-v <local_data_dir>:/data`.
+
+Some sites (SLAC, NIST, Princeton) use `shawnhammer`-style deploy scripts
+under [`scratch/shawn/scripts/`](scratch/shawn/scripts) that symlink the
+chosen cfg files into fixed locations
+(`/data/smurf_startup_cfg/smurf_startup.cfg`,
+`/data/pysmurf_cfg/<experiment>.cfg`) and the firmware docker into
+`/home/cryo/docker/smurf/current`. These are deployment conventions, not a
+required pysmurf layout — see those scripts for examples.
+
 ## Documentation
 Documentation is built using Sphinx, and follows the [NumPy Style
 Docstrings][1] convention. To build the documentation first install


### PR DESCRIPTION
## Summary

Closes #101.

The top-level `README.md` covered only install and Sphinx-docs build, with no breadcrumbs to the per-hardware cfg file system or the docker workflow. `README.config_file.md` (added in #655 in 2021) and `README.Docker.md` were not discoverable from the entry-point README, leaving the original 2019 ask in #101 unaddressed.

This PR inserts a `## Configuration` section between Installation and Documentation that:

- Points users at [`cfg_files/<site>/`](cfg_files) and [`cfg_files/template/template.cfg`](cfg_files/template/template.cfg) as the starting point for new hardware setups.
- Links [`README.config_file.md`](README.config_file.md) for the cfg file format and field reference.
- Links [`README.Docker.md`](README.Docker.md) for the container workflow — cfg passed via `-c <config_file>`, host data dir mounted via `-v <local_data_dir>:/data`.
- Notes that some sites (SLAC, NIST, Princeton) maintain `shawnhammer`-style deploy scripts under [`scratch/shawn/scripts/`](scratch/shawn/scripts) that symlink the chosen cfg into `/data/smurf_startup_cfg/`, `/data/pysmurf_cfg/`, and the firmware docker into `/home/cryo/docker/smurf/current`. Treated as a pointer to example scripts, not a documented pysmurf interface — those paths are a legacy site convention, not a stable requirement.

## Function interfaces that changed

None — docs-only change.

## Scope

- `README.md` only. +22 lines, 0 deletions.
- Does not modify `README.config_file.md` (already in flight via #945).
- Does not fill in `docs/user/configuration.rst` (still `Coming soon...`) — left as a separate, larger doc effort.
- Does not elevate the `/data/smurf_startup_cfg/` symlink layout to a canonical pysmurf interface.

## Test plan

- [x] All five linked paths resolve in the working tree (`cfg_files`, `cfg_files/template/template.cfg`, `README.config_file.md`, `README.Docker.md`, `scratch/shawn/scripts`).
- [x] `git diff main -- README.md` shows only the new `## Configuration` section between Installation and Documentation.
- [x] Docs-only change; CI `flake8 --count python/` is unaffected.
- [ ] Reviewer to confirm GitHub-rendered links resolve from the PR preview of `README.md`.