### PR TITLE
feat(scripts): Add smurf-latest-dir to jump to latest pysmurf session (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,25 @@ documentation by opening `_build/html/index.html` in the browser of your choice.
 The documentation is also updated to readthedocs here: https://pysmurf.readthedocs.io/en/main/
 
 [1]: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html
+
+## Navigating to the latest pysmurf session
+
+Each pysmurf client run drops outputs under
+`<default_data_dir>/<YYYYMMDD>/[<data_path_id>/]<session>/{outputs,plots,tune}`.
+`scripts/smurf-latest-dir` prints the path of the most recently modified
+session's `plots` (default), `outputs`, or `tune` subdir so you can `cd`
+straight in:
+
+```
+cd "$(scripts/smurf-latest-dir)"             # latest plots/
+cd "$(scripts/smurf-latest-dir outputs)"     # latest outputs/
+scripts/smurf-latest-dir --data-dir /custom/path --data-path-id crate1slot2
+```
+
+Defaults to `--data-dir /data/smurf_data`, which matches every cfg under
+`cfg_files/`. Handy aliases for `~/.bashrc`:
+
+```
+alias cdplots='cd "$(scripts/smurf-latest-dir)"'
+alias cdouts='cd "$(scripts/smurf-latest-dir outputs)"'
+```

--- a/scripts/smurf-latest-dir
+++ b/scripts/smurf-latest-dir
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# smurf-latest-dir - print the path to the most recent pysmurf session subdir.
+#
+# pysmurf lays sessions out as
+#     <data_dir>/<YYYYMMDD>/[<data_path_id>/]<session>/{outputs,plots,tune}
+# (see python/pysmurf/client/base/smurf_control.py). This helper finds the
+# most recently modified <session> dir and prints the requested subdir, so
+# users can `cd "$(smurf-latest-dir)"` without hunting through timestamps.
+#
+# Usage:
+#     smurf-latest-dir [plots|outputs|tune] [--data-dir DIR] [--data-path-id ID]
+#
+# Defaults: subdir=plots, data_dir=/data/smurf_data (matches every cfg in
+# cfg_files/). Exits non-zero if no session is found.
+
+set -euo pipefail
+
+usage() {
+    sed -n '3,15p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+data_dir="/data/smurf_data"
+data_path_id=""
+subdir="plots"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --data-dir)      data_dir="$2";      shift 2 ;;
+        --data-path-id)  data_path_id="$2";  shift 2 ;;
+        plots|outputs|tune) subdir="$1";     shift ;;
+        -h|--help)       usage; exit 0 ;;
+        *) echo "smurf-latest-dir: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+# Glob: <data_dir>/<8-digit-date>/[<data_path_id>/]<session>
+date_glob='[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'
+if [[ -n "$data_path_id" ]]; then
+    pattern="$data_dir/$date_glob/$data_path_id/*"
+else
+    pattern="$data_dir/$date_glob/*"
+fi
+
+# shellcheck disable=SC2086  # intentional word-splitting on $pattern
+# `|| true` keeps `set -e -o pipefail` from aborting when the glob has no
+# matches; the empty-result case is handled explicitly below.
+latest=$(ls -1dt $pattern 2>/dev/null | head -n1 || true)
+
+if [[ -z "$latest" || ! -d "$latest" ]]; then
+    echo "smurf-latest-dir: no session found under $data_dir" >&2
+    exit 1
+fi
+
+echo "$latest/$subdir"


### PR DESCRIPTION
## Summary

Resolves [#25](https://github.com/slaclab/pysmurf/issues/25) — *"Need command on servers to automatically navigate to latest plots directory/etc."*

Adds `scripts/smurf-latest-dir`, a small bash helper that prints the path of the most recently modified pysmurf session subdir under the standard data tree:

```
<data_dir>/<YYYYMMDD>/[<data_path_id>/]<session>/{outputs,plots,tune}
```

so users can do `cd "$(scripts/smurf-latest-dir)"` instead of `ls`-ing the date dir, eyeballing the most recent timestamped session, and `cd`-ing in by hand.

```
$ scripts/smurf-latest-dir
/data/smurf_data/20260501/1714600000/plots
$ cd "$(scripts/smurf-latest-dir outputs)"
$ scripts/smurf-latest-dir --data-path-id crate1slot2
```

## Design notes

- **Bash, not a Python entry point** — works without activating the pysmurf venv (common when SSHing into a smurf server just to inspect prior plots), no `pyproject.toml`/CI changes.
- **mtime sort (`ls -1dt`)** — robust against user-supplied non-numeric `name=` strings (`smurf_control.py:213-215`); default session names are unix timestamps so mtime ≈ lexical anyway.
- **Spans all dates under `<data_dir>`** — a server idle over a weekend has no `YYYYMMDD/` for today; "latest" must still resolve.
- **Default `--data-dir /data/smurf_data`** matches every cfg in `cfg_files/` (grepped: 20+ cfgs all set this value); `--data-dir` overrides.
- **`smurf_cmd_mode` is intentionally out of scope** — that layout (`<smurf_cmd_dir>/{outputs,plots,tune}`, `smurf_control.py:181-200`) has exactly one session, so "find latest" is meaningless there.
- No `SmurfControl` method added: inside an active session `self.plot_dir` is already populated.

## Test plan

- [x] Smoke test on a fresh tmp dir with two sessions of differing mtime: helper picks the newer one for `plots`, `outputs`, and `tune` subdirs.
- [x] `--data-path-id crate1slot2` selects the right nested layout.
- [x] Cross-date: older `YYYYMMDD/` exists alongside newer; helper still picks the newer.
- [x] Missing / empty `--data-dir`: exits 1 with `smurf-latest-dir: no session found under <dir>` to stderr.
- [x] `--data-dir <dir-with-only-empty-date>`: exits 1.
- [x] Unknown flag: exits 2 with usage message.
- [x] `--help`: prints the usage block.
- [x] `bash -n` syntax check clean.
- [x] CI gate: `flake8 --count python/` returns `0` (no Python files touched).
- [ ] Manual on a real smurf server with `/data/smurf_data` populated: `cd "$(scripts/smurf-latest-dir)"`.

## Closes

Closes #25.