### PR TITLE
Add Cython to client Docker to enable fast stream data reader

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get install -y \
 RUN pip3 install --no-cache-dir --upgrade pip
 
 RUN pip3 install --no-cache-dir \
+    Cython \
     scipy \
     pandas \
     PyYAML \


### PR DESCRIPTION
## Description
  
The Cython-optimized stream data reader (stream_data_reader.pyx) was never being compiled in the client Docker image because Cython was not installed when `pip3 install -e .` runs. Editable installs skip build isolation and don't auto-install build-system.requires from pyproject.toml, so the hatch build hook silently fails and users fall back to the slow pure-Python reader.
  
Adds Cython to the client Dockerfile's pip install block. numpy is already present in the rogue base image.

## Function interfaces that changed

No interface changes. Build-time dependency only.