### PR TITLE
Fix asymmetric DSP bandwidth boundary in get_processed_channels()

### DIFF
--- a/cfg_files/b33/experiment_b33_rfc1-2_C05-40_s4_2xLB_backplane.cfg
+++ b/cfg_files/b33/experiment_b33_rfc1-2_C05-40_s4_2xLB_backplane.cfg
@@ -1,0 +1,566 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_4" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_5" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_6" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_7" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask" : {
+},
+
+"amplifier" : {
+	     # Updated 8/9/21, gives roughly Id=4mA
+	     "hemt_Vg" : 0.265,
+	     "bit_to_V_hemt" : 1.93e-06,
+	      # C05-40, measured with drain set to 0.5V but output open
+	     "hemt_Id_offset" : 0.2326,
+	     "LNA_Vg" : 0,
+	      # C05-40, measured with drain set to 5.0V but output open	     
+	     "50k_Id_offset" : 0.5084,
+	     "dac_num_50k" : 32,
+	     "bit_to_V_50k" : 3.38e-06,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0,
+	     "hemt1" : {
+		     "drain_conversion_b": 1.74185,
+		     "drain_conversion_m": -0.259491,
+		     "drain_dac_num": 31,
+		     # C05-40, measured with drain set to 0.5V but output open
+		     "drain_offset": 0.2326,
+		     "drain_opamp_gain": 3.874,
+		     "drain_pic_address": 3,
+		     "drain_resistor": 50.0,
+		     "drain_volt_default": 0.5,
+		     "drain_volt_min": 0,
+		     "drain_volt_max": 2,
+		     "gate_bit_to_volt": 3.86936e-6,
+		     "gate_volt_default": 0.265,
+		     "gate_volt_min": 0,
+		     "gate_volt_max": 2.03,
+		     "power_bitmask": 1
+		     },
+
+             "hemt2":{
+	      	     "drain_conversion_m":-0.259491,
+              	     "drain_conversion_b":1.74185,
+              	     "drain_dac_num":29,
+		     # C05-40, measured with drain set to 0.5V but output open		     
+              	     "drain_offset":0.2881,
+              	     "drain_opamp_gain":3.874,
+              	     "drain_pic_address":10,
+              	     "drain_resistor":50.0,
+              	     "drain_volt_default":0.5,
+              	     "drain_volt_max":2,
+              	     "drain_volt_min":0,
+              	     "gate_bit_to_volt":3.86936e-6,
+              	     "gate_dac_num":27,
+              	     "gate_volt_default":0.0,
+              	     "gate_volt_max":2.03,
+              	     "gate_volt_min":0,
+              	     "power_bitmask":4
+              },
+
+             "50k1" : {
+               "drain_conversion_m": -0.224968,
+               "drain_conversion_b": 5.59815,
+               "drain_dac_num": 32,
+	       # C05-40, measured with drain set to 5.0V but output open
+               "drain_offset": 0.5084,
+               "drain_opamp_gain": 9.929,
+               "drain_pic_address": 4,
+               "drain_resistor": 12.0,
+               "drain_volt_default": 5.0,
+               "drain_volt_max": 5.5,
+               "drain_volt_min": 3.5,
+               "gate_bit_to_volt": 3.86936e-6,
+               "gate_dac_num": 30,
+               "gate_volt_default": 0.0,
+               "gate_volt_max": 2.03,
+               "gate_volt_min": 0,
+               "power_bitmask": 2
+	    },		
+
+           "50k2" : {
+               "drain_conversion_m": -0.224968,
+               "drain_conversion_b": 5.59815,
+               "drain_dac_num": 28,
+	       # C05-40, measured with drain set to 5.0V but output open
+               "drain_offset": 0.3599,
+               "drain_opamp_gain": 9.929,
+               "drain_pic_address": 11,
+               "drain_resistor": 12.0,
+               "drain_volt_default": 5.0,
+               "drain_volt_max": 5.5,
+               "drain_volt_min": 3.5,
+               "gate_bit_to_volt": 3.86936e-6,
+               "gate_dac_num": 26,
+               "gate_volt_default": 0.0,
+               "gate_volt_max": 2.03,
+               "gate_volt_min": 0,
+               "power_bitmask": 8
+           }
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24],
+        "12" : [25,26],
+        "13" : [27,28],
+        "14" : [29,30]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 16100,
+"high_low_current_ratio" : 5.669,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [3],
+
+"tune_band" : {
+	"reset_rate_khz" : 4.0,
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.495,
+	"delta_freq" : {
+		    "0" : 0.02,	
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02,
+		    "4" : 0.02,
+		    "5" : 0.02,
+		    "6" : 0.02,
+		    "7" : 0.02
+	},		
+	"lms_freq": {
+		    "0" : 16500,	
+		    "1" : 16500,
+		    "2" : 16500,
+		    "3" : 16500,
+		    "4" : 16500,
+		    "5" : 16500,
+		    "6" : 16500,
+		    "7" : 16500
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,	
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05,
+		    "4" : 0.05,
+		    "5" : 0.05,
+		    "6" : 0.05,
+		    "7" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,		    
+		    "2" : 0.98,
+		    "3" : 0.98,
+		    "4" : 0.98,
+		    "5" : 0.98,
+		    "6" : 0.98,
+		    "7" : 0.98		    
+	},	
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,		    
+		    "2" : 1e-4,
+		    "3" : 1e-4,
+		    "4" : 1e-4,
+		    "5" : 1e-4,
+		    "6" : 1e-4,
+		    "7" : 1e-4		    
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        },
+	"gradient_descent_converge_hz": {
+		    "0" : 500,
+		    "1" : 500,		    
+		    "2" : 500,
+		    "3" : 500,
+		    "4" : 500,
+		    "5" : 500,
+		    "6" : 500,
+		    "7" : 500		    
+        },
+	"gradient_descent_step_hz": {
+		    "0" : 1000,
+		    "1" : 1000,		    
+		    "2" : 1000,
+		    "3" : 1000,
+		    "4" : 1000,
+		    "5" : 1000,
+		    "6" : 1000,
+		    "7" : 1000		    
+        },
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,		    
+		    "2" : 0,
+		    "3" : 0,
+		    "4" : 0,
+		    "5" : 0,
+		    "6" : 0,
+		    "7" : 0
+        },
+	"gradient_descent_momentum": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1
+        },	
+	"eta_scan_del_f": {
+                    "0": 5000,
+                    "1": 5000,
+                    "2": 5000,
+                    "3": 5000,
+                    "4": 5000,
+                    "5": 5000,
+                    "6": 5000,
+                    "7": 5000		    
+        },
+        "eta_scan_amplitude":{
+                    "0" : 12,
+                    "1" : 12,
+                    "2" : 12,
+                    "3" : 12,
+                    "4" : 12,
+                    "5" : 12,
+                    "6" : 12,		    
+                    "7" : 12		    
+        },
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "backplane"
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 0,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+# For remote commanding
+#"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/cfg_files/b33/experiment_b33_rfc1-2_C05-40_s4_2xLB_extref.cfg
+++ b/cfg_files/b33/experiment_b33_rfc1-2_C05-40_s4_2xLB_extref.cfg
@@ -1,0 +1,566 @@
+{
+"epics_root" : "test_epics",
+"init": {
+
+	"dspEnable": 1,
+
+	"band_0" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_1" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_2" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.
+		"lmsDelay" : 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_3" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 12,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_4" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_5" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_6" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	},
+
+	"band_7" : {
+		"iq_swap_in" : 0,
+		"iq_swap_out" : 0,
+		"refPhaseDelay" : 6,
+		"refPhaseDelayFine" : 0,
+		# Matches system latency for LMS feedback (multiplex
+		# of 52x 9.6MHz ticks) Adjust to match refPhaseDelay*4
+		# (e.g. if refPhaseDelay = 6, lmsDelay = 24).  Mitch
+		# is checking this ; might not be refPhaseDelay*4 -
+		# need to revisit.		
+		"lmsDelay": 24,
+		# Adjust trigRstDly such that the ramp resets at the
+		# flux ramp glitch.  Not totally clear at the moment
+		# what that means.
+		"trigRstDly" : 15, # 0xF
+		"feedbackEnable": 1,
+		"feedbackGain" : 2048,
+		"feedbackPolarity" : 1,
+		"feedbackLimitkHz": 225,
+		"lmsGain": 1,
+		"att_uc": 0,
+		"att_dc": 0,
+		"amplitude_scale": 12
+	}
+},
+
+"bad_mask" : {
+},
+
+"amplifier" : {
+	     # Updated 8/9/21, gives roughly Id=4mA
+	     "hemt_Vg" : 0.265,
+	     "bit_to_V_hemt" : 1.93e-06,
+	      # C05-40, measured with drain set to 0.5V but output open
+	     "hemt_Id_offset" : 0.2326,
+	     "LNA_Vg" : 0,
+	      # C05-40, measured with drain set to 5.0V but output open	     
+	     "50k_Id_offset" : 0.5084,
+	     "dac_num_50k" : 32,
+	     "bit_to_V_50k" : 3.38e-06,
+	     "hemt_gate_min_voltage" : -1.0,
+	     "hemt_gate_max_voltage" :  1.0,
+	     "hemt1" : {
+		     "drain_conversion_b": 1.74185,
+		     "drain_conversion_m": -0.259491,
+		     "drain_dac_num": 31,
+		     # C05-40, measured with drain set to 0.5V but output open
+		     "drain_offset": 0.2326,
+		     "drain_opamp_gain": 3.874,
+		     "drain_pic_address": 3,
+		     "drain_resistor": 50.0,
+		     "drain_volt_default": 0.5,
+		     "drain_volt_min": 0,
+		     "drain_volt_max": 2,
+		     "gate_bit_to_volt": 3.86936e-6,
+		     "gate_volt_default": 0.265,
+		     "gate_volt_min": 0,
+		     "gate_volt_max": 2.03,
+		     "power_bitmask": 1
+		     },
+
+             "hemt2":{
+	      	     "drain_conversion_m":-0.259491,
+              	     "drain_conversion_b":1.74185,
+              	     "drain_dac_num":29,
+		     # C05-40, measured with drain set to 0.5V but output open		     
+              	     "drain_offset":0.2881,
+              	     "drain_opamp_gain":3.874,
+              	     "drain_pic_address":10,
+              	     "drain_resistor":50.0,
+              	     "drain_volt_default":0.5,
+              	     "drain_volt_max":2,
+              	     "drain_volt_min":0,
+              	     "gate_bit_to_volt":3.86936e-6,
+              	     "gate_dac_num":27,
+              	     "gate_volt_default":0.0,
+              	     "gate_volt_max":2.03,
+              	     "gate_volt_min":0,
+              	     "power_bitmask":4
+              },
+
+             "50k1" : {
+               "drain_conversion_m": -0.224968,
+               "drain_conversion_b": 5.59815,
+               "drain_dac_num": 32,
+	       # C05-40, measured with drain set to 5.0V but output open
+               "drain_offset": 0.5084,
+               "drain_opamp_gain": 9.929,
+               "drain_pic_address": 4,
+               "drain_resistor": 12.0,
+               "drain_volt_default": 5.0,
+               "drain_volt_max": 5.5,
+               "drain_volt_min": 3.5,
+               "gate_bit_to_volt": 3.86936e-6,
+               "gate_dac_num": 30,
+               "gate_volt_default": 0.0,
+               "gate_volt_max": 2.03,
+               "gate_volt_min": 0,
+               "power_bitmask": 2
+	    },		
+
+           "50k2" : {
+               "drain_conversion_m": -0.224968,
+               "drain_conversion_b": 5.59815,
+               "drain_dac_num": 28,
+	       # C05-40, measured with drain set to 5.0V but output open
+               "drain_offset": 0.3599,
+               "drain_opamp_gain": 9.929,
+               "drain_pic_address": 11,
+               "drain_resistor": 12.0,
+               "drain_volt_default": 5.0,
+               "drain_volt_max": 5.5,
+               "drain_volt_min": 3.5,
+               "gate_bit_to_volt": 3.86936e-6,
+               "gate_dac_num": 26,
+               "gate_volt_default": 0.0,
+               "gate_volt_max": 2.03,
+               "gate_volt_min": 0,
+               "power_bitmask": 8
+           }
+},
+
+"attenuator" : {
+	"att1" : 0,
+	"att2" : 1,
+	"att3" : 2,
+	"att4" : 3
+},
+
+"chip_to_freq" : {
+	"9" :  [4.94150, 5.05],
+	"10" : [5.05, 5.17550 ],
+	"11" : [5.20150, 5.28250 ],
+	"12" : [5.28250, 5.41050 ],
+	"13" : [5.42050, 5.54550 ],
+	"14" : [5.55150, 5.67650 ],
+	"15" : [5.66650, 5.79150 ],
+	"16" : [5.79050, 5.91550 ]
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"pic_to_bias_group": {
+        "0" : 0,
+        "1" : 1,
+        "2" : 2,
+        "3" : 3,
+        "4" : 4,
+        "5" : 5,
+        "6" : 6,
+        "7" : 7,
+        "8" : 8,
+        "9" : 9,
+        "10" : 10,
+        "11" : 11,
+        "12" : 12,
+        "13" : 13,
+        "14" : 14,
+        "15" : 15
+},
+
+# Set for C02 cryostat card.  See
+#https://confluence.slac.stanford.edu/display/SMuRF/Cryostat+board
+"bias_group_to_pair" : {
+        "0" : [1,2],
+        "1" : [3,4],
+        "2" : [5,6],
+        "3" : [7,8],
+        "4" : [9,10],
+        "5" : [11,12],
+        "6" : [13,14],
+        "7" : [15,16],
+        "8" : [17,18],
+        "9" : [19,20],
+        "10" : [21,22],
+        "11" : [23,24],
+        "12" : [25,26],
+        "13" : [27,28],
+        "14" : [29,30]
+},
+
+"R_sh" : 390e-6,
+"bias_line_resistance" : 16100,
+"high_low_current_ratio" : 5.669,
+
+"high_current_mode_bool": 0,
+
+"all_bias_groups": [3],
+
+"tune_band" : {
+	"reset_rate_khz" : 4.0,
+	"n_samples" : 262144,
+	"grad_cut" : 0.05,
+	"amp_cut" : 0.25,
+	"freq_max" : 250000000,
+	"freq_min" : -250000000,
+	# For Stanford 5-6ghz 528 box in FP29, with a standard (not
+	# modified for high current) RTM
+	"fraction_full_scale": 0.495,
+	"delta_freq" : {
+		    "0" : 0.02,	
+		    "1" : 0.02,
+		    "2" : 0.02,
+		    "3" : 0.02,
+		    "4" : 0.02,
+		    "5" : 0.02,
+		    "6" : 0.02,
+		    "7" : 0.02
+	},		
+	"lms_freq": {
+		    "0" : 16500,	
+		    "1" : 16500,
+		    "2" : 16500,
+		    "3" : 16500,
+		    "4" : 16500,
+		    "5" : 16500,
+		    "6" : 16500,
+		    "7" : 16500
+        },
+	# The fraction of each flux ramp cycle above which we start
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then You want this to be large enough to mask the transient
+	# which occurs after each flux ramp reset.  Must be in [0,1).
+	"feedback_start_frac" : {
+		    "0" : 0.05,	
+		    "1" : 0.05,
+		    "2" : 0.05,
+		    "3" : 0.05,
+		    "4" : 0.05,
+		    "5" : 0.05,
+		    "6" : 0.05,
+		    "7" : 0.05
+	},
+	# The fraction of each flux ramp cycle above which we stop
+	# applying feedback, within each cycle.  Must be >0.  If >1,
+	# then feedback over the entire cycle (after feedbackStart).
+	"feedback_end_frac" : {
+		    "0" : 0.98,
+		    "1" : 0.98,		    
+		    "2" : 0.98,
+		    "3" : 0.98,
+		    "4" : 0.98,
+		    "5" : 0.98,
+		    "6" : 0.98,
+		    "7" : 0.98		    
+	},	
+	"gradient_descent_gain": {
+		    "0" : 1e-4,
+		    "1" : 1e-4,		    
+		    "2" : 1e-4,
+		    "3" : 1e-4,
+		    "4" : 1e-4,
+		    "5" : 1e-4,
+		    "6" : 1e-4,
+		    "7" : 1e-4		    
+        },
+	"gradient_descent_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        },
+	"gradient_descent_converge_hz": {
+		    "0" : 500,
+		    "1" : 500,		    
+		    "2" : 500,
+		    "3" : 500,
+		    "4" : 500,
+		    "5" : 500,
+		    "6" : 500,
+		    "7" : 500		    
+        },
+	"gradient_descent_step_hz": {
+		    "0" : 1000,
+		    "1" : 1000,		    
+		    "2" : 1000,
+		    "3" : 1000,
+		    "4" : 1000,
+		    "5" : 1000,
+		    "6" : 1000,
+		    "7" : 1000		    
+        },
+	"gradient_descent_beta": {
+		    "0" : 0,
+		    "1" : 0,		    
+		    "2" : 0,
+		    "3" : 0,
+		    "4" : 0,
+		    "5" : 0,
+		    "6" : 0,
+		    "7" : 0
+        },
+	"gradient_descent_momentum": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1
+        },	
+	"eta_scan_del_f": {
+                    "0": 5000,
+                    "1": 5000,
+                    "2": 5000,
+                    "3": 5000,
+                    "4": 5000,
+                    "5": 5000,
+                    "6": 5000,
+                    "7": 5000		    
+        },
+        "eta_scan_amplitude":{
+                    "0" : 12,
+                    "1" : 12,
+                    "2" : 12,
+                    "3" : 12,
+                    "4" : 12,
+                    "5" : 12,
+                    "6" : 12,		    
+                    "7" : 12		    
+        },
+	"eta_scan_averages": {
+		    "0" : 1,
+		    "1" : 1,		    
+		    "2" : 1,
+		    "3" : 1,
+		    "4" : 1,
+		    "5" : 1,
+		    "6" : 1,
+		    "7" : 1		    
+        }
+	#"default_tune": "/data/smurf_data/tune/1558666435_tune.npy"
+},
+
+"flux_ramp" : {
+	"select_ramp" : 1,
+	"num_flux_ramp_counter_bits" : 32
+},
+
+"constant" : {
+	"pA_per_phi0" : 9e6
+},
+
+"timing" : {
+	# "ext_ref" : internal oscillator locked to an external
+	#   front-panel reference, or unlocked if there is no front
+	#   panel reference.  (LmkReg_0x0147 : 0x1A).  Also sets
+	#   flux_ramp_start_mode=0
+	# "backplane" : takes timing from timing master through
+	#   backplane.  Also sets flux_ramp_start_mode=1.
+	"timing_reference" : "ext_ref"
+},
+
+"fs" : 200.0,
+
+"smurf_to_mce" : {
+	"smurf_to_mce_file" : "/data/smurf2mce_config/smurf2mce.cfg",
+	"mask_file" : "/data/smurf2mce_config/mask.txt",
+	"receiver_ip" : "tcp://192.168.3.1:3334",
+	"port_number" : "3334",
+	"filter_freq" : 63,
+	"filter_order" : 0,
+	"filter_gain" : 1.0,
+	"file_name_extend" : 1,
+	"data_frames" : 300000,
+	"static_mask" : 0,
+	"num_averages" : 20,
+	# Kludge to account for offset in gcp channel number in early
+	# versios of the DSPv3 fw.  May be different for each band, in
+	# mitch_4_30 the offset for band 2 is -2.  Mitch plans to fix
+	# in fw, so this should be unnecessary soon.
+	"mask_channel_offset" : 0
+},
+
+"default_data_dir": "/data/smurf_data",
+# For remote commanding
+#"smurf_cmd_dir": "/data/smurf_data/smurf_cmd",
+"tune_dir" : "/data/smurf_data/tune",
+"status_dir" : "/data/smurf_data/status"
+}

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2548,8 +2548,9 @@ class SmurfUtilMixin(SmurfBase):
         channelorderfile : str or None, optional, default None
             Path to a file that contains one channel per line.
         """
-        n_proc = self.get_number_processed_channels()
-        tone_freq_offset = self.get_tone_frequency_offset_mhz()
+        band = self._bands[0]
+        n_proc = self.get_number_processed_channels(band)
+        tone_freq_offset = self.get_tone_frequency_offset_mhz(band)
         # Select the n_proc channels nearest to DC. Tie-break:
         # firmware uses -Fdsp/2 <= freq < Fdsp/2, so at equal |freq|
         # the negative frequency is included and positive excluded.

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -2537,16 +2537,24 @@ class SmurfUtilMixin(SmurfBase):
         tracking_setup only returns data for the processed
         channels. Therefore every channel is not returned.
 
+        The firmware processes the channels nearest to DC within its
+        DSP bandwidth. When two channels are equidistant from DC
+        (at the bandwidth boundary), the firmware includes the negative
+        frequency and excludes the positive (asymmetric: lower bound
+        inclusive, upper bound exclusive).
+
         Args
         ----
         channelorderfile : str or None, optional, default None
             Path to a file that contains one channel per line.
         """
         n_proc = self.get_number_processed_channels()
