### PR TITLE
feat(SmurfConfig): Re-add tone/analysis/synthesisScale as optional band cfg overrides (#67)

### DIFF
--- a/README.config_file.md
+++ b/README.config_file.md
@@ -25,6 +25,9 @@ You should be able to call this config file when you instantiate your `SmurfCont
 - `att_uc` - The upconverter (DAC) attenuator
 - `att_dc` - The downconverter (ADC) attenuator
 - `amplitude_scale` - The probe tone power.
+- `toneScale` *(optional)* - Override of the DSP `toneScale` register. Omit to keep the value programmed by `defaults.yml`.
+- `analysisScale` *(optional)* - Override of the DSP `analysisScale` register. Omit to keep the value programmed by `defaults.yml`.
+- `synthesisScale` *(optional)* - Override of the DSP `synthesisScale` register. Omit to keep the value programmed by `defaults.yml`.
 
 ## bad_mask
 

--- a/python/pysmurf/client/base/smurf_config.py
+++ b/python/pysmurf/client/base/smurf_config.py
@@ -459,6 +459,17 @@ class SmurfConfig:
 
                 # LMS gain, powers of 2
                 'lmsGain': And(int, lambda n: 0 <= n < 2**3),
+
+                # Optional DSP scale overrides.  When omitted, pysmurf
+                # does not touch the firmware register, so whatever
+                # value defaults.yml programmed stays in effect.  See
+                # issue #67.
+                Optional('toneScale', default=None):
+                    And(int, lambda n: 0 <= n < 2**4),
+                Optional('analysisScale', default=None):
+                    And(int, lambda n: 0 <= n < 2**4),
+                Optional('synthesisScale', default=None):
+                    And(int, lambda n: 0 <= n < 2**4),
             }
         #### Done specifying init schema
 

--- a/python/pysmurf/client/base/smurf_config_properties.py
+++ b/python/pysmurf/client/base/smurf_config_properties.py
@@ -170,6 +170,12 @@ class SmurfConfigPropertiesMixin:
         self._feedback_limit_khz = None
         self._feedback_polarity = None
 
+        # Optional DSP scale overrides (issue #67).  None means "leave
+        # whatever defaults.yml programmed alone".
+        self._tone_scale = None
+        self._analysis_scale = None
+        self._synthesis_scale = None
+
         # Mappings
         self._all_groups = None
         self._n_bias_groups = None
@@ -364,6 +370,18 @@ class SmurfConfigPropertiesMixin:
             for band in bands}
         self.feedback_polarity = {
             band:smurf_init_config[f'band_{band}']['feedbackPolarity']
+            for band in bands}
+
+        # Optional DSP scale overrides (issue #67).  Use .get() because
+        # these are Optional in the schema with default=None.
+        self.tone_scale = {
+            band:smurf_init_config[f'band_{band}'].get('toneScale')
+            for band in bands}
+        self.analysis_scale = {
+            band:smurf_init_config[f'band_{band}'].get('analysisScale')
+            for band in bands}
+        self.synthesis_scale = {
+            band:smurf_init_config[f'band_{band}'].get('synthesisScale')
             for band in bands}
 
         ## Mappings
@@ -2478,6 +2496,96 @@ class SmurfConfigPropertiesMixin:
         self._feedback_polarity = value
 
     ## End feedback_polarity property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start tone_scale property definition
+
+    # Getter
+    @property
+    def tone_scale(self):
+        """Per-band toneScale DSP register override.
+
+        Optional override of the toneScale firmware register set in
+        defaults.yml.  None means do not touch the register during
+        setup.
+
+        Specified per band in the pysmurf configuration file as
+        `init.band_#.toneScale`.
+
+        See Also
+        --------
+        analysis_scale, synthesis_scale
+
+        """
+        return self._tone_scale
+
+    # Setter
+    @tone_scale.setter
+    def tone_scale(self, value):
+        self._tone_scale = value
+
+    ## End tone_scale property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start analysis_scale property definition
+
+    # Getter
+    @property
+    def analysis_scale(self):
+        """Per-band analysisScale DSP register override.
+
+        Optional override of the analysisScale firmware register set
+        in defaults.yml.  None means do not touch the register during
+        setup.
+
+        Specified per band in the pysmurf configuration file as
+        `init.band_#.analysisScale`.
+
+        See Also
+        --------
+        tone_scale, synthesis_scale
+
+        """
+        return self._analysis_scale
+
+    # Setter
+    @analysis_scale.setter
+    def analysis_scale(self, value):
+        self._analysis_scale = value
+
+    ## End analysis_scale property definition
+    ###########################################################################
+
+    ###########################################################################
+    ## Start synthesis_scale property definition
+
+    # Getter
+    @property
+    def synthesis_scale(self):
+        """Per-band synthesisScale DSP register override.
+
+        Optional override of the synthesisScale firmware register set
+        in defaults.yml.  None means do not touch the register during
+        setup.
+
+        Specified per band in the pysmurf configuration file as
+        `init.band_#.synthesisScale`.
+
+        See Also
+        --------
+        tone_scale, analysis_scale
+
+        """
+        return self._synthesis_scale
+
+    # Setter
+    @synthesis_scale.setter
+    def synthesis_scale(self, value):
+        self._synthesis_scale = value
+
+    ## End synthesis_scale property definition
     ###########################################################################
 
     ###########################################################################

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -561,6 +561,22 @@ class SmurfControl(SmurfCommandMixin,
                     band, self._lms_gain[band],
                     write_log=write_log, **kwargs)
 
+                # Optional DSP scale overrides (issue #67).  When
+                # omitted from the cfg, leave whatever value
+                # defaults.yml programmed in place.
+                if self._tone_scale[band] is not None:
+                    self.set_tone_scale(
+                        band, self._tone_scale[band],
+                        write_log=write_log, **kwargs)
+                if self._analysis_scale[band] is not None:
+                    self.set_analysis_scale(
+                        band, self._analysis_scale[band],
+                        write_log=write_log, **kwargs)
+                if self._synthesis_scale[band] is not None:
+                    self.set_synthesis_scale(
+                        band, self._synthesis_scale[band],
+                        write_log=write_log, **kwargs)
+
                 self.set_trigger_reset_delay(
                     band, self._trigger_reset_delay[band],
                     write_log=write_log, **kwargs)


### PR DESCRIPTION
## Summary

Closes #67. Restores the per-band override path for the three DSP scale registers — `toneScale`, `analysisScale`, and `synthesisScale` — that were stripped from the cfg flow in commit 266b58c3 (May 2019) on the assumption that `defaults.yml` would be the only place they were set.

The override stays **opt-in**: cfgs that omit these keys behave exactly as before (whatever `defaults.yml` programmed stays in place). Cfgs that include them now have those values written to firmware during `setup()`, which is the behavior the issue asks for.

## Changes

- `python/pysmurf/client/base/smurf_config.py` — Add 3 `Optional(default=None)` entries to the `band_#` schema with bound `0..15` (matches `amplitude_scale`).
- `python/pysmurf/client/base/smurf_config_properties.py` — Add `_tone_scale` / `_analysis_scale` / `_synthesis_scale` private fields, dict-comprehension loaders in `copy_config_to_properties`, and `@property`/`@setter` accessors. Loaders use `.get()` so missing keys flow through as `None`.
- `python/pysmurf/client/base/smurf_control.py` — Three None-guarded setter calls in the `setup()` per-band loop, just after `set_lms_gain`. Pattern mirrors `lms_delay` (the closest existing analog).
- `README.config_file.md` — One bullet per param in the `band_#` section, marked *(optional)*.

`template.cfg` deliberately stays untouched — the issue framing is "useful to be able to override on occasion", not "every user should set these."

The setter/getter methods themselves (`set_tone_scale` etc. in `smurf_command.py`) were never removed and are reused as-is.

## Test plan

- [x] `flake8 --count python/` (matches CI in `.github/workflows/test-or-deploy.yml`) — 0 errors.
- [x] Schema regression — `cfg_files/template/template.cfg` validates and exposes all three scales as `None` per band.
- [x] Schema acceptance — synthetic cfg with `toneScale: 5, analysisScale: 7, synthesisScale: 4` in `band_0` and no scales in `band_1` validates; values flow through to `band_0`, `None` for `band_1`.
- [x] Schema rejection — `toneScale: 16` is rejected by `SchemaError` as expected.
- [x] Property plumbing — `__init__` defaults the three private fields to `None`, `@property`/`@setter` round-trip works, dict-comprehensions handle full / partial / absent overrides.
- [ ] On a real SMuRF: boot with a cfg that omits the three keys; confirm `S.get_tone_scale(band)` / `get_analysis_scale` / `get_synthesis_scale` retain the `defaults.yml` values after `setup()`. Then boot with a cfg that overrides them; confirm the registers reflect the cfg values.