### PR TITLE
fix(read_stream_data_daq): Detect streaming PV truncation (#83)

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -1627,6 +1627,16 @@ class SmurfUtilMixin(SmurfBase):
             hardware trigger.
         write_log : bool, optional, default False
             Whether to write outputs to log.
+
+        Raises
+        ------
+        ValueError
+            If the streaming PV returns fewer samples than ``data_length``.
+            The streaming waveform PVs are sized at rogue-server startup
+            via the ``-b`` flag (typically ``-b 524288`` = ``2**19``); a
+            larger request is silently truncated by EPICS, so this check
+            surfaces the truncation rather than letting callers consume a
+            short array.
         """
         # Ask mitch why this is what it is...
         if bay == 0:
@@ -1651,6 +1661,20 @@ class SmurfUtilMixin(SmurfBase):
 
         r0 = vals[pvs[0]]
         r1 = vals[pvs[1]]
+
+        got = min(len(r0), len(r1))
+        if got < data_length:
+            msg = (
+                f'Requested data_length={data_length} samples but the '
+                f'streaming PVs ({stream0}, {stream1}) returned only '
+                f'{got}. These waveform PVs are sized at rogue-server '
+                f'startup via the `-b` flag (typically `-b 524288` = '
+                f'2**19). To capture more samples, restart the rogue '
+                f'server with a larger `-b` value, or request fewer '
+                f'samples.'
+            )
+            self.log(msg, self.LOG_ERROR)
+            raise ValueError(msg)
 
         return r0, r1
 


### PR DESCRIPTION
## Summary

Closes #83.

The rogue-server EPICS waveform PVs (`AMCc.Stream{0..3}.Data`) are sized at server startup via the `-b` flag (typically `-b 524288` = 2**19). Requests for `data_length` larger than that buffer were silently truncated to the buffer size, so `read_adc_data` and `read_dac_data` returned a short array with no warning to the caller — exactly the behavior reported in #83.

This patch adds a post-hoc length check in `read_stream_data_daq` (the single choke point both `read_adc_data` and `read_dac_data` funnel through). After `SyncGroup.wait()`, it compares `len(r0)` / `len(r1)` against the requested `data_length` and raises `ValueError` with a message pointing the user at the rogue-server `-b` flag when the read came up short.

## Approach notes

- **Post-hoc rather than pre-flight.** A pre-flight check would require introspecting the pyrogue Variable's allocated size before triggering the DAQ. That introspection API is not used anywhere else in the pysmurf client and would be vulnerable to rogue-version drift. Detecting the truncation after the read is reliable regardless of where the truncation comes from.
- **One change site.** Both `read_adc_data` and `read_dac_data` use `read_stream_data_daq`, so the check covers both paths without duplication. Consistent with the issue's request that *functions know this limit and warn when exceeded*.
- **Raise, not warn.** The bug being reported is silent truncation; a warning that callers can miss would not close the issue's intent.

## Out of scope

- `take_debug_data` uses BSA waveform engine memory rather than the streaming PVs and has its own limit. That's being addressed in PR #959.
- The ADC railing warning is separately handled in PR #950.
- Exposing the buffer size as a server-side read-only PV (the @swh76 follow-up suggestion in the issue thread) is a rogue/smurf2mce change, not pysmurf.

## Test plan

- [x] `flake8 --count python/` (matches `.github/workflows/test-or-deploy.yml`) — 0 errors.
- [x] `python -m py_compile python/pysmurf/client/util/smurf_util.py` — clean.
- [ ] On hardware: `S.read_adc_data(band=0, data_length=2**19)` — runs unchanged.
- [ ] On hardware: `S.read_adc_data(band=0, data_length=2**20)` — raises `ValueError` with a message about the `-b` flag instead of silently returning a 2**19 array.
- [ ] On hardware: `S.read_dac_data(band=0, data_length=2**20)` — same expectation.
- [ ] On hardware: `S.check_adc_saturation(band=0)` and `S.check_dac_saturation(band=0)` — unchanged (they request `2**12`, well under the cap).