### PR TITLE
Bump minimum supported python to 3.10.

### DIFF
--- a/.github/workflows/test-or-deploy.yml
+++ b/.github/workflows/test-or-deploy.yml
@@ -251,7 +251,7 @@ jobs:
       - name: Build wheel
         uses: pypa/cibuildwheel@v4.1.0
         env:
-          CIBW_BUILD: cp38-manylinux_x86_64
+          CIBW_BUILD: cp310-manylinux_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BEFORE_BUILD: pip install hatch-vcs hatchling Cython numpy setuptools
 

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -4,7 +4,7 @@ Installation
 Requirements
 ------------
 
-- Python >= 3.8
+- Python >= 3.10
 - A running SMuRF rogue server (for hardware interaction)
 
 Dependencies (installed automatically): numpy, scipy, matplotlib,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,18 +23,12 @@ name = "pysmurf-slac"
 dynamic = ["version"]
 description = "The python control software for SMuRF"
 readme = "README.md"
-# Note: This is the older identifier format, which is needed to build on Python 3.8.
-license = {file = "LICENSE.txt"}
-# When updating to build on a more recent version, use the below identifiers.
-#license = "Stanford"
-#license-files = ["LICEN[CS]E*"]
-requires-python = ">=3.8"
+license-files = ["LICEN[CS]E*"]
+requires-python = ">=3.10"
 classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Support for 3.8 was starting to cause issues with the CI.

Downstream use of python 3.8 is being phased out by PRs currently open. Other breaking changes to `pysmurf` before this means those versions are no longer supported anyways.