### PR TITLE
Fix stochastic CI failure in SmurfProcessor base transmitter test

### DIFF
--- a/tests/core/validate_base_tx.py
+++ b/tests/core/validate_base_tx.py
@@ -109,10 +109,13 @@ if __name__ == "__main__":
         print('Done')
 
         # Wait for the pipeline to drain: poll until the FileWriter
-        # has received at least as many frames as entered the pipeline.
+        # and Transmitter have received at least as many frames as
+        # entered the pipeline.
         print('  Waiting for pipeline to drain... ', end='')
         rx_in = root.SmurfProcessor.FrameRxStats.FrameCnt.get()
         while root.SmurfProcessor.FileWriter.FrameCount.get() < rx_in:
+            time.sleep(0.1)
+        while root.SmurfProcessor.Transmitter.dataFrameCnt.get() < rx_in:
             time.sleep(0.1)
         print('Done')
 
@@ -179,8 +182,8 @@ if __name__ == "__main__":
         raise AssertionError(f'Meatadata frames dropped in the transmitter: {tx_meta_drop_cnt}')
 
     ## All Rx frames should have been sent to the transmitter
-    if rx_cnt != tx_data_cnt + tx_meta_cnt:
-        raise AssertionError(f'Missing RX frames in the transmitter: {rx_cnt - tx_data_cnt - tx_meta_cnt}')
+    if rx_cnt != tx_data_cnt:
+        raise AssertionError(f'Missing RX frames in the transmitter: {rx_cnt - tx_data_cnt}')
 
     ## The transmitter should have received some metadata frames
     if tx_meta_cnt == 0:

--- a/tests/core/validate_base_tx.py
+++ b/tests/core/validate_base_tx.py
@@ -179,8 +179,8 @@ if __name__ == "__main__":
         raise AssertionError(f'Meatadata frames dropped in the transmitter: {tx_meta_drop_cnt}')
 
     ## All Rx frames should have been sent to the transmitter
-    if rx_cnt != tx_data_cnt:
-        raise AssertionError(f'Missing RX frames in the transmitter: {rx_cnt - tx_data_cnt}')
+    if rx_cnt != tx_data_cnt + tx_meta_cnt:
+        raise AssertionError(f'Missing RX frames in the transmitter: {rx_cnt - tx_data_cnt - tx_meta_cnt}')
 
     ## The transmitter should have received some metadata frames
     if tx_meta_cnt == 0:


### PR DESCRIPTION
## Description
  
The `validate_base_tx.py` test was failing stochastically because the pipeline drain logic only waited for the  `FileWriter` to receive all frames before reading counters. The `Transmitter` is a separate downstream consumer, so a data frame could reach `FileWriter` (satisfying the drain) while still in-flight to the `Transmitter`. When counters were read in this state, `FrameRxStats.FrameCnt` was 1 higher than `Transmitter.dataFrameCnt`, causing the assertion to fail.

The fix adds a poll-wait for `Transmitter.dataFrameCnt` to also reach the expected count before reading counters.

  ## Tests done on this branch

  Ran the CI server test suite to confirm the stochastic failure no longer reproduces.

  ## Function interfaces that changed
  
  None. This is a test-only fix with no interface changes.