### PR TITLE
fix(stream_data_on): Reset firmware phase offsets at stream start (#93)

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -820,6 +820,7 @@ class SmurfUtilMixin(SmurfBase):
     def take_stream_data(self, meas_time, downsample_factor=None,
                          write_log=True, update_payload_size=True,
                          reset_unwrapper=True, reset_filter=True,
+                         reset_phase_offsets=True,
                          return_data=False, make_freq_mask=True,
                          register_file=False, IQ_mode=False):
         """
@@ -847,6 +848,10 @@ class SmurfUtilMixin(SmurfBase):
             Whether to reset the unwrapper before taking data.
         reset_filter : bool, optional, default True
             Whether to reset the filter before taking data.
+        reset_phase_offsets : bool, optional, default True
+            Whether to clear firmware per-channel phase-offset unwrap
+            counters / averages before taking data. See
+            :func:`stream_data_on` for details.  See slaclab/pysmurf#93.
         return_data : bool, optional, default False
             Whether to return the data. If False, returns the full
             path to the data.
@@ -870,6 +875,7 @@ class SmurfUtilMixin(SmurfBase):
         data_filename = self.stream_data_on(downsample_factor=downsample_factor,
             update_payload_size=update_payload_size, write_log=write_log,
             reset_unwrapper=reset_unwrapper, reset_filter=reset_filter,
+            reset_phase_offsets=reset_phase_offsets,
             make_freq_mask=make_freq_mask, IQ_mode=IQ_mode)
 
         # Sleep for the full measurement time
@@ -917,6 +923,10 @@ class SmurfUtilMixin(SmurfBase):
             Whether to reset the filter before taking data.
         reset_unwrapper : bool, optional, default True
             Whether to reset the unwrapper before taking data.
+        reset_phase_offsets : bool, optional, default True
+            Whether to clear firmware per-channel phase-offset unwrap
+            counters / averages before taking data. See
+            :func:`stream_data_on` for details.  See slaclab/pysmurf#93.
         make_freq_mask : bool, optional, default True
             Whether to write a text file with resonator frequencies.
         register_file : bool, optional, default False
@@ -939,7 +949,8 @@ class SmurfUtilMixin(SmurfBase):
     def stream_data_on(self, write_config=False, data_filename=None,
                        downsample_factor=None, write_log=True,
                        update_payload_size=True, reset_filter=True,
-                       reset_unwrapper=True, make_freq_mask=True,
+                       reset_unwrapper=True, reset_phase_offsets=True,
+                       make_freq_mask=True,
                        channel_mask=None, make_datafile=True,
                        filter_wait_time=0.1,IQ_mode=False):
         """
@@ -966,6 +977,13 @@ class SmurfUtilMixin(SmurfBase):
             Whether to reset the filter before taking data.
         reset_unwrapper : bool, optional, default True
             Whether to reset the unwrapper before taking data.
+        reset_phase_offsets : bool, optional, default True
+            Whether to clear the firmware per-channel phase-offset
+            unwrap counters and channel averages by toggling bit 0 of
+            ``AMCc.AppCore.TimingHeader.userConfig[0]`` high then low.
+            Prevents accumulated wrap counts from approaching the
+            32-bit limit, where double-precision filter math loses
+            resolution.  See slaclab/pysmurf#93.
         make_freq_mask : bool, optional, default True
             Whether to write a text file with resonator frequencies.
         channel_mask : list or None, optional, default None
@@ -1044,6 +1062,18 @@ class SmurfUtilMixin(SmurfBase):
             # start streaming before opening file
             # to avoid transient filter step
             self.set_stream_enable(1, write_log=False, wait_done=True)
+
+            if reset_phase_offsets:
+                # Clear firmware per-channel unwrap counters and
+                # averages before the software unwrapper/filter latch
+                # state. See slaclab/pysmurf#93.
+                try:
+                    self.clear_unwrapping_and_averages()
+                except Exception as e:
+                    self.log(
+                        'clear_unwrapping_and_averages() failed; '
+                        'continuing without firmware phase-offset '
+                        f'reset. ({e})', self.LOG_ERROR)
 
             if reset_unwrapper:
                 self.set_unwrapper_reset(write_log=write_log)


### PR DESCRIPTION
## Summary
- Wires the existing `clear_unwrapping_and_averages()` helper (`smurf_command.py:5439`, present since 2019 with zero callers) into `stream_data_on()` / `take_stream_data()` behind a new `reset_phase_offsets=True` kwarg, matching the existing `reset_unwrapper` / `reset_filter` pattern.
- The helper toggles bit 0 of `AMCc.AppCore.TimingHeader.userConfig[0]` to clear per-channel firmware unwrap counters and averages — without this, long runs (e.g. Pole) accumulate offsets approaching the 32-bit limit and the downstream double-precision filter loses resolution.
- Order is firmware reset *after* `set_stream_enable(1)` but *before* the software unwrapper/filter resets, so the software state machines latch on clean firmware data instead of the toggle transient.
- Wrapped in `try/except` so a firmware-version mismatch or CA race logs an error rather than breaking every `take_stream_data()` call.
- Issue #93's secondary suggestion (periodic background reset "even when not taking data") is out of scope — it needs a timer/config knob and addresses a less-severe case.

Closes #93.

## Test plan
- [x] `flake8 --count python/` — 0 errors (matches CI in `.github/workflows/test-or-deploy.yml`).
- [ ] **Drift test on hardware**: stream with `reset_phase_offsets=True` (new default) for ~10 min, stop, then start a second stream with `reset_phase_offsets=False`. Run 1 should start near zero per channel; run 2 should start near where run 1 ended.
- [ ] **No-regression check**: on a clean system, compare `take_stream_data(meas_time=10)` PSDs with the new default vs. `reset_phase_offsets=False` — should be identical within noise.
- [ ] **Failure-path check**: monkey-patch `clear_unwrapping_and_averages` to raise; confirm `take_stream_data` still returns a data file and a `LOG_ERROR` line appears.