### PR TITLE
feat(publisher): Register remaining file writes with self.pub (#55)

### DIFF
--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -1317,8 +1317,10 @@ class SmurfIVMixin(SmurfBase):
                            ha='right', va='top')
 
                 plt.tight_layout()
-                plt.savefig(os.path.join(self.plot_dir, iv_raw_dat['basename'] +
-                    f'_estimate_bias_bg{bg}.png'), bbox_inches='tight')
+                path = os.path.join(self.plot_dir, iv_raw_dat['basename'] +
+                    f'_estimate_bias_bg{bg}.png')
+                plt.savefig(path, bbox_inches='tight')
+                self.pub.register_file(path, 'iv_estimate_bias', plot=True)
 
             if not show_plot:
                 plt.close(fig)

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -260,12 +260,21 @@ class SmurfNoiseMixin(SmurfBase):
                 # Publish the data
                 self.pub.register_file(outfn, 'noise_timestream', format='txt')
 
-                np.save(os.path.join(self.output_dir,
-                    f'{basename}_wl_list'), wl_list)
-                np.save(os.path.join(self.output_dir,
-                    f'{basename}_f_knee_list'), f_knee_list)
-                np.save(os.path.join(self.output_dir,
-                    f'{basename}_n_list'), n_list)
+                wl_path = os.path.join(self.output_dir,
+                    f'{basename}_wl_list')
+                np.save(wl_path, wl_list)
+                self.pub.register_file(wl_path, 'noise_timestream',
+                    format='npy')
+                f_knee_path = os.path.join(self.output_dir,
+                    f'{basename}_f_knee_list')
+                np.save(f_knee_path, f_knee_list)
+                self.pub.register_file(f_knee_path, 'noise_timestream',
+                    format='npy')
+                n_path = os.path.join(self.output_dir,
+                    f'{basename}_n_list')
+                np.save(n_path, n_list)
+                self.pub.register_file(n_path, 'noise_timestream',
+                    format='npy')
 
         if make_summary_plot:
             bins = np.arange(0,351,20)
@@ -1293,6 +1302,7 @@ class SmurfNoiseMixin(SmurfBase):
                 self.log(f'Saving plot to {plot_fn}')
                 plt.savefig(plot_fn,
                     bbox_inches='tight')
+                self.pub.register_file(plot_fn, 'noise_vs_bias', plot=True)
                 plt.close()
 
             del f
@@ -1382,6 +1392,8 @@ class SmurfNoiseMixin(SmurfBase):
             plot_fn = os.path.join(self.plot_dir, plot_name)
             self.log(f'\nSaving NEI histogram to {plot_fn}')
             plt.savefig(plot_fn, bbox_inches='tight')
+            self.pub.register_file(plot_fn, 'noise_vs_bias_nei_hist',
+                plot=True)
             plt.close()
 
         if est_NEP:
@@ -1431,6 +1443,8 @@ class SmurfNoiseMixin(SmurfBase):
                 plot_fn = os.path.join(self.plot_dir, plot_name)
                 self.log(f'\nSaving NEP histogram to {plot_fn}')
                 plt.savefig(plot_fn, bbox_inches='tight')
+                self.pub.register_file(plot_fn, 'noise_vs_bias_nep_hist',
+                    plot=True)
                 plt.close()
 
 
@@ -1910,6 +1924,7 @@ class SmurfNoiseMixin(SmurfBase):
                 self.log(f'Saving plot to {plot_fn}')
                 plt.savefig(plot_fn,
                     bbox_inches='tight')
+                self.pub.register_file(plot_fn, 'noise_vs_tone', plot=True)
                 plt.close()
 
 
@@ -2036,8 +2051,10 @@ class SmurfNoiseMixin(SmurfBase):
             plt.tight_layout()
 
             if save_plot:
-                plt.savefig(os.path.join(self.plot_dir, f'{filename}.png'),
-                    bbox_inches='tight')
+                path = os.path.join(self.plot_dir, f'{filename}.png')
+                plt.savefig(path, bbox_inches='tight')
+                self.pub.register_file(path, 'noise_high_bandwidth',
+                    plot=True)
             if show_plot:
                 plt.show()
             else:
@@ -2045,7 +2062,10 @@ class SmurfNoiseMixin(SmurfBase):
 
         if save_psd:
             np.save(os.path.join(self.output_dir, f'{filename}'), ff)
-            np.save(os.path.join(self.output_dir, f'{filename}'), pxx)
+            psd_path = os.path.join(self.output_dir, f'{filename}')
+            np.save(psd_path, pxx)
+            self.pub.register_file(psd_path, 'noise_high_bandwidth_psd',
+                format='npy')
 
         return ff, pxx
 
@@ -2131,8 +2151,9 @@ class SmurfNoiseMixin(SmurfBase):
             if save_name is None:
                 raise IOError('To save plot, save_name must be provided')
             else:
-                plt.savefig(os.path.join(self.plot_dir, save_name),
-                            bbox_inches='tight')
+                path = os.path.join(self.plot_dir, save_name)
+                plt.savefig(path, bbox_inches='tight')
+                self.pub.register_file(path, 'svd_summary', plot=True)
 
         if show_plot:
             plt.show()
@@ -2189,8 +2210,9 @@ class SmurfNoiseMixin(SmurfBase):
             if save_name is None:
                 raise IOError('To save plot, save_name must be provided')
             else:
