### PR TITLE
docs(smurf_command): Mark RF DAC enable/reset/axil_addr as low-level (#7)

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -2805,6 +2805,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_dac_enable(self, bay, dac, val, **kwargs):
         """
+        Low-level function.  The RF DAC enable is configured
+        automatically during ``setup()``; users should not normally
+        need to call this directly.
+
         Enables DAC
 
         Args
@@ -2822,6 +2826,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_dac_enable(self, bay, dac, **kwargs):
         """
+        Low-level function.  The RF DAC enable is configured
+        automatically during ``setup()``; users should not normally
+        need to call this directly.
+
         Gets enable status of DAC
 
         Args
@@ -3698,6 +3706,11 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_dac_axil_addr(self, reg, val, **kwargs):
         """
+        Low-level function.  Used internally by
+        ``set_tes_bias_bipolar`` and ``set_tes_bias_bipolar_array`` to
+        route the RTM LUT to the correct DAC pair; users should not
+        normally need to call this directly.
+
         Sets the DacAxilAddr[#] registers.
         """
         assert (reg in range(2)), 'reg must be in [0,1]'
@@ -3707,6 +3720,9 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_dac_axil_addr(self, reg, **kwargs):
         """
+        Low-level function.  Used internally by the bipolar TES-bias
+        path; users should not normally need to call this directly.
+
         Gets the DacAxilAddr[#] registers.
         """
         assert (reg in range(2)), 'reg must be in [0,1]'
@@ -5773,6 +5789,11 @@ class SmurfCommandMixin(SmurfBase):
 
     def set_dac_reset(self, bay, dac, val, **kwargs):
         """
+        Low-level function.  Called from ``SmurfControl.setup()`` to
+        issue the physical reset to the RF DACs after
+        ``setDefaults``; users should not normally need to call this
+        directly.
+
         Toggles the physical reset line to DAC. Set to 1 then 0
 
         Args
@@ -5788,6 +5809,10 @@ class SmurfCommandMixin(SmurfBase):
 
     def get_dac_reset(self, bay, dac, **kwargs):
         """
+        Low-level function.  The DAC reset line is exercised by
+        ``SmurfControl.setup()``; users should not normally need to
+        call this directly.
+
         Reads the physical reset DAC register.  Will be either 0 or 1.
 
         Args


### PR DESCRIPTION
## Summary

Closes #7.

Adds a "Low-level function. ... users should not normally need to call this directly" preamble to the bare docstrings of the RF DAC enable / reset / axil-addr functions in `SmurfCommandMixin`:

- `set_dac_enable` / `get_dac_enable` (`smurf_command.py:2806`, `:2823`)
- `set_dac_axil_addr` / `get_dac_axil_addr` (`smurf_command.py:3699`, `:3708`)
- `set_dac_reset` / `get_dac_reset` (`smurf_command.py:5774`, `:5789`)

These are exercised by `SmurfControl.setup()` and by the bipolar TES-bias path (`set_tes_bias_bipolar` / `set_tes_bias_bipolar_array`); the lack of any "this is internal" hint was the root of the Princeton confusion that motivated #7. Phrasing matches the existing precedent at `get_amp_drain_enable` (`smurf_command.py:4480`: *"Don't use directly, use get_amp_drain_voltage."*).

Docstring-only — no API change, no behavior change.

## Why this is enough to close #7

Most of #7 was already done on `main`:
- The legacy ambiguous amplifier enables (`set_hemt_enable`, `set_50k_amp_enable`, `set_hemt_bias`, `set_amplifier_bias`, `get_50k_amp_drain_current`, …) are stubbed as deprecation wrappers redirecting to the new generic API (`smurf_command.py:4698-4746`).
- `get_amp_drain_enable` already documents *"Don't use directly"*; `set_amp_drain_enable` already notes that `set_amp_drain_voltage` toggles it automatically.
- RTM slow DAC enables (`set_rtm_slow_dac_enable*`, `get_rtm_slow_dac_enable*`) carry full docstrings explaining `0x2`/`0xE` semantics.
- PR #486 privatized the CryoCard low-level helpers (`_cmd_address`, `_cmd_data`, `_cmd_make`).

This PR closes the last gap — the RF DAC enables — without renaming any public API, since the second (tentative) half of #7 about hiding from ipython tab-completion would silently break downstream user code that calls these directly.

## Test plan

- [x] `flake8 --count python/` (CI lint) — 0 issues
- [x] `python -m py_compile python/pysmurf/client/command/smurf_command.py` — passes
- [x] AST parse: confirmed all six target functions now carry the new "Low-level function." preamble in their docstring
- [x] `git diff` — only six docstring blocks changed, no whitespace or behavior diff elsewhere