### PR TITLE
Update smurf_cfg to v3.2.0: disable RtmCryoDet sub-devices for RFSoC eth support

### DIFF
--- a/cfg_files/b33/experiment_b33_rfc1-2_C05-40_s4_rfsoc_extref.cfg
+++ b/cfg_files/b33/experiment_b33_rfc1-2_C05-40_s4_rfsoc_extref.cfg
@@ -344,7 +344,7 @@
 	#   flux_ramp_start_mode=0
 	# "backplane" : takes timing from timing master through
 	#   backplane.  Also sets flux_ramp_start_mode=1.
-	"timing_reference" : "fiber"
+	"timing_reference" : "ext_ref"
 },
 
 "fs" : 200.0,

--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -63,4 +63,4 @@ config_repo=https://github.com/slaclab/smurf_cfg
 # Define the configuration version:
 # ==================================
 # - config_repo_tag: tag version of the YML configuration repo to include.
-config_repo_tag=v3.1.0
+config_repo_tag=v3.2.0


### PR DESCRIPTION
## Description

Update smurf_cfg dependency to v3.2.0 which adds sub-device disables for RtmCryoDet in defaults_rfsoc_zcu208.yml.

The RFSoC ZCU208 reuses the RtmCryoDet register block for flux ramp trigger control but has no physical RTM board. The sub-devices within RtmCryoDet (RtmSpiCryo, RtmSpiMax, RtmSpiSr, LutCtrl) target SPI chips and DAC LUT memory that do not exist on the RFSoC. On PCIe systems these writes were silently absorbed by the KCU1500 AXI interconnect; on ethernet they cause register transaction timeouts because the ZCU208 AXI bus has no slave at those addresses.

The defaults file now disables these sub-devices so that InitRtm() only writes the flux ramp control registers actually implemented in the FPGA.  This is required for ethernet-based RFSoC deployments and is a no-op on PCIe.

## Tests done on this branch

Verified on rdsrv426 (ZCU208 PreSpectra over ethernet): server starts without register transaction timeouts, InitRtm() completes, flux ramp triggers, and streaming data is produced.

## Function interfaces that changed

None. This is a defaults configuration change only (smurf_cfg version bump in definitions.h). No API or function signature changes.