### PR TITLE
Document and warn on amplitudeScale; add dB helpers (closes #123, #114)

### DIFF
--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -2020,17 +2020,29 @@ class SmurfConfigPropertiesMixin:
     # Getter
     @property
     def amplitude_scale(self):
-        """Short description.
+        """Default per-band tone amplitude scale.
 
-        Gets or sets ?.
-        Units are ?.
+        Gets or sets the default tone amplitude scale used when a tuning
+        routine (:func:`find_freq`, :func:`setup_notches`,
+        :func:`tune_band_serial`, :func:`full_band_resp`, ...) is called
+        without an explicit ``tone_power``.  Indexed by band number, with
+        each entry a 4-bit unsigned integer in [0, 15].
+
+        Units are raw amplitudeScale codes with ~3 dB per LSB.  The
+        conventional full-scale value is 12, which leaves ~3 dB of DAC
+        headroom for the worst-case tone sum.  Values above 12 risk
+        railing the DAC, especially with many simultaneous tones.
 
         Specified in the pysmurf configuration file as
-        `amplitude_scale`.
+        ``amplitude_scale``, per band, under each ``band_N`` block.  The
+        config schema enforces the [0, 15] range; the firmware write
+        paths additionally log a warning when the value exceeds 12.
 
         See Also
         --------
-        ?
+        :func:`SmurfCommandMixin.set_amplitude_scale_array`
+        :func:`SmurfCommandMixin.set_amplitude_scale_channel`
+        :func:`SmurfCommandMixin.tone_power_to_db`
 
         """
         return self._amplitude_scale

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -1468,9 +1468,14 @@ class SmurfCommandMixin(SmurfBase):
             Per-channel tone amplitudes in [0, 15], length
             ``get_number_channels(band)``.
         """
+        arr = np.array(val).astype(np.uint)
+        if np.any(arr > 12):
+            self.log(
+                f'WARNING: amplitudeScale max={int(arr.max())} > 12 on '
+                f'band {band}.  DAC may rail with many simultaneous tones.')
         self._caput(
             self._cryo_root(band) + self._amplitude_scale_array_reg,
-            np.array(val).astype(np.uint), **kwargs)
+            arr, **kwargs)
 
     def get_amplitude_scale_array(self, band, **kwargs):
         """
@@ -2698,6 +2703,11 @@ class SmurfCommandMixin(SmurfBase):
         val : int
             Tone amplitude scale in [0, 15].
         """
