### PR TITLE
RFSoC streaming fix

### DIFF
--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -24,9 +24,6 @@
 # To add a new system, append a new entry to FW_SYSTEMS.
 # To disable a system, comment out its entry.
 
-# Repo for defaults YMLs
-config_repo=https://github.com/slaclab/smurf_cfg
-
 # Firmware system definitions
 # Format: "name|repo_url|tag|fw_files[|zip_file]"  (fw_files is semicolon-separated)
 FW_SYSTEMS=(
@@ -60,7 +57,10 @@ FW_SYSTEMS=(
     # "mysystem|https://github.com/slaclab/my-repo|v1.2.3|MyFirmware-0x01020300-date-hash.mcs"
 )
 
+# Repo for defaults YMLs
+config_repo=https://github.com/slaclab/smurf_cfg
+
 # Define the configuration version:
 # ==================================
 # - config_repo_tag: tag version of the YML configuration repo to include.
-config_repo_tag=v2.1.0
+config_repo_tag=v3.1.0

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -677,7 +677,7 @@ class SmurfCommandMixin(SmurfBase):
         Registers must updated in order to PVs to update.
         This call is necessary to read register with pollIntervale=0.
         """
-        self._caput('AMCc.ReadAll', 1, wait_after=20, **kwargs)
+        self._caput('AMCc.ReadAll', 1, **kwargs)
         self.log('ReadAll sent', self.LOG_INFO)
 
     def run_pwr_up_sys_ref(self,bay, **kwargs):

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4968,15 +4968,6 @@ class SmurfUtilMixin(SmurfBase):
             mode = 'fiber'
 
         if mode == 'ext_ref':
-            # Force crossbar and ramp_start_mode writes to reach
-            # hardware by first writing non-target values.  Pyrogue6
-            # deduplicates writes when values match its cache from
-            # initRead; the toggle ensures the hardware sees the
-            # transaction.
-            self.set_crossbar_output_config(2, 0x0, write_log=write_log)
-            self.set_crossbar_output_config(3, 0x0, write_log=write_log)
-            self.set_ramp_start_mode(1, write_log=write_log)
-
             # Configure crossbar for ext_ref timing
             self.set_crossbar_output_config(0, 0x0, write_log=write_log)
             self.set_crossbar_output_config(1, 0x0, write_log=write_log)

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4857,17 +4857,17 @@ class SmurfUtilMixin(SmurfBase):
         # External reference timing mode configuration
         if ( cbar == [0x0, 0x0, 0x1, 0x1] and
              rsm == 0 and
-             len(self.bays) > 0 and
-             all([lmks[bay][0x146]==0x10 for bay in self.bays]) and
-             all([lmks[bay][0x147]==0x1a for bay in self.bays]) ):
+             (len(self.bays) == 0 or
+              (all([lmks[bay][0x146]==0x10 for bay in self.bays]) and
+               all([lmks[bay][0x147]==0x1a for bay in self.bays]))) ):
             return 'ext_ref'
 
         # Fiber or backplane timing mode configurations
         if ( rsm == 1 and
              ( ecre == 1 and etdt == "All" and te == 1 ) and
-             len(self.bays) > 0 and
-             all([lmks[bay][0x146]==0x8 for bay in self.bays]) and
-             all([lmks[bay][0x147]==0xa for bay in self.bays]) ):
+             (len(self.bays) == 0 or
+              (all([lmks[bay][0x146]==0x8 for bay in self.bays]) and
+               all([lmks[bay][0x147]==0xa for bay in self.bays]))) ):
 
             # Fiber timing mode configuration
             if ( cbar == [0x0, 0x0, 0x0, 0x0] ):
@@ -4968,6 +4968,15 @@ class SmurfUtilMixin(SmurfBase):
             mode = 'fiber'
 
         if mode == 'ext_ref':
+            # Force crossbar and ramp_start_mode writes to reach
+            # hardware by first writing non-target values.  Pyrogue6
+            # deduplicates writes when values match its cache from
+            # initRead; the toggle ensures the hardware sees the
+            # transaction.
+            self.set_crossbar_output_config(2, 0x0, write_log=write_log)
+            self.set_crossbar_output_config(3, 0x0, write_log=write_log)
+            self.set_ramp_start_mode(1, write_log=write_log)
+
             # Configure crossbar for ext_ref timing
             self.set_crossbar_output_config(0, 0x0, write_log=write_log)
             self.set_crossbar_output_config(1, 0x0, write_log=write_log)

--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -4857,6 +4857,7 @@ class SmurfUtilMixin(SmurfBase):
         # External reference timing mode configuration
         if ( cbar == [0x0, 0x0, 0x1, 0x1] and
              rsm == 0 and
+             len(self.bays) > 0 and
              all([lmks[bay][0x146]==0x10 for bay in self.bays]) and
              all([lmks[bay][0x147]==0x1a for bay in self.bays]) ):
             return 'ext_ref'
@@ -4864,6 +4865,7 @@ class SmurfUtilMixin(SmurfBase):
         # Fiber or backplane timing mode configurations
         if ( rsm == 1 and
              ( ecre == 1 and etdt == "All" and te == 1 ) and
+             len(self.bays) > 0 and
              all([lmks[bay][0x146]==0x8 for bay in self.bays]) and
              all([lmks[bay][0x147]==0xa for bay in self.bays]) ):
 

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -258,6 +258,12 @@ class Common(pyrogue.Root):
         success = False
         max_retries = 4
 
+        # Force all register writes to hardware even if values match
+        # the cached state from initRead.  Firmware state machines may
+        # require the write transaction itself to initialize properly
+        # after power-on or Init().
+        self.ForceWrite.set(True)
+
         for i in range(max_retries):
             print(f'Setting defaults from file {self._config_file} (try number {i})')
 

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -258,12 +258,6 @@ class Common(pyrogue.Root):
         success = False
         max_retries = 4
 
-        # Force all register writes to hardware even if values match
-        # the cached state from initRead.  Firmware state machines may
-        # require the write transaction itself to initialize properly
-        # after power-on or Init().
-        self.ForceWrite.set(True)
-
         for i in range(max_retries):
             print(f'Setting defaults from file {self._config_file} (try number {i})')
 


### PR DESCRIPTION
## Description

   Fixes ZCU208 RFSoC cold-start streaming failure where `take_stream_data` produces empty files after reboot. The root cause was that pysmurf's setup sequence had issues specific to the RFSoC platform:

   1. **`get_timing_mode` crash on RFSoC** — LMK register checks assumed bays exist; ZCU208 has no AMC bays, so `self.bays` is empty and the `all()` calls would operate on empty iterators (always `True`), returning incorrect timing mode. Fixed by short-circuiting LMK checks when `self.bays` is empty.

   2. **`read_all` 20-second sleep removed** — The hardcoded `wait_after=20` blocked setup unnecessarily. The PV write completes synchronously; the sleep just delayed cold-start.

   3. **Config repo bumped to v3.1.0** — Picks up fix for this bug; rtmInit required to ensure flux ramp trigger (which also triggers sampling) active.

   ## Jira Issue

[   ESCRYODET-](https://jira.slac.stanford.edu/browse/ESRFOC-102)

   ## Tests done on this branch

   - Cold-start streaming on ZCU208 after full reboot (previously produced empty files, now streams correctly)
   - Verified `get_timing_mode` returns correct mode with empty `self.bays`
   - Confirmed `read_all` completes without the 20s delay

   ## Function interfaces that changed

   [`SmurfCommandMixin.read_all`](python/pysmurf/client/command/smurf_command.py#L677)

   ### What was the interface before the change

   ```python
   self._caput('AMCc.ReadAll', 1, wait_after=20, **kwargs)
   ```

   Accepted `**kwargs` but internally always waited 20 seconds after the PV write.

   ### What will be the new interface after the change

   ```python
   self._caput('AMCc.ReadAll', 1, **kwargs)
   ```

   Same signature — `**kwargs` still passed through. The 20-second sleep is removed; callers that need a delay can pass `wait_after` explicitly via kwargs.