### PR TITLE
feat(smurf_config): separate Rcable + cryostat-card cfg files (#86)

### DIFF
--- a/README.config_file.md
+++ b/README.config_file.md
@@ -68,7 +68,45 @@ This defines which timing master to use. The available values are "ext_ref" and 
 These are other variables that are in the top level of the config table. Several of these should probably be moved, but for now just know they exist.
 
 - `R_sh` - The resistance of the shunt resistor in Ohms
-- `bias_line_resistance`- The resistance of cabling from cryocard to the TES.
+- `bias_line_resistance`- The total round-trip TES bias-line resistance in low-current mode, in Ohms.  Includes both the inline resistance on the cryostat card and the cryocable resistance.  May be supplied directly (legacy single-value path) or derived from `Rcable` plus the cryostat-card resistance loaded from a card cfg file (see [Cryostat-card cfg files](#cryostat-card-cfg-files) below).  An explicitly set `bias_line_resistance` always takes precedence.
+- `Rcable` - Optional.  Round-trip TES bias-cable resistance plus any cold resistors, in Ohms, with the cryostat-card resistance excluded.  When paired with a cryostat-card cfg that supplies `R_cryostat_card`, the loader sets `bias_line_resistance = Rcable + R_cryostat_card` automatically.  Ignored if `bias_line_resistance` is set explicitly.
+- `cryostat_card_config_file` - Optional.  Path to a separate JSON cfg file holding cryostat-card-specific values (`R_cryostat_card`, `high_low_current_ratio`, `pic_to_bias_group`, `bias_group_to_pair`).  Resolved relative to the main cfg's directory if not absolute.  See [Cryostat-card cfg files](#cryostat-card-cfg-files) below.
 - `tune_dir`- The directory where the tuning files are stored. Tuning files define the resonator frequencies and the channel assignments
 - `default_data_dir`- The directory where the output data is stored. Output data can include anything from eta-scans to tracked resonator timestreams
 - `high_low_current_ratio` - The ratio between the high current mode (no filtering) and low current mode (with lowpass filter)
+
+# Cryostat-card cfg files
+
+Cryostat-card-specific values can live in a separate cfg file shared
+across experiment cfgs that use the same physical card.  Reference one
+from the main cfg via `cryostat_card_config_file`:
+
+```jsonc
+{
+    "cryostat_card_config_file" : "../cryostat_cards/cc02-06.cfg",
+    "Rcable" : 29.1,
+    "R_sh"   : 750e-6
+    // bias_line_resistance, high_low_current_ratio, pic_to_bias_group,
+    // and bias_group_to_pair are loaded from the card cfg.
+}
+```
+
+The card cfg encodes the resistors loaded onto the card and the card's
+PIC-to-bias-group / bias-group-to-DAC-pair maps:
+
+```jsonc
+{
+    "card_id"                : "cc02-06",
+    "R_cryostat_card"        : 16505.0,
+    "high_low_current_ratio" : 8.084,
+    "pic_to_bias_group"      : { "0": 0, "1": 1, "...": "..." },
+    "bias_group_to_pair"     : { "0": [1, 2], "1": [3, 4], "...": "..." }
+}
+```
+
+Two example card cfgs ship in `cfg_files/cryostat_cards/`.  See
+`cfg_files/cryostat_cards/README.md` for full merge semantics.
+
+If both the main cfg and the card cfg set the same key, the main cfg
+wins (explicit override) and a notice is printed.  This makes it easy
+to start from a card cfg and tweak a single value per deployment.

--- a/cfg_files/cryostat_cards/README.md
+++ b/cfg_files/cryostat_cards/README.md
@@ -1,0 +1,57 @@
+# Cryostat-card configuration files
+
+This directory holds reusable, hardware-specific configuration files for
+individual cryostat cards.  A cryostat-card cfg encodes everything that
+depends on the card itself (the resistors loaded onto the card, the PIC
+to bias-group mapping, and the bias group to RTM DAC pair mapping) so
+that a given card cfg can be referenced from multiple experiment cfgs
+that share the same physical card.
+
+A main pysmurf experiment cfg references a card cfg via the optional
+top-level `cryostat_card_config_file` key (resolved relative to the
+experiment cfg's directory if not absolute):
+
+```jsonc
+{
+    // ... other experiment cfg keys ...
+    "cryostat_card_config_file" : "../cryostat_cards/cc02-06.cfg",
+    "Rcable" : 29.1,    // round-trip cable + cold-resistor resistance, ohms
+    "R_sh" : 750e-6,
+    // bias_line_resistance, high_low_current_ratio, pic_to_bias_group,
+    // and bias_group_to_pair are all loaded from the card cfg.
+}
+```
+
+When loaded, the merge pass in `SmurfConfig.read()`:
+
+1. Reads the card cfg and copies `R_cryostat_card`,
+   `high_low_current_ratio`, `pic_to_bias_group`, and `bias_group_to_pair`
+   into the experiment cfg if those keys are not already set.  If a key
+   is set in both, the experiment cfg wins (explicit override) and a
+   notice is printed.
+2. Computes `bias_line_resistance = Rcable + R_cryostat_card` if the
+   experiment cfg did not set `bias_line_resistance` explicitly.
+
+An explicitly set `bias_line_resistance` always takes precedence
+(legacy single-value path), so existing experiment cfgs that bake the
+total in directly continue to work unchanged.
+
+## Card-cfg shape
+
+```jsonc
+{
+    "card_id"                : "cc02-06",  // free-form identifier
+    "R_cryostat_card"        : 16505.0,    // round-trip card-only resistance, ohms
+    "high_low_current_ratio" : 8.084,
+    "pic_to_bias_group"      : { "0": 0, "1": 1, ... },
+    "bias_group_to_pair"     : { "0": [1, 2], "1": [3, 4], ... }
+}
+```
+
+## Why not auto-detect the card?
+
+`CryoCard.get_fw_version()` only distinguishes the major version (C02
+vs C04), not which loadout is on the card.  Cards of the same type can
+have different on-card resistor values across deployments (e.g. C2-06
+vs C2-02 differ).  Auto-detection would silently use the wrong values,
+so card cfgs are referenced explicitly.

--- a/cfg_files/cryostat_cards/cc02-06.cfg
+++ b/cfg_files/cryostat_cards/cc02-06.cfg
@@ -1,0 +1,52 @@
+# Cryostat-card cfg for the C2-06 cryostat card.
+#
+# Source: cfg_files/ucsd/experiment_ucsd_k2so_cc02-06_lbOnlyBay0.cfg.
+# Each TES bias line on C2-06 was loaded with 6x 2.4k + 2x 1k = 16.4k
+# total design resistance.  R_cryostat_card below is the measured
+# card-only value (29.1 Ohm cable subtracted from the total 16534.1
+# Ohm reported in the source cfg).  Card measurements are summarized
+# in the C02-06 TID HWDB entry C02-06_swh_20190819.xls.
+
+{
+    "card_id" : "cc02-06",
+
+    "R_cryostat_card" : 16505.0,
+    "high_low_current_ratio" : 8.084,
+
+    "pic_to_bias_group" : {
+        "0"  : 0,
+        "1"  : 1,
+        "2"  : 2,
+        "3"  : 3,
+        "4"  : 4,
+        "5"  : 5,
+        "6"  : 6,
+        "7"  : 7,
+        "8"  : 8,
+        "9"  : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+    },
+
+    "bias_group_to_pair" : {
+        "0"  : [1, 2],
+        "1"  : [3, 4],
+        "2"  : [5, 6],
+        "3"  : [7, 8],
+        "4"  : [9, 10],
+        "5"  : [11, 12],
+        "6"  : [13, 14],
+        "7"  : [15, 16],
+        "8"  : [17, 18],
+        "9"  : [19, 20],
+        "10" : [21, 22],
+        "11" : [23, 24],
+        "12" : [25, 26],
+        "13" : [27, 28],
+        "14" : [29, 30]
+    }
+}

--- a/cfg_files/cryostat_cards/cc02-template.cfg
+++ b/cfg_files/cryostat_cards/cc02-template.cfg
@@ -1,0 +1,47 @@
+# Generic C02 cryostat-card cfg template.
+#
+# Source: cfg_files/template/template.cfg (R_cryostat_card and
+# high_low_current_ratio mirror the placeholder values used there).
+# Replace R_cryostat_card and high_low_current_ratio with values
+# measured for your specific card before relying on this cfg.
+
+{
+    "card_id" : "cc02-template",
+
+    "R_cryostat_card" : 15800.0,
+    "high_low_current_ratio" : 6.08,
+
+    "pic_to_bias_group" : {
+        "0"  : 0,
+        "1"  : 1,
+        "2"  : 2,
+        "3"  : 3,
+        "4"  : 4,
+        "5"  : 5,
+        "6"  : 6,
+        "7"  : 7,
+        "8"  : 8,
+        "9"  : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+    },
+
+    "bias_group_to_pair" : {
+        "0"  : [1, 2],
+        "1"  : [3, 4],
+        "2"  : [5, 6],
+        "3"  : [7, 8],
+        "4"  : [9, 10],
+        "5"  : [11, 12],
+        "6"  : [13, 14],
+        "7"  : [15, 16],
+        "8"  : [17, 18],
+        "9"  : [19, 20],
+        "10" : [21, 22],
+        "11" : [23, 24]
+    }
+}

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -143,6 +143,67 @@ class SmurfConfig:
         loaded_config = json.loads('\n'.join(no_comments))
         return loaded_config
 
+    @staticmethod
+    def _merge_cryostat_card_config(loaded_config, parent_filename=None):
+        """Merge a referenced cryostat-card config file into ``loaded_config``.
+
+        If ``loaded_config`` sets the optional top-level
+        ``cryostat_card_config_file`` key, reads that file (path
+        resolved relative to ``parent_filename``'s directory if not
+        absolute) and merges its values into ``loaded_config``.  For
+        each of the keys ``R_cryostat_card``, ``high_low_current_ratio``,
+        ``pic_to_bias_group``, and ``bias_group_to_pair``, the card-cfg
+        value is used only if the key is absent from the main config;
+        if the key is set in both, the main config wins (explicit
+        override) and a notice is printed.
+
+        Additionally, if ``bias_line_resistance`` is not set in the
+        main config but both ``Rcable`` and ``R_cryostat_card`` are
+        resolved, sets ``bias_line_resistance = Rcable + R_cryostat_card``.
+        An explicitly set ``bias_line_resistance`` is always honored
+        (the legacy override path), independent of ``Rcable``.
+
+        Args
+        ----
+        loaded_config : dict
+            Configuration dictionary as loaded from the main pysmurf
+            cfg file.  Modified in place and also returned.
+        parent_filename : str or None, optional, default None
+            Path to the main pysmurf cfg file; used to resolve a
+            relative ``cryostat_card_config_file`` path.  If None, only
+            absolute paths can be resolved.
+
+        Returns
+        -------
+        loaded_config : dict
+            The same dictionary, with merged-in card cfg values and a
+            computed ``bias_line_resistance`` if applicable.
+        """
+        card_path = loaded_config.get('cryostat_card_config_file')
+        if card_path is not None:
+            if not os.path.isabs(card_path) and parent_filename is not None:
+                card_path = os.path.join(
+                    os.path.dirname(os.path.abspath(parent_filename)),
+                    card_path)
+            card_config = SmurfConfig.read_json(card_path)
+            for key in ('R_cryostat_card', 'high_low_current_ratio',
+                        'pic_to_bias_group', 'bias_group_to_pair'):
+                if key in card_config:
+                    if key in loaded_config:
+                        print(f'cryostat_card_config_file: main config '
+                              f'overrides card cfg key {key!r}')
+                    else:
+                        loaded_config[key] = card_config[key]
+
+        if ('bias_line_resistance' not in loaded_config and
+                'Rcable' in loaded_config and
+                'R_cryostat_card' in loaded_config):
+            loaded_config['bias_line_resistance'] = (
+                float(loaded_config['Rcable']) +
+                float(loaded_config['R_cryostat_card']))
+
+        return loaded_config
+
     def read(self, update=False, validate=True):
         """Read config file and update the config dictionary.
 
@@ -182,6 +243,12 @@ class SmurfConfig:
             dictionary.
         """
         config = self.read_json(self.filename)
+
+        # Merge in a referenced cryostat-card config file, if any, and
+        # derive bias_line_resistance from Rcable + R_cryostat_card if
+        # the user supplied them instead of bias_line_resistance.
+        config = self._merge_cryostat_card_config(
+            config, parent_filename=self.filename)
 
         # validate
         if validate:
@@ -475,15 +542,24 @@ class SmurfConfig:
         #### Done specifying attenuator schema
 
         #### Start specifying cryostat card schema
-        ## SHOULD MAKE IT SO THAT WE JUST LOAD AND VALIDATE A SEPARATE,
-        ## HARDWARE SPECIFIC CRYOSTAT CARD CONFIG FILE.  FOR NOW, JUST DO
-        ## SOME VERY BASIC VALIDATION.
+        # `pic_to_bias_group` and `bias_group_to_pair` are
+        # cryostat-card-specific.  They may be supplied either inline
+        # in the main pysmurf cfg or in a separate cryostat-card cfg
+        # file referenced via the optional `cryostat_card_config_file`
+        # top-level key (see `_merge_cryostat_card_config`).  The merge
+        # pass runs before schema validation, so by this point both
+        # keys are required to be present in the merged dict.
         def represents_int(string):
             try:
                 int(string)
                 return True
             except ValueError:
                 return False
+
+        # Optional path to a cryostat-card cfg file.  When set, the
+        # merge pass copies card-specific keys from that file into the
+        # main config before validation.
+        schema_dict[Optional("cryostat_card_config_file")] = str
 
         schema_dict["pic_to_bias_group"] = {And(str, represents_int) : int}
         schema_dict["bias_group_to_pair"] = {And(str, represents_int) : [int, int]}
@@ -710,8 +786,17 @@ class SmurfConfig:
         schema_dict["R_sh"] = And(Use(float), lambda f: f > 0)
 
         # Round-trip resistance on TES bias lines, in low current mode.
-        # Includes the resistance on the cryostat cards, and cable resistance.
+        # Includes the resistance on the cryostat cards, and cable
+        # resistance.  May be supplied directly (legacy path) or
+        # derived in `_merge_cryostat_card_config` from `Rcable` plus
+        # the cryostat-card `R_cryostat_card`.
         schema_dict["bias_line_resistance"] = And(Use(float), lambda f: f > 0)
+
+        # Round-trip resistance of the TES bias cable plus any in-line
+        # cold resistors, with the cryostat-card resistance excluded.
+        # Optional; only consulted if `bias_line_resistance` is not
+        # set explicitly.  See `_merge_cryostat_card_config`.
+        schema_dict[Optional("Rcable")] = And(Use(float), lambda f: f > 0)
 
         # Ratio between the current per DAC unit in high current mode to the
         # current in low current mode.  Constained to be greater than or equal

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -157,6 +157,7 @@ class SmurfConfigPropertiesMixin:
 
         # Cryocard
         self._bias_line_resistance = None
+        self._Rcable = None
         self._high_low_current_ratio = None
         self._high_current_mode_bool = None
         self._pic_to_bias_group = None
@@ -331,6 +332,7 @@ class SmurfConfigPropertiesMixin:
 
         ## Cryocard
         self.bias_line_resistance = config.get('bias_line_resistance')
+        self.Rcable = config.get('Rcable')
         self.high_low_current_ratio = config.get('high_low_current_ratio')
         self.high_current_mode_bool = config.get('high_current_mode_bool')
         # Mapping from peripheral interface controller (PIC) to bias group
@@ -1132,6 +1134,44 @@ class SmurfConfigPropertiesMixin:
         self._bias_line_resistance = value
 
     ## End bias_line_resistance property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start Rcable property definition
+
+    # Getter
+    @property
+    def Rcable(self):
+        """TES bias cable-only round-trip resistance.
+
+        Gets or sets the round-trip TES bias cable resistance,
+        excluding the inline resistance on the cryostat card.  The
+        cryostat-card resistance is supplied separately via
+        ``R_cryostat_card`` (typically loaded from a cryostat-card cfg
+        file referenced by ``cryostat_card_config_file``).  When both
+        are provided and ``bias_line_resistance`` is not set
+        explicitly, the loader computes ``bias_line_resistance =
+        Rcable + R_cryostat_card``.  Units are Ohms.
+
+        ``None`` if the user supplied ``bias_line_resistance``
+        directly (the legacy single-value path).
+
+        Specified in the pysmurf configuration file as ``Rcable``.
+
+        Returns
+        -------
+        float or None
+            Round-trip TES bias cable resistance in Ohms, or ``None``
+            if not specified.
+        """
+        return self._Rcable
+
+    # Setter
+    @Rcable.setter
+    def Rcable(self, value):
+        self._Rcable = value
+
+    ## End Rcable property definition
     ###########################################################################
 
     ###########################################################################

--- a/tests/client/validate_cryostat_card_config.py
+++ b/tests/client/validate_cryostat_card_config.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : SmurfConfig Cryostat-Card Cfg Validation Script
+#-----------------------------------------------------------------------------
+# File       : validate_cryostat_card_config.py
+# Created    : 2026-05-01
+#-----------------------------------------------------------------------------
+# Description:
+# Validates the cryostat-card cfg merge pass added for issue #86: a
+# separate `Rcable` cfg variable plus a `cryostat_card_config_file`
+# pointer that pulls card-specific values out of a shared cfg file.
+#
+# Exercises four scenarios:
+#   1. Legacy path: an experiment cfg that sets `bias_line_resistance`
+#      directly continues to load unchanged.
+#   2. New path: an experiment cfg that sets `Rcable` and references a
+#      card cfg via `cryostat_card_config_file` resolves
+#      `bias_line_resistance = Rcable + R_cryostat_card`.
+#   3. Override: when both legacy and new keys are present, the
+#      explicit `bias_line_resistance` wins.
+#   4. Missing: a cfg that references a card cfg but supplies neither
+#      `Rcable` nor `bias_line_resistance` fails schema validation.
+#
+# Runs without hardware.  Exit 0 on pass.
+#-----------------------------------------------------------------------------
+# This file is part of the pysmurf software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level
+# directory of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the pysmurf software platform, including this file, may
+# be copied, modified, propagated, or distributed except according to
+# the terms contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+def _load_smurf_config_class():
+    """Import the SmurfConfig class without triggering pysmurf.client's
+    eager import chain (which depends on a working pyrogue install).
+    """
+    module_path = os.path.join(
+        REPO_ROOT, 'python', 'pysmurf', 'client', 'base', 'smurf_config.py')
+    spec = importlib.util.spec_from_file_location(
+        'pysmurf_smurf_config_under_test', module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.SmurfConfig
+
+
+SmurfConfig = _load_smurf_config_class()
+TEMPLATE_CFG = os.path.join(REPO_ROOT, 'cfg_files', 'template', 'template.cfg')
+CARD_CFG = os.path.join(
+    REPO_ROOT, 'cfg_files', 'cryostat_cards', 'cc02-template.cfg')
+
+
+def _load_template_dict(tmpdir):
+    """Read the shipped template cfg and rewrite filesystem-validated
+    directory keys to writable subdirs of ``tmpdir`` so the cfg can
+    validate on hosts without ``/data/smurf_data``.
+    """
+    cfg_dict = SmurfConfig.read_json(TEMPLATE_CFG)
+    for key in ('default_data_dir', 'smurf_cmd_dir', 'tune_dir',
+                'status_dir'):
+        sub = os.path.join(tmpdir, key)
+        os.makedirs(sub, exist_ok=True)
+        cfg_dict[key] = sub
+    return cfg_dict
+
+
+def _write_cfg(path, cfg_dict):
+    """Write a cfg dict to ``path`` as JSON."""
+    with open(path, 'w') as f:
+        json.dump(cfg_dict, f, indent=2)
+
+
+def test_legacy_path(tmpdir):
+    """Legacy `bias_line_resistance` cfgs continue to load unchanged."""
+    cfg_dict = _load_template_dict(tmpdir)
+    cfg_path = os.path.join(tmpdir, 'experiment_legacy.cfg')
+    _write_cfg(cfg_path, cfg_dict)
+
+    cfg = SmurfConfig(cfg_path)
+    assert cfg.config['bias_line_resistance'] == 15800, (
+        f"expected 15800, got {cfg.config['bias_line_resistance']}")
+    assert cfg.config['high_low_current_ratio'] == 6.08, (
+        f"expected 6.08, got {cfg.config['high_low_current_ratio']}")
+    assert 'pic_to_bias_group' in cfg.config
+    assert 'bias_group_to_pair' in cfg.config
+    print('PASS  legacy_path: template-style cfg loads with '
+          'bias_line_resistance=15800')
+
+
+def test_new_path(tmpdir):
+    """`Rcable` + card cfg → bias_line_resistance is computed."""
+    cfg_dict = _load_template_dict(tmpdir)
+    # Strip the keys that should now flow in from the card cfg.
+    for key in ('bias_line_resistance', 'high_low_current_ratio',
+                'pic_to_bias_group', 'bias_group_to_pair'):
+        cfg_dict.pop(key, None)
+    cfg_dict['Rcable'] = 100.0
+    cfg_dict['cryostat_card_config_file'] = CARD_CFG  # absolute path
+
+    new_cfg_path = os.path.join(tmpdir, 'experiment_new_path.cfg')
+    _write_cfg(new_cfg_path, cfg_dict)
+
+    cfg = SmurfConfig(new_cfg_path)
+    expected = 100.0 + 15800.0
+    assert cfg.config['bias_line_resistance'] == expected, (
+        f"expected {expected}, got {cfg.config['bias_line_resistance']}")
+    assert cfg.config['high_low_current_ratio'] == 6.08
+    assert cfg.config['pic_to_bias_group']
+    assert cfg.config['bias_group_to_pair']
+    assert cfg.config['Rcable'] == 100.0
+    print('PASS  new_path: Rcable + R_cryostat_card sums to '
+          f'bias_line_resistance={expected}')
+
+
+def test_override_path(tmpdir):
+    """Explicit `bias_line_resistance` wins over Rcable + card cfg."""
+    cfg_dict = _load_template_dict(tmpdir)
+    cfg_dict['bias_line_resistance'] = 99999.0  # explicit override
+    cfg_dict['Rcable'] = 100.0
+    cfg_dict['cryostat_card_config_file'] = CARD_CFG
+
+    cfg_path = os.path.join(tmpdir, 'experiment_override.cfg')
+    _write_cfg(cfg_path, cfg_dict)
+
+    cfg = SmurfConfig(cfg_path)
+    assert cfg.config['bias_line_resistance'] == 99999.0, (
+        f"explicit override expected 99999.0, got "
+        f"{cfg.config['bias_line_resistance']}")
+    print('PASS  override_path: legacy bias_line_resistance=99999 '
+          'wins over Rcable+card cfg')
+
+
+def test_missing_path(tmpdir):
+    """Card cfg without Rcable or bias_line_resistance → validation fails."""
+    cfg_dict = _load_template_dict(tmpdir)
+    for key in ('bias_line_resistance', 'high_low_current_ratio',
+                'pic_to_bias_group', 'bias_group_to_pair'):
+        cfg_dict.pop(key, None)
+    cfg_dict['cryostat_card_config_file'] = CARD_CFG
+    # Note: no Rcable, no bias_line_resistance.
+
+    cfg_path = os.path.join(tmpdir, 'experiment_missing.cfg')
+    _write_cfg(cfg_path, cfg_dict)
+
+    raised = False
+    try:
+        SmurfConfig(cfg_path)
+    except Exception as exc:  # noqa: BLE001 - schema raises SchemaError
+        raised = True
+        msg = str(exc)
+        assert 'bias_line_resistance' in msg, (
+            f"expected schema error to mention bias_line_resistance, "
+            f"got: {msg}")
+    assert raised, 'expected SmurfConfig to raise without bias_line_resistance'
+    print('PASS  missing_path: schema rejects cfg with neither Rcable '
+          'nor bias_line_resistance')
+
+
+def test_relative_card_path(tmpdir):
+    """`cryostat_card_config_file` is resolved relative to main cfg dir."""
+    # Put a copy of the card cfg next to the experiment cfg so a bare
+    # filename resolves correctly.
+    local_card = os.path.join(tmpdir, 'cc02-template.cfg')
+    shutil.copy(CARD_CFG, local_card)
+
+    cfg_dict = _load_template_dict(tmpdir)
+    for key in ('bias_line_resistance', 'high_low_current_ratio',
+                'pic_to_bias_group', 'bias_group_to_pair'):
+        cfg_dict.pop(key, None)
+    cfg_dict['Rcable'] = 50.0
+    cfg_dict['cryostat_card_config_file'] = 'cc02-template.cfg'  # relative
+
+    cfg_path = os.path.join(tmpdir, 'experiment_relative.cfg')
+    _write_cfg(cfg_path, cfg_dict)
+
+    cfg = SmurfConfig(cfg_path)
+    assert cfg.config['bias_line_resistance'] == 50.0 + 15800.0
+    print('PASS  relative_card_path: relative card cfg path resolved '
+          'against main cfg dir')
+
+
+def main():
+    failures = []
+    tests = [test_legacy_path, test_new_path, test_override_path,
+             test_missing_path, test_relative_card_path]
+    for fn in tests:
+        # Each test gets its own tempdir so tmpdir-rooted paths don't
+        # collide between tests (e.g. each writes a different cfg file
+        # into the same dir, but more importantly cached state from one
+        # test's cfg file doesn't leak into the next).
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                fn(tmpdir)
+            except Exception as exc:  # noqa: BLE001
+                failures.append((fn.__name__, repr(exc)))
+                print(f'FAIL  {fn.__name__}: {exc!r}')
+
+    if failures:
+        print(f'\n{len(failures)} test(s) failed:')
+        for name, err in failures:
+            print(f'  - {name}: {err}')
+        sys.exit(1)
+
+    print('\nAll cryostat-card cfg tests passed.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Closes #86. Splits TES bias-line resistance into two new optional cfg keys so a single cryostat-card cfg file can be shared across experiment cfgs that use the same physical card:

- `Rcable` — round-trip cable + cold-resistor resistance (cryostat-card resistance excluded).
- `cryostat_card_config_file` — path to a card-specific cfg file holding `R_cryostat_card`, `high_low_current_ratio`, `pic_to_bias_group`, and `bias_group_to_pair`.

When both are provided, the loader sets `bias_line_resistance = Rcable + R_cryostat_card`. An explicit `bias_line_resistance` in the main cfg always wins, so every existing cfg loads unchanged (full backward compat).

The merge pass runs in `SmurfConfig.read()` before schema validation. If a card-cfg key is also set in the main cfg, the main cfg wins and a notice is printed — making it easy to start from a card cfg and tweak one value per deployment.

Two example card cfgs ship under `cfg_files/cryostat_cards/`:
- `cc02-06.cfg` — seeded from the existing UCSD C2-06 experiment cfg (16505 Ω card-only, 8.084 high/low ratio).
- `cc02-template.cfg` — generic C02 template matching `cfg_files/template/template.cfg` values.

This addresses the explicit TODO that's been in `smurf_config.py:478-480` since the cryostat-card schema was first added.

## Why not auto-detect via `CryoCard.get_fw_version()`?

`get_fw_version()` only distinguishes the major version (C02 vs C04), not which loadout is on the card. Cards of the same type can have different on-card resistor values across deployments (e.g. C2-06 vs C2-02 — confirmed by grep across `cfg_files/`). Auto-detection would silently use the wrong values for many real deployments, so card cfgs are referenced explicitly.

## Files

- `python/pysmurf/client/base/smurf_config.py` — new `_merge_cryostat_card_config()` helper, `Rcable` + `cryostat_card_config_file` schema entries, TODO replaced.
- `python/pysmurf/client/base/smurf_config_properties.py` — additive `Rcable` property.
- `cfg_files/cryostat_cards/{README.md,cc02-06.cfg,cc02-template.cfg}` — new directory with shape docs + two seed card cfgs.
- `README.config_file.md` — new "Cryostat-card cfg files" section + updated `bias_line_resistance` description.
- `tests/client/validate_cryostat_card_config.py` — five-scenario hardware-free validator (legacy, new, override, missing, relative-path) using `importlib` to avoid the `pysmurf.client` package's eager `pyrogue` import.

## Test plan

- [x] `flake8 --count python/` → 0 errors (matches CI).
- [x] `python tests/client/validate_cryostat_card_config.py` → all 5 tests pass.
- [x] Regression sweep: load every `cfg_files/**/experiment_*.cfg` with the merge pass + schema validation. 25/38 pass on this branch — identical to unmodified `main`. The 13 pre-existing failures are unrelated (`50k_Id_offset` / `reset_rate_khz` schema strictness on legacy cfgs).
- [ ] Real-hardware smoke: load a C2-06 deployment cfg migrated to use `cryostat_card_config_file: ../cryostat_cards/cc02-06.cfg` + `Rcable: 29.1`, confirm `bias_line_resistance` matches the previous explicit value (16534.1 Ω) and IV / noise analyses behave identically.

## Out of scope

- Migrating existing `cfg_files/**/experiment_*.cfg` files to the new keys. They keep working as-is; users can opt in. Follow-up issue can track repo-wide migration.
- Adding card cfgs for every C02/C03/C04 variant. Two seed examples is enough to demonstrate the pattern; values for other variants need experimental confirmation.
- Auto-detecting card type from `CryoCard.get_fw_version()` — see rationale above.