### PR TITLE
Fix IQ mode mask and frequency files writing wrong channel numbers

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -1035,9 +1035,20 @@ class SmurfUtilMixin(SmurfBase):
 
                 channel_mask = self.make_channel_mask(bands, smurf_chans, IQ_mode=IQ_mode)
                 self.set_channel_mask(channel_mask)
+
+                # In IQ mode, build the original channel list for the
+                # mask/freq files (one entry per physical channel).  The
+                # IQ stream indices sent to the ChannelMapper are an
+                # internal detail and should not be written to disk.
+                if IQ_mode:
+                    file_mask = self.make_channel_mask(bands, smurf_chans,
+                                                      IQ_mode=False)
+                else:
+                    file_mask = channel_mask
             else:
                 channel_mask = np.atleast_1d(channel_mask)
                 self.set_channel_mask(channel_mask)
+                file_mask = channel_mask
 
             time.sleep(0.5)
 
@@ -1076,17 +1087,19 @@ class SmurfUtilMixin(SmurfBase):
 
 
             # Save mask file as text file. Eventually this will be in the
-            # raw data output
+            # raw data output.  In IQ mode, file_mask contains the original
+            # absolute channel numbers (band*n_chan + ch) rather than the
+            # IQ stream indices used by the ChannelMapper.
             mask_fname = os.path.join(data_filename.replace('.dat',
                 '_mask.txt'))
-            tools.save_to_txt(mask_fname, channel_mask, fmt='%i')
+            tools.save_to_txt(mask_fname, file_mask, fmt='%i')
             self.pub.register_file(mask_fname, 'mask')
             self.log(mask_fname)
 
             if make_freq_mask:
                 if write_log:
                     self.log("Writing frequency mask.")
-                freq_mask = self.make_freq_mask(channel_mask)
+                freq_mask = self.make_freq_mask(file_mask)
                 tools.save_to_txt(os.path.join(data_filename.replace('.dat',
                     '_freq.txt')), freq_mask, fmt='%4.4f')
                 self.pub.register_file(


### PR DESCRIPTION
### Description
  
When take_stream_data or stream_data_on is called with `IQ_mode=True`, the mask and frequency files saved to disk contained the internal IQ stream indices used by the SmurfProcessor ChannelMapper, rather than the actual firmware channel numbers and tone frequencies.

For example, band 0 channel 50 was written to the mask file as 100 (its IQ stream position: 2*ch) instead of 50 (its absolute channel number: band*512 + ch). For bands > 0 the problem was worse: band 1 channel 4 was written as 1032 (IQ position: 1*1024 + 2*4), which make_freq_mask and make_mask_lookup then misinterpreted as band 2, channel 8 — producing wrong frequencies in the freq file and wrong band/channel mappings on read-back.
  
The fix separates the two uses of the channel mask:
- The IQ stream indices are still sent to set_channel_mask() (the ChannelMapper needs them to extract the correct positions from the IQ-format stream).
- The mask and freq files now receive the original absolute channel numbers (band*n_chan + ch) via a second call to make_channel_mask(..., IQ_mode=False).
  
When `IQ_mode=False`, behavior is unchanged (file_mask = channel_mask).

### Tests done on this branch

Took 1 second of IQ stream data with channels in bands 0, 1, 2, 3. Confirmed:
- Mask file contains correct absolute channel numbers (not IQ stream indices)
- Freq file contains correct tone frequencies 
- Data loads back non-zero for all bands
- make_mask_lookup correctly maps band/channel to data row index
- Normal (non-IQ) data taking is unaffected
  
### Function interfaces that changed

No public interfaces changed. The fix is internal to stream_data_on — it introduces a local variable file_mask that is written to the mask/freq text files in place of the raw channel_mask. All function signatures, return values, and file formats remain the same.