### PR TITLE
fix(smurf_tune.tracking_setup): Warn instead of crashing when no channels are on (#38)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2735,6 +2735,20 @@ class SmurfTuneMixin(SmurfBase):
             self.log("Number of channels on with flux ramp "+
                 f"response : {len(channels_on)}", self.LOG_USER)
 
+            # Issue #38: avoid crashing in the make_plot block (np.max on
+            # an empty array) and surface a clear error when there is
+            # nothing to analyze in this band.
+            if len(channels_on) == 0:
+                self.log(
+                    f"No channels in band {band} have flux ramp response "
+                    "(either no channels are on, or none responded). "
+                    "Skipping tracking_setup analysis.",
+                    self.LOG_ERROR)
+                self.set_iq_stream_enable(band, 1, write_log=write_log)
+                if return_data:
+                    return f, df, sync
+                return
+
             f_span = np.max(f,0) - np.min(f,0)
 
         if make_plot:


### PR DESCRIPTION
## Summary
- Closes #38. `tracking_setup` previously crashed when no channels in the band were amplitude-on (or none showed flux-ramp response): `channels_on` was an empty list and the `make_plot` block hit `np.max(f_span[channels_on])`, raising `ValueError: zero-size array to reduction operation maximum which has no identity`.
- Adds a guard inside the `return_data or make_plot` block in `python/pysmurf/client/tune/smurf_tune.py`: when `len(channels_on) == 0`, log a `LOG_ERROR` naming the band, restore the IQ stream (matching the normal exit path's cleanup at line 2849), and return early.
- When `return_data=True` the early return still yields the 3-tuple `(f, df, sync)`, so existing callers (`eta_phase_check`, `track_and_check`, `estimate_lms_freq`, `estimate_flux_ramp_amp`, `smurf_noise.take_noise_psd`, etc.) are unaffected.

## Test plan
- [x] `flake8 --count python/` (CI's lint gate) reports `0` violations on the modified file.
- [ ] Manual: invoke `tracking_setup(band, make_plot=True)` on a band with all amplitudes zeroed (`set_amplitude_scale_array(band, np.zeros(...))`) and confirm a `LOG_ERROR` line appears and the call returns cleanly without raising.
- [ ] Manual: confirm the IQ stream is re-enabled on the early-out path (`get_iq_stream_enable(band) == 1` after the call).
- [ ] Confirm a normal call with channels on still produces histograms and returns `(f, df, sync)` unchanged.