+        if int(val) > 12:
+            self.log(
+                f'WARNING: amplitudeScale={int(val)} > 12 on '
+                f'band {band} channel {channel}.  '
+                f'DAC may rail with many simultaneous tones.')
         self._caput(
             self._channel_root(band, channel) +
             self._amplitude_scale_channel_reg,

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -2785,6 +2785,98 @@ class SmurfCommandMixin(SmurfBase):
                 'integer in [0,1,2,3,4,5,6,7] ...'
         return bay
 
+    @staticmethod
+    def tone_power_to_db(val):
+        """
+        Converts a raw amplitudeScale code to dB relative to the
+        conventional full-scale value of 12.  3 dB per LSB.
+
+        Args
+        ----
+        val : int
+            Raw amplitudeScale code in [0, 15].
+
+        Returns
+        -------
+        db : float
+            Tone power in dB relative to amplitudeScale = 12.  Negative
+            values are below conventional full scale; positive values
+            risk railing the DAC.
+        """
+        return 3.0 * (int(val) - 12)
+
+    @staticmethod
+    def tone_power_from_db(db):
+        """
+        Inverse of :func:`tone_power_to_db`.  Rounds to the nearest raw
+        amplitudeScale code.
+
+        Args
+        ----
+        db : float
+            Tone power in dB relative to amplitudeScale = 12.
+
+        Returns
+        -------
+        val : int
+            Raw amplitudeScale code in [0, 15].
+
+        Raises
+        ------
+        ValueError
+            If the rounded result falls outside [0, 15].
+        """
+        val = int(round(12 + db / 3.0))
+        if val < 0 or val > 15:
+            raise ValueError(
+                f'tone_power_from_db({db}) -> {val} out of [0, 15].')
+        return val
+
+    @staticmethod
+    def att_to_db(val):
+        """
+        Converts a raw 5-bit UC/DC attenuator code to dB of attenuation
+        relative to no attenuation.  0.5 dB per LSB.
+
+        Args
+        ----
+        val : int
+            Raw attenuator code in [0, 31].
+
+        Returns
+        -------
+        db : float
+            Attenuation in dB.  0 dB = no attenuation.
+        """
+        return 0.5 * int(val)
+
+    @staticmethod
+    def att_from_db(db):
+        """
+        Inverse of :func:`att_to_db`.  Rounds to the nearest raw 5-bit
+        attenuator code.
+
+        Args
+        ----
+        db : float
+            Attenuation in dB, relative to no attenuation.
+
+        Returns
+        -------
+        val : int
+            Raw attenuator code in [0, 31].
+
+        Raises
+        ------
+        ValueError
+            If the rounded result falls outside [0, 31].
+        """
+        val = int(round(db / 0.5))
+        if val < 0 or val > 31:
+            raise ValueError(
+                f'att_from_db({db}) -> {val} out of [0, 31].')
+        return val
+
     # Attenuator
     _uc_reg = 'UC[{}]'
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -1518,7 +1518,7 @@ class SmurfCommandMixin(SmurfBase):
         n_channels=self.get_number_channels(band)
         new_amp = np.zeros((n_channels,),dtype=np.uint)
         new_amp[np.where(old_amp!=0)] = tone_power
-        self.set_amplitude_scale_array(self, new_amp, **kwargs)
+        self.set_amplitude_scale_array(band, new_amp, **kwargs)
 
     _feedback_enable_array_reg = 'feedbackEnable'
 

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -1410,6 +1410,20 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_amplitude_scales(self, band, val, **kwargs):
         """
+        Sets the per-band scalar tone amplitude (``setAmplitudeScales``).
+        This is a single 4-bit unsigned integer in [0, 15] applied to every
+        channel of ``band``.  The conventional value is 12, which is full
+        scale with ~3 dB of headroom; each LSB is ~3 dB.  Values above 12
+        risk railing the DAC, especially with many simultaneous tones.
+        See :func:`tone_power_to_db` for the dB conversion.
+
+        Args
+        ----
+        band : int
+            The band to set.
+        val : int
+            Tone amplitude scale in [0, 15].  12 is the conventional
+            full-scale value.
         """
         self._caput(
             self._cryo_root(band) + self._amplitude_scales_reg,
@@ -1417,6 +1431,18 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_amplitude_scales(self, band, **kwargs):
         """
+        Gets the per-band scalar tone amplitude.  See
+        :func:`set_amplitude_scales` for units and range.
+
+        Args
+        ----
+        band : int
+            The band to query.
+
+        Returns
+        -------
+        val : int
+            Tone amplitude scale in [0, 15].
         """
         return self._caget(
             self._cryo_root(band) + self._amplitude_scales_reg,
@@ -1426,6 +1452,21 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_amplitude_scale_array(self, band, val, **kwargs):
         """
+        Sets the per-channel tone amplitude array (``amplitudeScale``) for
+        ``band``.  Each element is a 4-bit unsigned integer in [0, 15] with
+        ~3 dB per LSB; the conventional full-scale value is 12.  A value of
+        0 turns the channel off.  Values above 12 risk railing the DAC,
+        especially with many simultaneous tones, so a warning is logged
+        when any element exceeds 12.  See :func:`tone_power_to_db` for the
+        dB conversion.
+
+        Args
+        ----
+        band : int
+            The band to set.
+        val : int array
+            Per-channel tone amplitudes in [0, 15], length
+            ``get_number_channels(band)``.
         """
         self._caput(
             self._cryo_root(band) + self._amplitude_scale_array_reg,
@@ -1433,17 +1474,18 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_amplitude_scale_array(self, band, **kwargs):
         """
-        Gets the array of amplitudes
+        Gets the per-channel tone amplitude array.  See
+        :func:`set_amplitude_scale_array` for units and range.
 
         Args
         ----
         band : int
-            The band to search.
+            The band to query.
 
         Returns
         -------
-        amplitudes : array
-            The tone amplitudes.
+        amplitudes : int array
+            Per-channel tone amplitudes in [0, 15].
         """
         return self._caget(
             self._cryo_root(band) + self._amplitude_scale_array_reg,
@@ -1452,16 +1494,19 @@ class SmurfCommandMixin(SmurfBase):
     def set_amplitude_scale_array_currentchans(self, band, tone_power,
                                                **kwargs):
         """
-        Set only the currently on channels to a new drive power. Essentially
-        a more convenient wrapper for set_amplitude_scale_array to only change
-        the channels that are on.
+        Sets only the currently on channels to a new drive power.  A
+        convenience wrapper around :func:`set_amplitude_scale_array` that
+        preserves which channels are off (amplitude 0) and rewrites the
+        rest with ``tone_power``.
 
         Args
         ----
         band : int
             The band to change.
         tone_power : int
-            Tone power to change to.
+            Tone amplitude scale in [0, 15] to write to every on-channel.
+            12 is the conventional full-scale value; values > 12 risk
+            railing the DAC.  See :func:`set_amplitude_scale_array`.
         """
 
         old_amp = self.get_amplitude_scale_array(band, **kwargs)
@@ -2638,6 +2683,20 @@ class SmurfCommandMixin(SmurfBase):
     def set_amplitude_scale_channel(self, band, channel, val,
                                     **kwargs):
         """
+        Sets the tone amplitude (``amplitudeScale``) on a single channel.
+        The value is a 4-bit unsigned integer in [0, 15] with ~3 dB per
+        LSB; the conventional full-scale value is 12.  A value of 0 turns
+        the channel off.  Values above 12 risk railing the DAC and trigger
+        a warning.  See :func:`tone_power_to_db` for the dB conversion.
+
+        Args
+        ----
+        band : int
+            The band the channel belongs to.
+        channel : int
+            The channel index within ``band``.
+        val : int
+            Tone amplitude scale in [0, 15].
         """
         self._caput(
             self._channel_root(band, channel) +
@@ -2646,6 +2705,20 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_amplitude_scale_channel(self, band, channel, **kwargs):
         """
+        Gets the tone amplitude on a single channel.  See
+        :func:`set_amplitude_scale_channel` for units and range.
+
+        Args
+        ----
+        band : int
+            The band the channel belongs to.
+        channel : int
+            The channel index within ``band``.
+
+        Returns
+        -------
+        val : int
+            Tone amplitude scale in [0, 15].
         """
         return self._caget(
             self._channel_root(band, channel) +
@@ -2707,14 +2780,17 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_att_uc(self, b, val, **kwargs):
         """
-        Set the upconverter attenuator
+        Sets the up-converter (DAC-side) RF attenuator for ``b``.  The
+        value is a 5-bit unsigned integer in [0, 31] with 0.5 dB per LSB,
+        so 0 = no attenuation and 31 = 15.5 dB of attenuation.  See
+        :func:`att_to_db` for the dB conversion.
 
         Args
         ----
         b : int
             The band number.
         val : int
-            The attenuator value.
+            UC attenuator code in [0, 31].
         """
         att = int(self.band_to_att(b))
         bay = self.band_to_bay(b)
@@ -2724,12 +2800,18 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_att_uc(self, b, **kwargs):
         """
-        Get the upconverter attenuator value
+        Gets the up-converter RF attenuator code for ``b``.  See
+        :func:`set_att_uc` for units and range.
 
         Args
         ----
         b : int
             The band number.
+
+        Returns
+        -------
+        val : int
+            UC attenuator code in [0, 31].
         """
         att = int(self.band_to_att(b))
         bay = self.band_to_bay(b)
@@ -2742,14 +2824,17 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_att_dc(self, b, val, **kwargs):
         """
-        Set the down-converter attenuator
+        Sets the down-converter (ADC-side) RF attenuator for ``b``.  The
+        value is a 5-bit unsigned integer in [0, 31] with 0.5 dB per LSB,
+        so 0 = no attenuation and 31 = 15.5 dB of attenuation.  See
+        :func:`att_to_db` for the dB conversion.
 
         Args
         ----
         b : int
             The band number.
         val : int
-            The attenuator value
+            DC attenuator code in [0, 31].
         """
         att = int(self.band_to_att(b))
         bay = self.band_to_bay(b)
@@ -2759,12 +2844,18 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_att_dc(self, b, **kwargs):
         """
-        Get the down-converter attenuator value
+        Gets the down-converter RF attenuator code for ``b``.  See
+        :func:`set_att_dc` for units and range.
 
         Args
         ----
         b : int
             The band number.
+
+        Returns
+        -------
+        val : int
+            DC attenuator code in [0, 31].
         """
         att = int(self.band_to_att(b))
         bay = self.band_to_bay(b)


### PR DESCRIPTION
## Summary

Closes #123 and the linked #114.

Issue #123 has been open since 2019 and asks for three things on the `amplitudeScale` and UC/DC attenuator interfaces:

1. **Better docstrings** explaining what `amplitudeScale` is and why the conventional value is 12.
2. **A warning** when `amplitudeScale != 12` (in particular `> 12`, which has empirically caused DAC railing on >10 tones at amplitudeScale 14/15).
3. **Set attenuators and tone power in dB** rather than raw register codes (Dan's suggestion).

#114 is the docstring-only subset for UC/DC attenuators and is closed by the same docstring commit.

## What changed

Four atomic commits, all additive — no API breaks, no schema changes, no changes to tuning workflows.

### `docs(amplitudeScale,att_uc,att_dc): Document units, ranges, and DAC-rail risk (#123, #114)`

Fill in real docstrings for:

- `set_amplitude_scales` / `get_amplitude_scales`
- `set_amplitude_scale_array` / `get_amplitude_scale_array`
- `set_amplitude_scale_channel` / `get_amplitude_scale_channel`
- `set_amplitude_scale_array_currentchans`
- `set_att_uc` / `get_att_uc`
- `set_att_dc` / `get_att_dc`

Replace the placeholder `amplitude_scale` property docstring (literal `?` placeholders) in `SmurfConfigPropertiesMixin` with one that documents the [0, 15] range, the 3 dB / LSB convention, the meaning of 12 = full scale with ~3 dB DAC headroom, and links to the firmware write paths and the new dB helpers.

Attenuator docstrings document the [0, 31] 5-bit range, 0.5 dB / LSB convention, and that 0 = no attenuation.

### `feat(set_amplitude_scale_array,_channel): Warn when amplitudeScale > 12 (#123)`

`set_amplitude_scale_array` and `set_amplitude_scale_channel` now log a single `WARNING:` line on the firmware write path when any element / value exceeds 12.  Values ≤ 12 stay silent so routine low-power tuning is not noisy.  No API change; existing callers behave identically except for the new log line.

### `feat(SmurfCommandMixin): Add tone_power and att dB conversion helpers (#123)`

Four new `@staticmethod` helpers on `SmurfCommandMixin`:

- `tone_power_to_db(val)` — raw amplitudeScale → dB relative to 12.  3 dB / LSB.
- `tone_power_from_db(db)` — inverse, with bounds-check ValueError outside [0, 15].
- `att_to_db(val)` — raw 5-bit attenuator code → dB.  0.5 dB / LSB.
- `att_from_db(db)` — inverse, with bounds-check ValueError outside [0, 31].

Pure conversions, no register I/O.  Existing call sites are untouched; users who want to specify in dB call e.g. `S.set_att_uc(b, S.att_from_db(8))`.

### `fix(set_amplitude_scale_array_currentchans): Pass band, not self (#123)`

Latent bug spotted while editing the file: line 1471 called `self.set_amplitude_scale_array(self, new_amp, ...)` — passing the `SmurfControl` instance as the `band` argument.  Replaced `self` with `band`.

## Does this PR break any interface?

- [ ] Yes
- [X] No

All four commits are additive: new docstrings, a new log line on >12, four new public static helpers, and a one-character bugfix in a function that was broken anyway.  No existing callers change behavior except that they now see a warning when they pass amplitudeScale > 12, which is the user-visible intent of issue #123.

## Test plan

- [ ] `flake8 --count python/` — verified clean locally after every commit (matches the only gating CI check).
- [ ] Inspect rendered Sphinx docs for the updated docstrings.
- [ ] On hardware: confirm the `WARNING:` line appears in the log when calling `set_amplitude_scale_channel(b, c, 13)` and does not appear for `val=12`.
- [ ] On hardware: confirm `S.set_att_uc(b, S.att_from_db(8))` writes raw code 16, and `S.att_to_db(S.get_att_uc(b))` round-trips.
- [ ] Confirm no behavioral regression in `find_freq` / `setup_notches` / `tune_band_serial` / `full_band_resp` (the workflows that pull `tone_power` from `self._amplitude_scale[band]`).

## Intentionally NOT changed

- No new `tone_power_db` cfg field — adding a parallel knob doubles surface area and creates ambiguity if both are set.  Defer until concrete demand.
- No `set_*_db` / `get_*_db` wrapper methods — the static helpers are sufficient and avoid maintaining two parallel paths to the same register.
- No change to the schema range.  Issue #123 wants warnings, not a hard cap.
- No changes to `find_freq`, `setup_notches`, `tune_band_serial`, or `full_band_resp`.