### PR TITLE
Fix client matplotlib dual install

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get install -y \
     python3-gi-cairo \
     python3-cairocffi \
     gir1.2-gtk-3.0 \
-    python3-matplotlib \
  && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir --upgrade pip

--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -1188,7 +1188,7 @@ class SmurfCommandMixin(SmurfBase):
         """
         self._caput(
             self._cryo_root(band) + self._eta_scan_amplitude_reg,
-            np.uint(val), **kwargs)
+            np.uint32(val), **kwargs)
 
     def get_eta_scan_amplitude(self, band, **kwargs):
         """
@@ -1439,7 +1439,7 @@ class SmurfCommandMixin(SmurfBase):
         """
         self._caput(
             self._cryo_root(band) + self._amplitude_scale_array_reg,
-            np.array(val).astype(np.uint), **kwargs)
+            np.array(val).astype(np.uint32), **kwargs)
 
     def get_amplitude_scale_array(self, band, **kwargs):
         """
@@ -1476,7 +1476,7 @@ class SmurfCommandMixin(SmurfBase):
 
         old_amp = self.get_amplitude_scale_array(band, **kwargs)
         n_channels=self.get_number_channels(band)
-        new_amp = np.zeros((n_channels,),dtype=np.uint)
+        new_amp = np.zeros((n_channels,),dtype=np.uint32)
         new_amp[np.where(old_amp!=0)] = tone_power
         self.set_amplitude_scale_array(self, new_amp, **kwargs)
 
@@ -2652,7 +2652,7 @@ class SmurfCommandMixin(SmurfBase):
         self._caput(
             self._channel_root(band, channel) +
             self._amplitude_scale_channel_reg,
-            np.uint(val), **kwargs)
+            np.uint32(val), **kwargs)
 
     def get_amplitude_scale_channel(self, band, channel, **kwargs):
         """


### PR DESCRIPTION
## Description

Two fixes for the client Docker container:

1. **Remove `python3-matplotlib` from apt install** — The base image (`smurf-rogue:R5.0.1`) already installs matplotlib via pip in the venv. The duplicate system package (v3.6.3 via apt) conflicted with the venv copy (v3.10.8), causing the Axes3D import warning and forcing a numpy downgrade to 1.26.4.

2. **Replace `np.uint` with `np.uint32`** — `np.uint` (without size suffix) was removed in numpy 2.0. With the Dockerfile fix, the container now runs numpy 2.4.4, so these 4 call sites in `smurf_command.py` would crash. The firmware amplitude scale registers are 32-bit unsigned, so `np.uint32` is the correct explicit type.

## Tests done on this branch

 - CI passes (Flake8, Docker Definition, Documentation Build, Client Tests)
 - Client Tests job no longer shows the Axes3D `UserWarning`
 - `import pysmurf.client` succeeds cleanly in the container with numpy 2.4.4

## Function interfaces that changed

[`python/pysmurf/client/command/smurf_command.py`](python/pysmurf/client/command/smurf_command.py)

### What was the interface before the change

`set_eta_scan_amplitude`, `set_amplitude_scale_array`, `set_tone_power_amp_scale`, and `set_amplitude_scale_channel` internally cast values using `np.uint` (a generic alias that mapped to `np.uint64` on most platforms).

### What will be the new interface after the change

Same functions now cast using `np.uint32`, which explicitly matches the 32-bit firmware register width. No change to the external Python API — callers pass the same arguments and get the same behavior.