### PR TITLE
fix(shawnhammer): Refuse to run inside an existing tmux session (#78)

### DIFF
--- a/scratch/shawn/scripts/shawnhammer.sh
+++ b/scratch/shawn/scripts/shawnhammer.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Refuse to run from inside an existing tmux session.  This script kills and
+# recreates its own tmux session below; if it is launched from inside that
+# (or any) tmux session, the surrounding shell gets torn down and the script
+# silently dies with no obvious error.  See pysmurf issue #78.
+if [ -n "$TMUX" ]; then
+    echo "ERROR: shawnhammer cannot be run from inside a tmux session." 1>&2
+    echo "       Detach from tmux first (Ctrl-b d), then re-run from a regular shell." 1>&2
+    exit 1
+fi
+
 # stalls sometimes for some reason...
 #xhost +
 


### PR DESCRIPTION
## Summary
- Closes #78. shawnhammer manages its own tmux session via `tmux kill-session` / `tmux new-session`. When the script is launched from inside that (or any) tmux session, the surrounding shell gets torn down and the script silently dies with no obvious error.
- Adds a `$TMUX` guard at the very top of `scratch/shawn/scripts/shawnhammer.sh` that bails with a clear error before any side effects.

## Test plan
- [x] `bash -n scratch/shawn/scripts/shawnhammer.sh` — syntax OK
- [x] With `TMUX` set: prints `ERROR: shawnhammer cannot be run from inside a tmux session.` and exits 1 (no tmux session is killed)
- [x] With `TMUX` unset: guard is skipped; script proceeds to the existing arg/cfg validation (no false positive)
- [ ] Smoke-test on a real SMuRF server: `tmux new -s test78` then run `shawnhammer` — confirm it refuses; detach and re-run from a normal shell — confirm normal startup is unchanged.

## Note on PR #967
PR #967 renames this file to `scripts/smurf_startup.sh`. Whichever lands second is a trivial rebase to move the same 10-line guard into the renamed file.