### PR TITLE
Adds eth support for rfsoc modes.

### DIFF
--- a/python/pysmurf/core/roots/CmbEth.py
+++ b/python/pysmurf/core/roots/CmbEth.py
@@ -16,12 +16,24 @@
 # copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-from CryoDet._MicrowaveMuxBpEthGen2 import FpgaTopLevel
 import pyrogue
+import pyrogue.protocols
 import rogue.protocols.srp
 
 import pysmurf
 from pysmurf.core.roots.Common import Common
+
+
+# For RFSoC systems the FpgaTopLevel subclass that defaults isRFSOC=True is used.
+# For standard ATCA systems the BpEthGen2 class is used directly.
+# The import is deferred to a function so the correct zip/PYTHONPATH is already
+# in place before the import is attempted.
+def _import_fpga_top_level(is_rfsoc=False):
+    if is_rfsoc:
+        from CryoDet._MicrowaveMuxZcu208 import FpgaTopLevel
+    else:
+        from CryoDet._MicrowaveMuxBpEthGen2 import FpgaTopLevel
+    return FpgaTopLevel
 
 class CmbEth(Common):
     def __init__(self, *,
@@ -48,7 +60,12 @@ class CmbEth(Common):
         self._srp = rogue.protocols.srp.SrpV3()
         pyrogue.streamConnectBiDir(self._srp, self._stream.application(dest=0x0))
 
-        # Instantiate Fpga top level
+        # Instantiate Fpga top level. Import is deferred until here so that the
+        # correct pyrogue zip is already on sys.path before the import is attempted.
+        # For RFSoC systems this resolves to CryoDet._MicrowaveMuxZcu208.FpgaTopLevel
+        # (which defaults isRFSOC=True); for ATCA systems to _MicrowaveMuxBpEthGen2.
+        FpgaTopLevel = _import_fpga_top_level(is_rfsoc)
+
         # In order to be backwards compatible for now, also support
         # FpgaTopLevel which doesn't have the enablePwrI2C argument.
         try:


### PR DESCRIPTION
## Description

Apply the deferred `FpgaTopLevel` import pattern to `CmbEth`, matching the fix already present in `CmbPcie`. The module-level `from CryoDet._MicrowaveMuxBpEthGen2 import FpgaTopLevel` would fail if the pyrogue zip was not yet on `sys.path`, and always used the ATCA class regardless of `is_rfsoc`.

## Tests done on this branch

- Verified flake8 clean

## Function interfaces that changed

`CmbEth.__init__` — [`python/pysmurf/core/roots/CmbEth.py`](python/pysmurf/core/roots/CmbEth.py)

### What was the interface before the change

No change to the interface. Internally, `FpgaTopLevel` was imported at module load time from `CryoDet._MicrowaveMuxBpEthGen2` unconditionally.

### What will be the new interface after the change

No change to the interface. Internally, the import is now deferred to inside `__init__` via `_import_fpga_top_level(is_rfsoc)`, selecting `CryoDet._MicrowaveMuxZcu208` for RFSoC systems and `CryoDet._MicrowaveMuxBpEthGen2` for ATCA, after the pyrogue zip is on `sys.path`.