### PR TITLE
fix(client): Remove/fix deprecated matplotlib calls

### DIFF
--- a/python/pysmurf/client/debug/smurf_iv.py
+++ b/python/pysmurf/client/debug/smurf_iv.py
@@ -423,8 +423,6 @@ class SmurfIVMixin(SmurfBase):
             phase_excursion_list.append(phase_excursion)
 
             if make_plot:
-                plt.rcParams["patch.force_edgecolor"] = True
-
                 if not show_plot:
                     plt.ioff()
 
@@ -1029,8 +1027,6 @@ class SmurfIVMixin(SmurfBase):
             # would work once we had a permanent lookup table of ch to bias group...
 
             if make_plot: # make the timestream plot
-                plt.rcParams["patch.force_edgecolor"] = True
-
                 if not show_plot:
                     plt.ioff()
 

--- a/python/pysmurf/client/debug/smurf_noise.py
+++ b/python/pysmurf/client/debug/smurf_noise.py
@@ -134,9 +134,6 @@ class SmurfNoiseMixin(SmurfBase):
 
         n_channel = len(channels)
 
-        if make_summary_plot or make_channel_plot:
-            plt.rcParams["patch.force_edgecolor"] = True
-
         noise_floors = np.full((len(low_freq), n_channel), np.nan)
         f_knees = np.full(n_channel,np.nan)
         res_freqs = np.full(n_channel,np.nan)
@@ -1006,7 +1003,7 @@ class SmurfNoiseMixin(SmurfBase):
             del phase
 
         # Make plot
-        cm = plt.get_cmap('plasma')
+        cm = plt.colormaps['plasma']
         noise_est_data = []
         if est_NEP:
             NEP_est_data = []
@@ -1763,7 +1760,7 @@ class SmurfNoiseMixin(SmurfBase):
         n_tone = len(tone)
 
         # Make plot
-        cm = plt.get_cmap('plasma')
+        cm = plt.colormaps['plasma']
 
         # Different plot sizes depending on whether there are timestream plots
         n_col = 3

--- a/python/pysmurf/client/tune/smurf_tune.py
+++ b/python/pysmurf/client/tune/smurf_tune.py
@@ -2378,7 +2378,7 @@ class SmurfTuneMixin(SmurfBase):
 
         unique_subband = np.unique(subband)
 
-        cm = plt.get_cmap('viridis')
+        cm = plt.colormaps['viridis']
 
         timestamp = self.get_timestamp()
 
@@ -3011,7 +3011,7 @@ class SmurfTuneMixin(SmurfBase):
         scale = 1.0E3
 
         fig, ax = plt.subplots(1)
-        cm = plt.get_cmap('viridis')
+        cm = plt.colormaps['viridis']
         for j, k in enumerate(keys):
             sync = dat['data'][k]['sync']
             df = dat['data'][k]['df']
@@ -3602,7 +3602,7 @@ class SmurfTuneMixin(SmurfBase):
             if filename is not None:
                 f, resp = np.load(filename)
 
-            cm = plt.cm.get_cmap('viridis')
+            cm = plt.colormaps['viridis']
             plt.figure(figsize=(10,4))
 
             for i, sb in enumerate(subband):


### PR DESCRIPTION
Calls to `plt.get_cmap` are generating errors in the latest `matplotlib`. Fixed these and got Claude to look for any other deprecated calls.

- Remove usage of plt.rcParams["patch.force_edgecolor"], which was removed in matplotlib 3.1
- Replace deprecated plt.get_cmap() and plt.cm.get_cmap() calls with plt.colormaps[] (deprecated since matplotlib 3.7)

Files changed

- python/pysmurf/client/debug/smurf_iv.py
- python/pysmurf/client/debug/smurf_noise.py
- python/pysmurf/client/tune/smurf_tune.py