### PR TITLE
feat(smurf_util): Add keep_channels_subset helper

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2146,6 +2146,81 @@ class SmurfUtilMixin(SmurfBase):
         self.set_amplitude_scale_channel(band, channel, 0, **kwargs)
         self.set_feedback_enable_channel(band, channel, 0, **kwargs)
 
+    @set_action()
+    def keep_channels_subset(self, band, subbands=None, freq_min_mhz=None,
+                             freq_max_mhz=None, channels_to_keep=None,
+                             **kwargs):
+        """
+        Drops on-channels in a band to the subset matching all supplied
+        criteria. Channels currently on (per :func:`which_on`) that fail
+        any supplied filter are disabled with :func:`channel_off`. With
+        no filters supplied, this is a no-op.
+
+        Filters combine with logical AND. See
+        :func:`turn_off_noisy_channels` and :func:`check_lock` for
+        related criterion-based disable helpers.
+
+        Args
+        ----
+        band : int
+            The band whose on-channels to filter.
+        subbands : iterable of int, optional, default None
+            Keep only on-channels whose subband is in this iterable.
+            Example: ``range(13, 16)`` for subbands 13-15.
+        freq_min_mhz : float, optional, default None
+            Keep only on-channels with resonator frequency >= this
+            value, in MHz.
+        freq_max_mhz : float, optional, default None
+            Keep only on-channels with resonator frequency <= this
+            value, in MHz.
+        channels_to_keep : iterable of int, optional, default None
+            Explicit channel allow-list. Useful for passing the
+            surviving channels of an external analysis (e.g. the
+            TES-like channels identified from :func:`analyze_iv`).
+
+        Returns
+        -------
+        dropped : np.ndarray
+            Channels that were turned off.
+        """
+        on_channels = self.which_on(band)
+        if (subbands is None and freq_min_mhz is None and
+                freq_max_mhz is None and channels_to_keep is None):
+            return np.array([], dtype=int)
+
+        keep = np.ones(len(on_channels), dtype=bool)
+
+        if subbands is not None:
+            subbands_set = {int(s) for s in subbands}
+            ch_subbands = np.array([
+                self.get_subband_from_channel(band, int(ch))
+                for ch in on_channels
+            ])
+            keep &= np.array([sb in subbands_set for sb in ch_subbands])
+
+        if freq_min_mhz is not None or freq_max_mhz is not None:
+            freqs = self.channel_to_freq(band)
+            if freq_min_mhz is not None:
+                keep &= (freqs >= freq_min_mhz)
+            if freq_max_mhz is not None:
+                keep &= (freqs <= freq_max_mhz)
+
+        if channels_to_keep is not None:
+            allow = {int(c) for c in channels_to_keep}
+            keep &= np.array([int(ch) in allow for ch in on_channels])
+
+        dropped = on_channels[~keep]
+        for ch in dropped:
+            self.channel_off(band, int(ch), **kwargs)
+
+        self.log(
+            f'keep_channels_subset(band={band}): kept '
+            f'{int(keep.sum())} of {len(on_channels)} channels, '
+            f'dropped {len(dropped)}.',
+            self.LOG_USER,
+        )
+        return dropped
+
 
     def set_feedback_limit_khz(self, band, feedback_limit_khz, **kwargs):
         """


### PR DESCRIPTION
## Summary
- Adds `SmurfUtilMixin.keep_channels_subset(band, subbands=None, freq_min_mhz=None, freq_max_mhz=None, channels_to_keep=None)` in `python/pysmurf/client/util/smurf_util.py`, sitting next to `band_off` / `channel_off`.
- Disables currently-on channels (per `which_on`) that fail any supplied filter; filters combine with logical AND; no-op when no filters are supplied.
- Composes existing helpers (`which_on`, `get_subband_from_channel`, `channel_to_freq`, `channel_off`); no new low-level API introduced.
- Mirrors the caller-supplies-the-metric pattern of `turn_off_noisy_channels` and `check_lock`.

Closes #27.

## Usage
The three examples from the original issue:
```python
S.keep_channels_subset(band, subbands=range(13, 16))               # subbands 13-15
S.keep_channels_subset(band, freq_min_mhz=5100, freq_max_mhz=5200) # 5.1-5.2 GHz
S.keep_channels_subset(band, channels_to_keep=tes_like_chs)        # external IV/TES filter
```
The IV/TES-quality criterion is intentionally left to the caller — `analyze_iv` already returns metrics, so policy (which `R_n` / `p_trans` is "TES-like") stays in calling code:
```python
iv = S.analyze_iv_from_file(...)
good = [ch for ch in iv[band] if iv[band][ch]['R_n'] > 5e-3]
S.keep_channels_subset(band, channels_to_keep=good)
```

## Test plan
- [x] `flake8 --count python/` clean (matches CI)
- [x] AST parse confirms signature, `@set_action()` decorator, and docstring
- [x] `python -m py_compile` clean
- [ ] Hardware smoke test: tune a band, call `S.keep_channels_subset(band, subbands=range(13, 16))`, verify `S.which_on(band)` afterward returns only channels whose `S.get_subband_from_channel(band, ch)` is in {13, 14, 15}
- [ ] Hardware smoke test: cross-check `freq_min_mhz` / `freq_max_mhz` against `S.channel_to_freq(band)`
- [ ] Confirm `band_off` / `channel_off` behavior unchanged