-        n_chan = self.get_number_channels()
-        n_cut = (n_chan - n_proc)//2
-        return np.sort(self.get_channel_order(
-            channel_orderfile=channel_orderfile)[n_cut:-n_cut])
+        tone_freq_offset = self.get_tone_frequency_offset_mhz()
+        # Select the n_proc channels nearest to DC. Tie-break:
+        # firmware uses -Fdsp/2 <= freq < Fdsp/2, so at equal |freq|
+        # the negative frequency is included and positive excluded.
+        sort_key = np.abs(tone_freq_offset) + (tone_freq_offset > 0) * 1e-10
+        return np.sort(np.argsort(sort_key)[:n_proc])
 
     def get_subband_from_channel(self, band, channel, channelorderfile=None,
             yml=None):

--- a/scratch/shawn/verify_channel_mapping.py
+++ b/scratch/shawn/verify_channel_mapping.py
@@ -1,0 +1,228 @@
+"""
+Verification script for DSPv3 channel mapping bug.
+
+This script identifies the mismatch between the firmware's actual
+processed channel set and pysmurf's computed processed channel set.
+
+The bug: pysmurf uses a symmetric frequency cut (|freq| < Fdsp/2) to
+determine which 416 of 512 channels are processed, but the firmware
+uses an asymmetric condition (-Fdsp/2 <= freq < Fdsp/2). This causes
+a one-channel discrepancy at the bandwidth boundary that shifts the
+debug data mapping for channels 23 and 24 (subbands 51 and 75).
+
+Usage:
+    Run in a pysmurf session with an active band:
+        %run verify_channel_mapping.py
+
+    Or import and call:
+        from verify_channel_mapping import verify_channel_mapping
+        verify_channel_mapping(S, band=0)
+
+    Set PROBE_FIRMWARE=True to empirically measure the firmware's
+    processed set (takes ~10 minutes). Set False to use the theoretical
+    computation only.
+"""
+
+import numpy as np
+import time
+
+PROBE_FIRMWARE = False  # Set True to empirically probe each channel
+
+
+def get_firmware_processed_empirical(S, band, nsamp=2**12):
+    """Probe each channel to find which ones produce non-zero debug data.
+
+    Turns on each channel individually with rf_iq debug data and checks
+    for non-zero output. This gives ground truth for which channels the
+    firmware actually processes.
+
+    WARNING: This takes ~10 minutes and will disturb any active channels.
+    """
+    print("Probing firmware processed channels empirically...")
+    print("(This turns on each channel individually — will take several minutes)")
+
+    n_channels = S.get_number_channels(band)
+    firmware_processed = []
+    firmware_unprocessed = []
+
+    for chan in range(n_channels):
+        S.set_amplitude_scale_channel(band, chan, 12)
+        i, q, sync = S.take_debug_data(band=band, channel=None,
+                                        rf_iq=True, nsamp=nsamp)
+        S.channel_off(band, chan)
+
+        if len(np.nonzero(i)[0]) > 0:
+            firmware_processed.append(chan)
+        else:
+            firmware_unprocessed.append(chan)
+
+        if (chan + 1) % 64 == 0:
+            print(f"  ... probed {chan + 1}/{n_channels} channels")
+
+    return np.array(sorted(firmware_processed)), np.array(sorted(firmware_unprocessed))
+
+
+def get_firmware_processed_theoretical(S, band):
+    """Compute the firmware's processed channel set from first principles.
+
+    The firmware processes the N channels nearest to DC (where N comes
+    from get_number_processed_channels). At the bandwidth boundary, the
+    firmware includes the negative frequency and excludes the positive
+    (asymmetric: lower bound inclusive, upper bound exclusive).
+    """
+    tone_freq_offset = S.get_tone_frequency_offset_mhz(band)
+    n_proc = S.get_number_processed_channels(band)
+
+    # Select the n_proc channels nearest to DC.
+    # Tie-break: at equal |freq|, negative is included, positive excluded.
+    sort_key = np.abs(tone_freq_offset) + (tone_freq_offset > 0) * 1e-10
+    processed = np.sort(np.argsort(sort_key)[:n_proc])
+    all_chans = np.arange(len(tone_freq_offset))
+    unprocessed = np.sort(np.setdiff1d(all_chans, processed))
+
+    return processed, unprocessed
+
+
+def get_pysmurf_processed(S, band):
+    """Get pysmurf's current computed processed channel set."""
+    return S.get_processed_channels()
+
+
+def analyze_mapping_shift(fw_processed, py_processed, tone_freq_offset):
+    """Analyze how the mismatch shifts the debug data mapping.
+
+    Returns list of (stream_position, fw_channel, pysmurf_channel) tuples
+    where the mapping diverges.
+    """
+    fw_order = sorted(fw_processed)
+    py_order = sorted(py_processed)
+
+    shifts = []
+    n = min(len(fw_order), len(py_order))
+    for k in range(n):
+        if fw_order[k] != py_order[k]:
+            shifts.append((k, fw_order[k], py_order[k]))
+
+    return shifts
+
+
+def verify_channel_mapping(S, band=0):
+    """Run the full verification.
+
+    Args
+    ----
+    S : pysmurf SmurfControl instance
+    band : int
+        Which band to verify.
+
+    Returns
+    -------
+    bool
+        True if mapping is correct (no mismatch), False if bug is present.
+    """
+    print("=" * 70)
+    print(f"  Channel Mapping Verification — Band {band}")
+    print("=" * 70)
+
+    # Get tone frequency offsets
+    tone_freq_offset = S.get_tone_frequency_offset_mhz(band)
+    digitizer_frequency_mhz = S.get_digitizer_frequency_mhz(band)
+    n_channels = S.get_number_channels(band)
+    half_dsp_bw = 0.8125 * digitizer_frequency_mhz / 2
+
+    print(f"\nSystem parameters:")
+    print(f"  Digitizer frequency: {digitizer_frequency_mhz} MHz")
+    print(f"  DSP bandwidth:       {2 * half_dsp_bw} MHz")
+    print(f"  Half DSP BW:         +/- {half_dsp_bw} MHz")
+    print(f"  Number of channels:  {n_channels}")
+    print(f"  Expected processed:  {int(0.8125 * n_channels)}")
+
+    # --- Firmware processed set ---
+    if PROBE_FIRMWARE:
+        fw_processed, fw_unprocessed = get_firmware_processed_empirical(S, band)
+    else:
+        fw_processed, fw_unprocessed = get_firmware_processed_theoretical(S, band)
+        print(f"\n  (Using theoretical firmware model — set PROBE_FIRMWARE=True")
+        print(f"   to empirically verify with hardware)")
+
+    # --- pysmurf processed set ---
+    py_processed = get_pysmurf_processed(S, band)
+
+    print(f"\nProcessed channel counts:")
+    print(f"  Firmware:  {len(fw_processed)} channels")
+    print(f"  pysmurf:   {len(py_processed)} channels")
+
+    # --- Compare ---
+    fw_set = set(fw_processed)
+    py_set = set(py_processed)
+
+    only_in_fw = sorted(fw_set - py_set)
+    only_in_py = sorted(py_set - fw_set)
+
+    if len(only_in_fw) == 0 and len(only_in_py) == 0:
+        print(f"\n*** PASS: Firmware and pysmurf processed sets MATCH perfectly ***")
+        print(f"    The channel mapping bug is NOT present (or has been fixed).")
+        return True
+
+    print(f"\n*** MISMATCH DETECTED ***")
+    print(f"\n  Channels firmware processes but pysmurf excludes ({len(only_in_fw)}):")
+    for c in only_in_fw:
+        print(f"    Channel {c:3d}  (freq = {tone_freq_offset[c]:+.1f} MHz)")
+
+    print(f"\n  Channels pysmurf includes but firmware does NOT process ({len(only_in_py)}):")
+    for c in only_in_py:
+        print(f"    Channel {c:3d}  (freq = {tone_freq_offset[c]:+.1f} MHz)")
+
+    # --- Analyze mapping shift ---
+    shifts = analyze_mapping_shift(fw_processed, py_processed, tone_freq_offset)
+
+    if shifts:
+        print(f"\n  Debug stream mapping errors ({len(shifts)} positions affected):")
+        print(f"  {'Stream Pos':<12} {'FW outputs':<20} {'pysmurf assigns to':<20}")
+        print(f"  {'-'*12} {'-'*20} {'-'*20}")
+        for pos, fw_ch, py_ch in shifts:
+            print(f"  {pos:<12d} ch {fw_ch:3d} ({tone_freq_offset[fw_ch]:+.1f} MHz)"
+                  f"   ch {py_ch:3d} ({tone_freq_offset[py_ch]:+.1f} MHz)")
+
+        # Check impact on subbands 51 and 75 (channels 23, 24)
+        print(f"\n  Impact on subbands 51 and 75:")
+        for target_ch, sb_name in [(23, "subband 51 (-57.6 MHz)"),
+                                    (24, "subband 75 (+57.6 MHz)")]:
+            affected = [(pos, fw_ch, py_ch) for pos, fw_ch, py_ch in shifts
+                        if py_ch == target_ch]
+            if affected:
+                pos, fw_ch, py_ch = affected[0]
+                print(f"    Channel {target_ch} ({sb_name}):")
+                print(f"      pysmurf reads stream position {pos}")
+                print(f"      but that position has data for channel {fw_ch} "
+                      f"(freq={tone_freq_offset[fw_ch]:+.1f} MHz)")
+                if abs(tone_freq_offset[fw_ch]) > half_dsp_bw - 5:
+                    print(f"      -> Band-edge channel! Likely shows FLAT LINE "
+                          f"(no resonator)")
+                else:
+                    print(f"      -> Gets WRONG channel's data")
+            else:
+                print(f"    Channel {target_ch} ({sb_name}): not directly affected")
+
+    print(f"\n*** FAIL: Channel mapping bug IS present ***")
+    print(f"    Fix get_processed_channels() to use asymmetric boundary condition:")
+    print(f"    -Fdsp/2 <= freq < Fdsp/2  (not symmetric |freq| < Fdsp/2)")
+    return False
+
+
+if __name__ == "__main__":
+    # When run directly in a pysmurf session, 'S' should already be defined
+    try:
+        S
+    except NameError:
+        print("ERROR: No pysmurf instance 'S' found.")
+        print("Run this script from within an active pysmurf session,")
+        print("or set S = your SmurfControl instance before running.")
+        raise SystemExit(1)
+
+    band = 0  # Change this to your active band
+    result = verify_channel_mapping(S, band=band)
+    if result:
+        print("\nChannel mapping is correct.")
+    else:
+        print("\nChannel mapping has errors — see above for details.")

