### PR TITLE
feat(SmurfBase): Add batch_mode for foolproof headless plotting (closes #51)

### DIFF
--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -54,6 +54,14 @@ class SmurfBase:
     script_id : str or None, optional, default None
         Script id included with publisher messages. For example,
         the script or operation name.
+    batch_mode : bool, optional, default False
+        Foolproof non-interactive plotting mode (issue #51). When
+        True, switches the matplotlib backend to ``Agg`` and turns
+        off interactive mode, so plots will never pop up regardless
+        of any per-call ``show_plot`` argument or ambient
+        ``plt.ion()`` state. ``save_plot=True`` continues to work
+        for writing PNGs to disk. Once switched to Agg the backend
+        cannot be switched back without restarting Python.
     """
 
     _base_args = ['verbose', 'logfile', 'log_timestamp', 'log_prefix',
@@ -77,7 +85,8 @@ class SmurfBase:
     """
 
     def __init__(self, log=None, server_addr="localhost", server_port=9000, atca_port=9100,
-                 atca_monitor=False, offline=False, pub_root=None, script_id=None, **kwargs):
+                 atca_monitor=False, offline=False, pub_root=None, script_id=None,
+                 batch_mode=False, **kwargs):
         """
         """
 
@@ -89,6 +98,12 @@ class SmurfBase:
             verb = kwargs.pop('verbose', None)
             if verb is not None:
                 self.set_verbose(verb)
+
+        # Foolproof non-interactive plotting (issue #51).  Apply the
+        # backend switch before any pysmurf method has a chance to
+        # create a figure.
+        self._batch_mode = False
+        self.set_batch_mode(batch_mode)
 
         self._server_addr = server_addr
         self._server_port = server_port
@@ -247,6 +262,39 @@ class SmurfBase:
 
         # LUT table length for arbitrary waveform generation
         self._lut_table_array_length = 2048
+
+    def set_batch_mode(self, value):
+        """Enable or disable foolproof non-interactive plotting (issue #51).
+
+        When enabled, switches the matplotlib backend to ``Agg`` and
+        disables interactive mode.  ``plt.show()`` becomes a no-op
+        and figures cannot be displayed by any pysmurf routine,
+        regardless of any per-call ``show_plot`` argument.
+        ``save_plot=True`` continues to work for writing PNGs.
+
+        Note
+        ----
+        Switching to ``Agg`` is one-way for the life of the Python
+        process.  ``set_batch_mode(False)`` clears the flag but does
+        not restore a GUI backend.  Restart Python without
+        ``batch_mode=True`` to re-enable interactive plotting.
+
+        Args
+        ----
+        value : bool
+            True to enable batch mode, False to disable the flag.
+        """
+        value = bool(value)
+        self._batch_mode = value
+        if value:
+            import matplotlib.pyplot as plt
+            plt.switch_backend('Agg')
+            plt.ioff()
+            plt.close('all')
+
+    def get_batch_mode(self):
+        """Return True if batch_mode is enabled (no interactive plots)."""
+        return self._batch_mode
 
     def init_log(self, verbose=0, logger=SmurfLogger, logfile=None,
                  log_timestamp=True, log_prefix=None, **kwargs):

--- a/python/pysmurf/client/base/smurf_control.py
+++ b/python/pysmurf/client/base/smurf_control.py
@@ -72,6 +72,13 @@ class SmurfControl(SmurfCommandMixin,
        Whether to make a skip making a directory.
     validate_config : bool, optional, default True
        Whether to check if the input config file is correct.
+    batch_mode : bool, optional, default False
+       Foolproof non-interactive plotting mode (issue #51).  When
+       True, switches the matplotlib backend to ``Agg`` and turns
+       off interactive mode, so plots will never pop up regardless
+       of any per-call ``show_plot`` argument.  ``save_plot=True``
+       continues to work for writing PNGs to disk.  May also be
+       toggled later via ``set_batch_mode``.
 
     Attributes
     ----------
@@ -93,7 +100,7 @@ class SmurfControl(SmurfCommandMixin,
     def __init__(self, cfg_file=None, data_dir=None, name=None, make_logfile=True,
                  setup=False, offline=False, smurf_cmd_mode=False,
                  shelf_manager='shm-smrf-sp01', no_dir=False, validate_config=True,
-                 data_path_id=None, **kwargs):
+                 data_path_id=None, batch_mode=False, **kwargs):
         """Constructor for the SmurfControl class.
 
         See the SmurfControl class docstring for more details.
@@ -124,7 +131,7 @@ class SmurfControl(SmurfCommandMixin,
         # Save shelf manager - Should this be in the config?
         self.shelf_manager = shelf_manager
 
-        super().__init__(offline=offline, **kwargs)
+        super().__init__(offline=offline, batch_mode=batch_mode, **kwargs)
 
         if cfg_file is not None or data_dir is not None:
             self.initialize(data_dir=data_dir,


### PR DESCRIPTION
## Summary

Resolves [#51](https://github.com/slaclab/pysmurf/issues/51) — *"Need a foolproof way of disabling interactive plotting"*.

Adds a new `batch_mode` flag (with matching `set_batch_mode` / `get_batch_mode` accessors) on `SmurfBase`, threaded through `SmurfControl`. When enabled, two layers of defense make interactive plotting genuinely impossible:

| Layer | Mechanism | Effect |
|---|---|---|
| 1 | `plt.switch_backend('Agg')` | Non-interactive backend — `plt.show()` is a no-op, no GUI possible |
| 2 | `plt.ioff()` + `plt.close('all')` | Disables auto-display in Jupyter/IPython; clears any existing figures |

This is a deliberately surgical change (2 files, +58/-3) — none of the existing 21 `plt.show()` sites or `plt.ion/ioff` toggles need to change because the backend switch makes them moot.

`save_plot=True` continues to work for writing PNGs to disk, which addresses @hlym's follow-up comment about saving plots without displaying them.

## Usage

```python
# Constructor flag
S = pysmurf.client.SmurfControl(cfg_file=..., batch_mode=True)

# Or toggle later
S.set_batch_mode(True)
S.get_batch_mode()  # -> True
```

## Notes

- `set_batch_mode(True)` is one-way for the life of the Python process. `set_batch_mode(False)` clears the flag but does not restore a GUI backend (you must restart Python). This matches matplotlib's recommended post-import switch behavior.
- The CI workflow `.github/workflows/test-or-deploy.yml:231` currently does `matplotlib.use("Agg")` as a workaround before importing pysmurf — concrete evidence the pain point was real. That workaround continues to work; this change is additive.

## Test plan

- [x] `flake8 --count python/` passes (matches CI invocation)
- [x] Offline-mode verification: constructor flag, default, runtime toggle, bool coercion, `plt.show()` no-op, `savefig` works under Agg
- [ ] Live verification on a SMuRF system: confirm `batch_mode=True` keeps plots from popping up over X11/SSH