### PR TITLE
fix(JesdWatchdog): Extend to monitor both bays (#20)

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -272,11 +272,25 @@ class SmurfUtilMixin(SmurfBase):
 
     # the JesdWatchdog will check if an instance of the JesdWatchdog is already
     # running and kill itself if there is
-    def start_jesd_watchdog(self):
+    def start_jesd_watchdog(self, epics_prefix, bays=None):
+        """Start the JesdWatchdog subprocess monitoring the given bays.
+
+        Args
+        ----
+        epics_prefix : str
+            EPICS prefix of the running rogue server (e.g. ``'smurf_server_s5'``).
+        bays : list of int, optional
+            Bay indices to monitor. Defaults to ``self.bays`` (the bays
+            detected at server startup).
+        """
         import pysmurf.client.watchdog.JesdWatchdog as JesdWatchdog
         import subprocess
         import sys
-        subprocess.Popen([sys.executable,JesdWatchdog.__file__])
+        if bays is None:
+            bays = self.bays
+        args = [sys.executable, JesdWatchdog.__file__, epics_prefix]
+        args += [str(b) for b in bays]
+        subprocess.Popen(args)
 
     # Shawn needs to make this better and add documentation.
     @set_action()

--- a/python/pysmurf/client/watchdog/JesdWatchdog.py
+++ b/python/pysmurf/client/watchdog/JesdWatchdog.py
@@ -14,40 +14,54 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import logging
+import re
 import sys
 import time
 from datetime import datetime
 
 import epics
 
+# Matches the bay index in PV names like
+# "...:AppTopJesd[1]:JesdRx:DataValid".
+_BAY_RE = re.compile(r'AppTopJesd\[(\d+)\]')
+
+
 class JesdWatchdog(object):
-    def __init__(self, prefix):
+    def __init__(self, prefix, bays):
         self.logfile = '/tmp/JesdWatchdog.log'
-        logging.basicConfig(filename=self.logfile,level=logging.ERROR)
+        logging.basicConfig(filename=self.logfile, level=logging.ERROR)
 
         self.prefix = prefix
+        self.bays = list(bays)
         self.enabledPv     = epics.get_pv('SIOC:SMRF:ML00:AO001', callback=self.enableChanged, auto_monitor=True)
         self.enable        = self.enabledPv.get()
-        self.jesdtxreset_thread = None
-        self.jesdrxreset_thread = None
+        self.jesdtxreset_thread = {bay: None for bay in self.bays}
+        self.jesdrxreset_thread = {bay: None for bay in self.bays}
         self.counterPv     = epics.get_pv('SIOC:SMRF:ML00:AO001CNT')
         self.counterPvProc = epics.get_pv('SIOC:SMRF:ML00:AO001CNT.PROC')
-        self.JesdRxValidPv = epics.get_pv(prefix + ':AMCc:FpgaTopLevel:AppTop:AppTopJesd[0]:JesdRx:DataValid', callback=self.jesdValidChanged, auto_monitor=True)
-        self.JesdTxValidPv = epics.get_pv(prefix + ':AMCc:FpgaTopLevel:AppTop:AppTopJesd[0]:JesdTx:DataValid', callback=self.jesdValidChanged, auto_monitor=True)
 
+        # Keep PV references in dicts so callbacks stay registered for the
+        # lifetime of the watchdog. One Rx/Tx pair per enabled bay.
+        self.JesdRxValidPv = {}
+        self.JesdTxValidPv = {}
+        for bay in self.bays:
+            rx_pv = f'{prefix}:AMCc:FpgaTopLevel:AppTop:AppTopJesd[{bay}]:JesdRx:DataValid'
+            tx_pv = f'{prefix}:AMCc:FpgaTopLevel:AppTop:AppTopJesd[{bay}]:JesdTx:DataValid'
+            self.JesdRxValidPv[bay] = epics.get_pv(rx_pv, callback=self.jesdValidChanged, auto_monitor=True)
+            self.JesdTxValidPv[bay] = epics.get_pv(tx_pv, callback=self.jesdValidChanged, auto_monitor=True)
 
     def enableChanged(self, pvname, value, *args, **kwargs):
         print("Enable changed to " + str(value))
         self.enable = value
 
     @staticmethod
-    def jesdRXReset(prefix):
-        logging.error(f'[{datetime.now()}] ' +
-                      ' JesdRx went down, will attempt to recover...')
+    def jesdRXReset(prefix, bay):
+        logging.error(f'[{datetime.now()}] '
+                      f' JesdRx went down on bay={bay}, will attempt to recover...')
 
         # for recovery
-        PwrUpSysRef = epics.get_pv(prefix + ':AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:LMK:PwrUpSysRef')
-        JesdRxEnable = epics.get_pv(prefix + ':AMCc:FpgaTopLevel:AppTop:AppTopJesd[0]:JesdRx:Enable')
+        PwrUpSysRef = epics.get_pv(f'{prefix}:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[{bay}]:LMK:PwrUpSysRef')
+        JesdRxEnable = epics.get_pv(f'{prefix}:AMCc:FpgaTopLevel:AppTop:AppTopJesd[{bay}]:JesdRx:Enable')
 
         #1. Toggle JesdRx:Enable 0x3F3 -> 0x0 -> 0x3F3
         JesdRxEnable.put(0x0)
@@ -56,25 +70,25 @@ class JesdWatchdog(object):
         PwrUpSysRef.put(1)
 
     @staticmethod
-    def jesdTXReset(prefix):
-        logging.error(f'[{datetime.now()}] ' +
-                      ' JesdTx went down, will attempt to recover...')
+    def jesdTXReset(prefix, bay):
+        logging.error(f'[{datetime.now()}] '
+                      f' JesdTx went down on bay={bay}, will attempt to recover...')
 
         # for recovery
-        PwrUpSysRef = epics.get_pv(prefix + ':AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:LMK:PwrUpSysRef')
-        JesdTxEnable = epics.get_pv(prefix + ':AMCc:FpgaTopLevel:AppTop:AppTopJesd[0]:JesdTx:Enable')
-        DAC0JesdRstN = epics.get_pv(prefix + ':AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:DAC[0]:JesdRstN')
-        DAC1JesdRstN = epics.get_pv(prefix + ':AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:DAC[1]:JesdRstN')
+        PwrUpSysRef = epics.get_pv(f'{prefix}:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[{bay}]:LMK:PwrUpSysRef')
+        JesdTxEnable = epics.get_pv(f'{prefix}:AMCc:FpgaTopLevel:AppTop:AppTopJesd[{bay}]:JesdTx:Enable')
+        DAC0JesdRstN = epics.get_pv(f'{prefix}:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[{bay}]:DAC[0]:JesdRstN')
+        DAC1JesdRstN = epics.get_pv(f'{prefix}:AMCc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[{bay}]:DAC[1]:JesdRstN')
 
         #1. Toggle JesdRx:Enable 0x3CF -> 0x0 -> 0x3CF
         JesdTxEnable.put(0x0)
         JesdTxEnable.put(0x3CF)
 
-        #2. Toggle AMCcc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:DAC[0]:JesdRstN 0x1 -> 0x0 -> 0x1
+        #2. Toggle AMCcc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[bay]:DAC[0]:JesdRstN 0x1 -> 0x0 -> 0x1
         DAC0JesdRstN.put(0x0)
         DAC0JesdRstN.put(0x1)
 
-        #3. Toggle AMCcc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[0]:DAC[1]:JesdRstN 0x1 -> 0x0 -> 0x1
+        #3. Toggle AMCcc:FpgaTopLevel:AppTop:AppCore:MicrowaveMuxCore[bay]:DAC[1]:JesdRstN 0x1 -> 0x0 -> 0x1
         DAC1JesdRstN.put(0x0)
         DAC1JesdRstN.put(0x1)
 
@@ -82,18 +96,26 @@ class JesdWatchdog(object):
         PwrUpSysRef.put(1)
 
     def jesdValidChanged(self, pvname, value, *args, **kwargs):
-        #print('[%s] ' % str(datetime.now()) + pvname + ' changed ; value=%s'%(str(value)))
-        if self.enable == 1:
-            if value == 0:
-                # JesdRx
-                if 'JesdRx' in pvname:
-                    self.jesdrxreset_thread = epics.ca.CAThread(target=self.jesdRXReset, args=(self.prefix,))
-                    self.jesdrxreset_thread.start()
+        if self.enable != 1 or value != 0:
+            return
 
-                # JesdTx
-                if 'JesdTx' in pvname:
-                    self.jesdtxreset_thread = epics.ca.CAThread(target=self.jesdTXReset, args=(self.prefix,))
-                    self.jesdtxreset_thread.start()
+        match = _BAY_RE.search(pvname)
+        if match is None:
+            logging.error(f'[{datetime.now()}] could not parse bay from pvname={pvname}')
+            return
+        bay = int(match.group(1))
+
+        # JesdRx
+        if 'JesdRx' in pvname:
+            self.jesdrxreset_thread[bay] = epics.ca.CAThread(
+                target=self.jesdRXReset, args=(self.prefix, bay))
+            self.jesdrxreset_thread[bay].start()
+
+        # JesdTx
+        if 'JesdTx' in pvname:
+            self.jesdtxreset_thread[bay] = epics.ca.CAThread(
+                target=self.jesdTXReset, args=(self.prefix, bay))
+            self.jesdtxreset_thread[bay].start()
 
     def run(self):
         count  = self.counterPv.get()
@@ -110,13 +132,15 @@ class JesdWatchdog(object):
         return
 
 
-
-
-
 if __name__ == '__main__':
     prefix = 'test_epics'
     if len(sys.argv) > 1:
         prefix = sys.argv[1]
 
-    wd = JesdWatchdog(prefix)
+    if len(sys.argv) > 2:
+        bays = [int(b) for b in sys.argv[2:]]
+    else:
+        bays = [0]
+
+    wd = JesdWatchdog(prefix, bays)
     wd.run()


### PR DESCRIPTION
## Summary
- Closes #20.
- `JesdWatchdog` previously hardcoded the bay index to `0` in every PV path (`AppTopJesd[0]`, `MicrowaveMuxCore[0]`), so a JESD drop on bay 1 was silently ignored on dual-AMC systems.
- Watchdog now subscribes per-bay `Rx`/`Tx` `DataValid` PVs; the valid-changed callback parses the bay index out of the incoming `pvname` and dispatches the matching reset thread. `jesdRXReset` / `jesdTXReset` take a `bay` arg and apply it to both `AppTopJesd[bay]` and `MicrowaveMuxCore[bay]`.
- `start_jesd_watchdog(epics_prefix, bays=None)` now requires the EPICS prefix (the watchdog is the only EPICS-CA consumer in pysmurf — the client itself runs over ZMQ to rogue, so the prefix has to come from the caller) and defaults `bays` to `self.bays`. The previous zero-arg form silently fell through to the placeholder prefix `test_epics` inside the watchdog's `__main__`, so it never actually worked against a real system.
- Direct CLI usage stays backward-compatible: `argv[1] = prefix`, `argv[2:] = bays` (defaults to `[0]` when omitted).

## Test plan
- [x] `flake8 --count python/` clean (matches CI invocation in `.github/workflows/test-or-deploy.yml`).
- [x] `python python/pysmurf/client/watchdog/JesdWatchdog.py myprefix 0 1` starts cleanly with no exceptions.
- [x] Bay-extraction regex unit-checked against `AppTopJesd[0]` and `AppTopJesd[1]` PV name forms.
- [ ] Hardware verification on a 2-bay system: force a `JesdRx:Enable` toggle on bay 1, confirm `/tmp/JesdWatchdog.log` shows `JesdRx went down on bay=1` and the recovery sequence runs against bay-1 PVs. Repeat for bay 0 to confirm no regression.