--- a/scratch/shawn/verify_channel_mapping.py
+++ b/scratch/shawn/verify_channel_mapping.py
@@ -26,7 +26,7 @@ Usage:
 import numpy as np
 import time
 
-PROBE_FIRMWARE = False  # Set True to empirically probe each channel
+PROBE_FIRMWARE = True  # Set True to empirically probe each channel
 
 
 def get_firmware_processed_empirical(S, band, nsamp=2**12):


### PR DESCRIPTION
## Description
  
Closes https://github.com/slaclab/pysmurf/issues/97 by fixing incorrect channel mapping in `get_processed_channels()` that caused channels 23 and 24 (subbands 51 and 75) to show flat lines in `tracking_setup` and any other function that calls `take_debug_data`.
  
The firmware determines which 416 of 512 channels to process using an **asymmetric** boundary condition from the DSP clock bandwidth:

-Fdsp/2 <= freq < Fdsp/2
  
The old code used a **symmetric** frequency cut (remove 48 from each end of the sorted frequency list), which is equivalent to `|freq| < Fdsp/2`. This excludes channel 25 (freq = -249.6 MHz, at the lower boundary) and includes channel 22 (freq = +249.6 MHz, at the upper boundary) — the opposite of what the firmware does.
  
The new code selects the 416 channels nearest to DC, with the tie-breaking rule that at equal |freq|, the negative frequency is included and the positive is excluded. This matches the firmware without hardcoding the DSP bandwidth ratio.
  
