### PR TITLE
fix(assign_channels): Surface stale or missing master channel assignment (#63)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -77,6 +77,8 @@ class SmurfTuneMixin(SmurfBase):
         new_master_assignment : bool, optional, default False
             Whether to make a new master assignment which forces
             resonators at a given frequency to a given channel.
+            Set True the first time you tune or whenever the resonator
+            set has changed.
         track_and_check : bool, optional, default True
             Whether or not after tuning to run track and check.
         """
@@ -299,6 +301,8 @@ class SmurfTuneMixin(SmurfBase):
             Whether to make a plot per subband. This is very slow.
         new_master_assignment : bool, optional, default False
             Whether to overwrite the previous master_assignment list.
+            Set True the first time you tune or whenever the resonator
+            set has changed.
         from_old_tune : bool, optional, default False
             Whether to use an old tuning file. This will load a tuning
             file and use its peak frequencies as a starting point for
@@ -1676,6 +1680,12 @@ class SmurfTuneMixin(SmurfBase):
         offsets = np.zeros(len(freq))
 
         if not new_master_assignment:
+            if f'band_{band}' not in self.channel_assignment_files:
+                msg = (f'No channel_assignment file found for band {band} '
+                       f'in {self.tune_dir}. Rerun with '
+                       'new_master_assignment=True to create one.')
+                self.log(msg, self.LOG_ERROR)
+                raise RuntimeError(msg)
             freq_master,subbands_master,channels_master,groups_master = \
                 self.get_master_assignment(band)
             n_freqs = len(freq)
@@ -1704,7 +1714,15 @@ class SmurfTuneMixin(SmurfBase):
                     self.log(f'No match found for {f:.2f} MHz')
             self.log(
                 f'No channel assignment for {n_unmatched} of {n_freqs}'+
-                ' resonances.')
+                ' resonances.', self.LOG_USER)
+            if n_freqs > 0 and n_unmatched / n_freqs >= 0.5:
+                self.log(
+                    f'WARNING: {n_unmatched}/{n_freqs} resonances in '
+                    f'band {band} did not match the master channel '
+                    'assignment. The master assignment file may be '
+                    'out of date. To reassign all current resonances '
+                    'and overwrite the master file, rerun with '
+                    'new_master_assignment=True.', self.LOG_USER)
         else:
             d_freq = np.diff(freq)
             close_idx = d_freq > min_offset


### PR DESCRIPTION
## Summary

Closes #63.

`assign_channels()` previously failed silently in two ways when the master channel assignment file was out of date or missing:

1. **No file at all (first-time tune):** `get_master_assignment()` raised a cryptic `KeyError: 'band_X'`.
2. **Stale file:** unmatched resonances were left at `channels[idx] = -1` and the existing summary log went out at default level, giving no actionable hint.

This PR keeps the fix surgical inside `assign_channels()` plus two 1-line docstring nudges:

- Raise `RuntimeError` with a clear message when no `*channel_assignment_b{band}.txt` exists for the requested band, suggesting the user rerun with `new_master_assignment=True`.
- When >=50% of found resonances fail to match the loaded master file, emit a prominent `LOG_USER` warning suggesting `new_master_assignment=True`.
- Promote the existing `"No channel assignment for N of M resonances"` summary to `LOG_USER` so the count is always visible.
- Append one sentence to the `new_master_assignment` docstring in `tune()` and `tune_band_serial()` clarifying when to set it `True`.

Threshold is hardcoded at 50%; can be promoted to a kwarg later if anyone asks.

## Caller-impact audit

Every internal caller of `assign_channels()` propagates `new_master_assignment` and does not branch on `channels == -1`:

- `tune_band` (line 245)
- `tune_band_serial` (lines 331, 377)
- `setup_notches` (line 3966)
- `setup_notches_simulator` (line 4095)

`grep` of the repo finds zero call sites that catch the old `KeyError` from `get_master_assignment`. The new `RuntimeError` is a strict improvement.

## Test plan

- [x] `flake8 --count python/` → 0 (matches CI invocation in `.github/workflows/test-or-deploy.yml`)
- [ ] **First-time tune:** point pysmurf at a fresh `tune_dir` with no `*channel_assignment_b*.txt`, run `S.setup_notches(band)` (or `S.tune()`) → expect `RuntimeError: No channel_assignment file found for band X in /path/to/tune_dir...`
- [ ] **Stale tune:** with an existing assignment file whose frequencies are far from the current resonances (or use a small `min_offset`), run `S.setup_notches(band)` → expect both `No channel assignment for N of M resonances.` and the new `WARNING: ... master assignment file may be out of date ...` line at `LOG_USER`
- [ ] **Healthy tune (no regression):** existing assignment matches resonances → normal matching logs, no warning
- [ ] **`new_master_assignment=True` (no regression):** `get_master_assignment` is never called, no warnings emitted, file is written

The repo's existing test scaffold (`conftest.py`, `test_resonator.py`, `test_loopback.py`) requires a running SMuRF server, so the hardware-dependent test plan items above need to be exercised on a real system.