### PR TITLE
fix(plot_tune_summary): Skip empty full_band_resp from from_old_tune (#13)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -386,11 +386,11 @@ class SmurfTuneMixin(SmurfBase):
         if tone_power is None:
             tone_power = self._amplitude_scale[band]
         self.freq_resp[band]['tone_power'] = tone_power
-        self.freq_resp[band]['full_band_resp'] = {}
-        if freq is not None:
-            self.freq_resp[band]['full_band_resp']['freq'] = freq * 1.0E-6 + center_freq
-        if resp is not None:
-            self.freq_resp[band]['full_band_resp']['resp'] = resp
+        if freq is not None and resp is not None:
+            self.freq_resp[band]['full_band_resp'] = {
+                'freq': freq * 1.0E-6 + center_freq,
+                'resp': resp,
+            }
         self.freq_resp[band]['timestamp'] = timestamp
 
 
@@ -531,10 +531,14 @@ class SmurfTuneMixin(SmurfBase):
         # Plot individual eta scan
         if eta_scan:
             keys = self.freq_resp[band]['resonances'].keys()
-            # If using full band response as input
-            if 'full_band_resp' in self.freq_resp[band]:
-                freq = self.freq_resp[band]['full_band_resp']['freq']
-                resp = self.freq_resp[band]['full_band_resp']['resp']
+            # If using full band response as input. Older tune files
+            # may have an empty full_band_resp dict (e.g. saved by
+            # tune_band_serial(from_old_tune=True)) -- require both
+            # 'freq' and 'resp' subkeys before taking this branch.
+            fbr = self.freq_resp[band].get('full_band_resp') or {}
+            if 'freq' in fbr and 'resp' in fbr:
+                freq = fbr['freq']
+                resp = fbr['resp']
                 for k in keys:
                     r = self.freq_resp[band]['resonances'][k]
                     channel=r['channel']


### PR DESCRIPTION
## Summary

Fixes #13. `plot_tune_summary(band, eta_scan=True)` crashes with `KeyError: 'freq'` when the loaded tune file contains an empty `full_band_resp = {}`.

The empty dict is written by `tune_band_serial(from_old_tune=True)`: that path loads tune data from disk without running a fresh full-band sweep, but `freq_resp[band]['full_band_resp'] = {}` was assigned unconditionally and the empty dict was then persisted by `save_tune()`. On a later session, the existence check in `plot_tune_summary` (`if 'full_band_resp' in self.freq_resp[band]`) passed, but accessing `['freq']` raised.

## Changes

- `tune_band_serial` (`smurf_tune.py:389-393`): only assign `full_band_resp` when both `freq` and `resp` are populated. Prevents future tune files from carrying an empty dict.
- `plot_tune_summary` (`smurf_tune.py:533-541`): also require the `'freq'` and `'resp'` subkeys before taking the full-band branch. Already-saved bad tune files fall through to the existing per-resonance `freq_eta_scan` / `resp_eta_scan` branch instead of raising.

## Test plan

- [x] `flake8 --count python/` — 0 errors (matches CI).
- [x] Smoke test of the patched predicates: confirmed pre-fix code reproduces `KeyError('freq')` on an empty `full_band_resp`, post-fix code falls through to the `else` branch and the populated-`full_band_resp` happy path is unchanged.
- [ ] Full hardware exercise of `plot_tune_summary(band, eta_scan=True)` against a tune file produced by `tune_band_serial(from_old_tune=True)` — requires SMuRF hardware; not feasible from this checkout.