### PR TITLE
feat(smurf_tune): Encode bands present in tune filename (closes #14)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -4236,13 +4236,50 @@ class SmurfTuneMixin(SmurfBase):
         return ang
 
 
+    def _tune_band_suffix(self):
+        """
+        Hex bitmask (e.g. 'b01', 'b91', 'bFF') of the bands that hold real
+        tune data in self.freq_resp.  A band counts as tuned only when its
+        entry has a populated 'resonances' key, since self.freq_resp is
+        pre-seeded for every configured band at init time.
+        """
+        mask = 0
+        for band, entry in self.freq_resp.items():
+            if isinstance(entry, dict) and 'resonances' in entry:
+                mask |= (1 << int(band))
+        return f'b{mask:02X}'
+
+    def _mask_from_tune_path(self, path):
+        """
+        Parse the ``_tune_b{XX}`` suffix from a tune filename and return its
+        integer bitmask.  Returns 0 for legacy ``*_tune.npy`` files that have
+        no band suffix.
+        """
+        base = os.path.basename(path)
+        if not base.endswith('.npy'):
+            return 0
+        stem = base[:-len('.npy')]
+        marker = '_tune_b'
+        idx = stem.rfind(marker)
+        if idx < 0:
+            return 0
+        try:
+            return int(stem[idx + len(marker):], 16)
+        except ValueError:
+            return 0
+
     @set_action()
     def save_tune(self, update_last_tune=True):
         """
-        Saves the tuning information (self.freq_resp) to tuning directory
+        Saves the tuning information (self.freq_resp) to tuning directory.
+        The output filename encodes which bands hold tune data as a hex
+        bitmask suffix, e.g. ``..._tune_b01.npy`` (band 0 only) or
+        ``..._tune_bFF.npy`` (all 8 bands).  See :func:`last_tune` for the
+        band-aware lookup that consumes this naming scheme.
         """
         timestamp = self.get_timestamp()
-        savedir = os.path.join(self.tune_dir, timestamp+"_tune")
+        band_suffix = self._tune_band_suffix()
+        savedir = os.path.join(self.tune_dir, f'{timestamp}_tune_{band_suffix}')
         self.log(f'Saving to : {savedir}.npy')
         np.save(savedir, self.freq_resp)
         self.pub.register_file(savedir, 'tune', format='npy')
@@ -4310,13 +4347,35 @@ class SmurfTuneMixin(SmurfBase):
             return fs
 
     @set_action()
-    def last_tune(self):
+    def last_tune(self, band=None):
         """
         Returns the full path to the most recent tuning file, or None
         if no tune files are found.
+
+        Args
+        ----
+        band : int, int array, or None, optional, default None
+            If given, only return the most recent tune file whose
+            ``_b{XX}`` hex bitmask suffix indicates it contains tune data
+            for every band requested.  Legacy ``*_tune.npy`` files (no
+            suffix) carry unknown band content and are excluded when a
+            band filter is supplied.  When ``band`` is ``None`` (the
+            default), legacy and band-tagged files are both considered.
         """
-        tune_files = glob.glob(os.path.join(self.tune_dir,
-                                            '*_tune.npy'))
+        tune_files = (
+            glob.glob(os.path.join(self.tune_dir, '*_tune.npy')) +
+            glob.glob(os.path.join(self.tune_dir, '*_tune_b*.npy'))
+        )
+        if band is not None:
+            wanted = 0
+            for b in np.ravel(np.array(band)):
+                wanted |= (1 << int(b))
+            filtered = []
+            for f in tune_files:
+                mask = self._mask_from_tune_path(f)
+                if mask != 0 and (mask & wanted) == wanted:
+                    filtered.append(f)
+            tune_files = filtered
         if len(tune_files) == 0:
             self.log(
                 f'No tune files found in {self.tune_dir}',


### PR DESCRIPTION
## Summary
- Tune filenames now encode which bands hold real tune data via a hex bitmask suffix, e.g. `..._tune_b01.npy` (band 0), `..._tune_b91.npy` (bands 0, 4, 7), `..._tune_bFF.npy` (all 8 bands) — matching the convention proposed in #14.
- A band counts as tuned only when `freq_resp[band]` has a populated `'resonances'` key, since `freq_resp` is pre-seeded with empty placeholders for every configured band at init time.
- `last_tune()` gains an optional `band` argument that filters to the most recent tune file whose suffix proves it covers the requested band(s). Legacy `*_tune.npy` files (no suffix) are still discovered when `band=None`, but excluded when a band filter is supplied since their contents are unknown.

Closes #14.

## Changes
Single file: `python/pysmurf/client/tune/smurf_tune.py`
- New private helpers `_tune_band_suffix()` and `_mask_from_tune_path()`
- `save_tune()` filename now `{timestamp}_tune_b{XX}.npy`
- `last_tune(band=None)` dual-globs old and new naming and filters by bitmask

No API breakage: existing `last_tune()` callers (`smurf_tune.py:91`, `:4274`) pass no args and keep working. `load_tune()` is filename-agnostic and unchanged.

## Test plan
- [x] `flake8 --count python/` → 0 (matches CI in `.github/workflows/test-or-deploy.yml`)
- [x] Standalone sanity check of helpers: confirmed `b01`, `b91`, `bFF` for the issue's worked examples; confirmed pre-seeded-but-untuned bands are NOT counted (`b04` for band 2 only); confirmed `_mask_from_tune_path` round-trips and returns 0 for legacy/garbage filenames; confirmed `band`-filter logic returns the expected files.
- [ ] Hardware/server-docker smoke: run `S.tune_band_serial(band=2); path = S.save_tune()` and verify `path.endswith('_tune_b04.npy')`, `S.last_tune() == path`, `S.last_tune(band=2) == path`, `S.last_tune(band=5) != path`.
- [ ] Backward compatibility: drop a fake legacy `9999999999_tune.npy` into `tune_dir` and confirm `S.last_tune()` (no band arg) still finds it.