### PR TITLE
fix(core.Common): Use LoadConfigProcess.

### DIFF
--- a/python/pysmurf/client/command/smurf_command.py
+++ b/python/pysmurf/client/command/smurf_command.py
@@ -584,7 +584,7 @@ class SmurfCommandMixin(SmurfBase):
         n_processed_channels=int(0.8125*n_channels)
         return n_processed_channels
 
-    def set_defaults_pv(self, max_timeout_sec=60.0, **kwargs):
+    def set_defaults_pv(self, max_timeout_sec=300.0, **kwargs):
         r"""Loads the default configuration.
 
         Calls the rogue `setDefaults` command, which loads the default
@@ -597,9 +597,11 @@ class SmurfCommandMixin(SmurfBase):
 
         Args
         ----
-        max_timeout_sec : float, optional, default 400.0
+        max_timeout_sec : float, optional, default 300.0
             Seconds to wait for system to configure before giving up.
             Only used for pysmurf core code versions >= 4.1.0.
+            The underlying process will give up after 240s by default,
+            so if a shorter timeout is set here, it may not complete.
         \**kwargs
             Arbitrary keyword arguments.  Passed directly to
             all `_caget` calls.
@@ -633,10 +635,10 @@ class SmurfCommandMixin(SmurfBase):
             # once complete.
             start_time = time.time()
 
-            # Start by calling the 'setDefaults' command. Set the 'wait' flag
-            # to wait for the command to finish, although the server usually
-            # gets unresponsive during setup and the connection is lost.
-            self._caput('AMCc.setDefaults', 1, wait_done=True, **kwargs)
+            # Start by calling the 'setDefaults' command.
+            # This is now implemented as a rogue Process, so this call will
+            # return immediately, and the wait loop that follows will begin
+            self._caput('AMCc.setDefaults.Start', 1, **kwargs)
 
             # Now let's wait until the process is finished. We define a maximum
             # time we will wait, 400 seconds in this case

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -16,6 +16,7 @@
 # copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
+import time
 
 import pyrogue
 import pyrogue.interfaces
@@ -114,7 +115,7 @@ class Common(pyrogue.Root):
         # will be called with a predefined file passed during startup
         # However, it can be usefull also win the GUI, so it is always added.
         self._config_file = config_file
-        self.add(pyrogue.LocalCommand(
+        self.add(pyrogue.Process(
             name='setDefaults',
             description='Set default configuration',
             function=self._set_defaults_cmd))
@@ -216,7 +217,7 @@ class Common(pyrogue.Root):
 
         # Load default configuration, if requested
         if self._configure:
-            self.setDefaults.call()
+            self._set_defaults_cmd()
 
         # Update the 'EnabledBays' variable with the correct list of enabled bays.
         self.SmurfApplication.EnabledBays.set(self._enabled_bays)
@@ -254,20 +255,27 @@ class Common(pyrogue.Root):
     # "max_retries" times.
     # This method returns "True" if the configuration file was load correctly, or
     # "False" otherwise.
-    def _load_config(self):
+    def _load_config(self, timeout=60, max_retries=4):
         success = False
-        max_retries = 4
 
         for i in range(max_retries):
             print(f'Setting defaults from file {self._config_file} (try number {i})')
 
             try:
                 # Try to load the defaults file
-                ret = self.LoadConfig(self._config_file)
+                self.LoadConfigProcess.LoadMode.setDisp("File")
+                self.LoadConfigProcess.ConfigFile.set(self._config_file)
+                self.LoadConfigProcess.Start()
 
+                # wait for process to complete
+                start = time.time()
+                def keep_waiting():
+                    return (timeout == 0) or ((time.time() - start) <= timeout)
+                while self.LoadConfigProcess.Running.value() and keep_waiting():
+                    time.sleep(0.1)
                 # Check the return value from 'LoadConfig'.
-                if not ret:
-                    print(f'\nSetting defaults try number {i} failed. "LoadConfig" returned "False"\n')
+                if self.LoadConfigProcess.Message.value() != "Done":
+                    print(f'\nSetting defaults try number {i} failed. "LoadConfig" process did not finish.\n')
                 else:
                     success = True
                     break

--- a/python/pysmurf/core/roots/Common.py
+++ b/python/pysmurf/core/roots/Common.py
@@ -242,6 +242,10 @@ class Common(pyrogue.Root):
             # Set the status register to 'Not found'.
             self.SmurfApplication.JesdStatus.set(3)
 
+        # disable the updateGroup period so that variable updates cannot
+        # interfere with configuration
+        self.setDefaults.UpdatePeriod.set(0.0)
+
         self.Ready.set(True)
 
     def stop(self):
@@ -257,6 +261,10 @@ class Common(pyrogue.Root):
     # "False" otherwise.
     def _load_config(self, timeout=60, max_retries=4):
         success = False
+
+        # ensure the update period is disabled, otherwise the variable update
+        # thread can interfere with some steps of initialisation
+        self.LoadConfigProcess.UpdatePeriod.set(0.0)
 
         for i in range(max_retries):
             print(f'Setting defaults from file {self._config_file} (try number {i})')


### PR DESCRIPTION
Avoids timing out on long-running command.

This was often causing crashes during testing on the LAT, now that the ZMQ client will time out on long-running `Command` calls breaking with previous behavior in rogue 4 / EPICS.

Tested on the B33 smurf.