-                plt.savefig(os.path.join(self.plot_dir, save_name),
-                            bbox_inches='tight')
+                path = os.path.join(self.plot_dir, save_name)
+                plt.savefig(path, bbox_inches='tight')
+                self.pub.register_file(path, 'svd_modes', plot=True)
 
         if show_plot:
             plt.show()

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -4225,9 +4225,10 @@ class SmurfTuneMixin(SmurfBase):
             plt.tight_layout()
             if save_plot:
                 timestamp = self.get_timestamp()
-                plt.savefig(os.path.join(self.plot_dir,
-                    f'{timestamp}_IQ_svd_b{band}ch{channel:03}.png'),
-                    bbox_inches='tight')
+                path = os.path.join(self.plot_dir,
+                    f'{timestamp}_IQ_svd_b{band}ch{channel:03}.png')
+                plt.savefig(path, bbox_inches='tight')
+                self.pub.register_file(path, 'iq_svd', plot=True)
             if show_plot:
                 plt.show()
             else:
@@ -4457,9 +4458,10 @@ class SmurfTuneMixin(SmurfBase):
             plt.tight_layout()
 
             if save_plot:
-                plt.savefig(os.path.join(self.plot_dir,
-                    f'{timestamp}_optimize_lms_delay_b{band}.png'),
-                    bbox_inches='tight')
+                path = os.path.join(self.plot_dir,
+                    f'{timestamp}_optimize_lms_delay_b{band}.png')
+                plt.savefig(path, bbox_inches='tight')
+                self.pub.register_file(path, 'optimize_lms_delay', plot=True)
             if show_plot:
                 plt.show()
             else:

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4630,9 +4630,10 @@ class SmurfUtilMixin(SmurfBase):
             plt.tight_layout()
 
             if save_plot:
-                plt.savefig(os.path.join(self.plot_dir,
-                                         f'{timestamp}_probe_tone_gap.png'),
-                            bbox_inches='tight')
+                path = os.path.join(self.plot_dir,
+                                    f'{timestamp}_probe_tone_gap.png')
+                plt.savefig(path, bbox_inches='tight')
+                self.pub.register_file(path, 'probe_tone_gap', plot=True)
 
             if show_plot:
                 plt.show()


### PR DESCRIPTION
## Summary

Closes the spirit of #55 by adding `self.pub.register_file()` calls to the 15 remaining unpublished `plt.savefig` / `np.save` sites in `tune/`, `debug/`, and `util/` so the SO DAQ archiver can pick up every output file.

The publisher infrastructure that #55 asked for is already in place on `main` — `Publisher.register_file(...)` lives at `python/pysmurf/client/util/pub.py:186`, attached to every `SmurfControl` instance as `self.pub`, and the specific call site #55 called out (`tune/smurf_tune.py:2869` in `be01b4e6`) is now the `full_band_resp` block at smurf_tune.py:784–794 and publishes all three of its `.txt` outputs. The maintainers chose the scattered-`register_file` pattern over the centralized `pysmurf.util` wrapper-functions originally suggested in the issue body, and that pattern is now used in dozens of sites across the client. This PR brings the remaining stragglers in line.

## Changes

- **`python/pysmurf/client/tune/smurf_tune.py`** — `analyze_IQ_stream` (`iq_svd`) and `optimize_lms_delay` plots.
- **`python/pysmurf/client/debug/smurf_noise.py`** — `wl_list` / `f_knee_list` / `n_list` `.npy` saves; per-channel `noise_vs_bias` plot; NEI summary histogram; NEP summary histogram; per-channel `noise_vs_tone` plot; `take_noise_high_bandwidth` single-channel plot; `take_noise_high_bandwidth` PSD `.npy` save; `plot_svd_summary`; `plot_svd_modes`.
- **`python/pysmurf/client/debug/smurf_iv.py`** — `estimate_phase_transition` raw-bias plot (`iv_estimate_bias`).
- **`python/pysmurf/client/util/smurf_util.py`** — `identify_probe_tones` gap plot (`probe_tone_gap`).

Coverage of file-write sites in those four files: **39/55 → 54/55** (70.9% → 98.2%).

## Out of scope (separate follow-up)

`debug/smurf_noise.py:2047–2048` writes both the frequency array `ff` and the PSD array `pxx` to the same path `f'{filename}'`, so `ff` is silently overwritten by `pxx`. This PR leaves the bug alone (surgical changes only) and registers only the surviving file (`pxx`). I'll file a separate issue for the collision.

## Test plan

- [x] `flake8 --count python/` (matches `.github/workflows/test-or-deploy.yml:51`) — 0 errors.
- [x] `git diff` — every changed line is either a `path = ...` hoist of an existing `os.path.join(...)`, the unchanged `savefig`/`save` call rewritten to take the local `path`, or a new `self.pub.register_file(...)` line. No behavior changes outside the publisher.
- [x] Coverage check: `grep -nE '(plt\.savefig|fig\.savefig|np\.save\b|np\.savetxt|np\.savez)' python/pysmurf/client/{tune,debug,util}/*.py` returns 55 sites; manual review shows 54 are now paired with `register_file` (the 1 remaining is the deliberate ff/pxx collision noted above).
- [ ] CI test-server / test-client / test-docs run in PR — local Docker run not available on this host; the changes are line-local and don't alter imports.

Closes #55 once merged.