### Impact on `take_debug_data` without the fix

`decode_data()` maps the 416-sample debug stream back to 512 channel indices using `get_processed_channels()`. The one-channel discrepancy between pysmurf and firmware creates a 3-position shift in the debug stream mapping:

  | Stream position | Firmware outputs | pysmurf assigns to |
  |---|---|---|
  | 18 | ch 23 (-57.6 MHz) | ch 22 (+249.6 MHz) |
  | 19 | ch 24 (+57.6 MHz) | ch 23 (-57.6 MHz) |
  | 20 | ch 25 (-249.6 MHz) | ch 24 (+57.6 MHz) |

Result: channel 23's data appears at channel 22, channel 24's data appears at channel 23, and channel 24 displays data from the band-edge channel 25 (flat line). Only `take_debug_data` (and callers like `tracking_setup`) are affected — the streaming readout path is not impacted.

## Tests done on this branch

- Verified theoretically that the new processed channel set matches the firmware's asymmetric validity condition exactly (416 channels, correct boundary handling)
- Ran per-channel RF IQ probe (turning on each channel individually with `take_debug_data`) confirming firmware processes channel 25 and does not process channel 22
- Confirmed channels 23 and 24 now map to correct stream positions (18 and 19)
- Ran `tracking_setup` on band with channels in subbands 51/75 — no longer shows flat lines

Verification notebook from latest version of pysmurf ; [rogue6_issue97_postfix.ipynb](https://github.com/user-attachments/files/27749465/rogue6_issue97_postfix.ipynb)