### PR TITLE
fix(tracking_setup): Include band number in FR_amp_v_err plot filename (#8)

### DIFF
--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2783,7 +2783,7 @@ class SmurfTuneMixin(SmurfBase):
 
             if save_plot:
                 path = os.path.join(self.plot_dir,
-                    timestamp + '_FR_amp_v_err' + plotname_append + '.png')
+                    f'{timestamp}_b{band}_FR_amp_v_err{plotname_append}.png')
                 plt.savefig(path, bbox_inches='tight')
                 self.pub.register_file(path, 'amp_vs_err', plot=True)
 


### PR DESCRIPTION
## Summary

Closes #8.

`tracking_setup` writes its 3-panel summary plot to
`{timestamp}_FR_amp_v_err{plotname_append}.png`. The band number is missing
from the filename, so running `tracking_setup` across multiple bands in one
session overwrites the same file repeatedly — the plot from the last band run
is the only one that survives on disk.

This PR adds `_b{band}_` to the filename, matching the convention already used
elsewhere in `smurf_tune.py`:

- `{timestamp}_b{band}_full_band_resp_raw.png` (`smurf_tune.py:753`)
- `{timestamp}_b{band}_full_band_resp.png` (`smurf_tune.py:770`)
- `{timestamp}_channel_assignment_b{band}.txt` (`smurf_tune.py:1769`)
- `..._b{band}_sb{sb:03}_flux_ramp_check.png` (`smurf_tune.py:2426`)

`plotname_append` is preserved at the end so the existing
"append-to-plot-filename" feature (PR #233) keeps working. The publisher tag
(`'amp_vs_err'` at `smurf_tune.py:2788`) is independent of the filename and is
not touched.

### Diff

`python/pysmurf/client/tune/smurf_tune.py` — 1 line changed:

```diff
                 path = os.path.join(self.plot_dir,
-                    timestamp + '_FR_amp_v_err' + plotname_append + '.png')
+                    f'{timestamp}_b{band}_FR_amp_v_err{plotname_append}.png')
```

## Note on issue #8 history

Issue #8 (filed 2019-04-11) asked for three things on the tracking-setup
summary plot:

1. **Band number visible on the plot** — already satisfied in `main` by the
   `fig.suptitle(f'{timestamp} Band {band}')` added 2020-05-29 (commit
   `3dd49f2c9`, "updating plotting for tracking_setup").
2. **More info on the plot** — already satisfied in `main` by the
   operational-parameters text box at `smurf_tune.py:2770-2780` (Reset rate,
   LMS freq, LMS gain, FR amp, FB start/end, FB enable 1/2/3, n_chan), added
   2020-03-31 → 2020-05-29.
3. **Band number in filename** — fixed by this PR.

The 2020 commits were never linked back to #8, so the issue stayed open.

## Test plan

- [x] `flake8 --count python/` (CI parity command from `.github/workflows/test-or-deploy.yml`) → 0 errors
- [x] `git grep "FR_amp_v_err" -- python/` → only the new line; no stale
  references
- [ ] CI: flake8, docker definitions, docs build
- [ ] Hardware sanity check (any reviewer with a crate): run
  `S.tracking_setup(band=N, ...)` for two different bands and confirm both
  `..._b<N1>_FR_amp_v_err...png` and `..._b<N2>_FR_amp_v_err...png` survive
  on disk in `self.plot_dir`.