### PR TITLE
Support rogue 6.14

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/slaclab/smurf-rogue:R5.0.1
+FROM ghcr.io/slaclab/smurf-rogue:R5.1.0
 
 RUN apt-get update
 RUN apt-get install -y \

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/slaclab/smurf-rogue:R5.0.1
+FROM ghcr.io/slaclab/smurf-rogue:R5.1.0
 
 # Install Xvfb for virtual display support when running with GUI (-g)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -29,7 +29,7 @@
 FW_SYSTEMS=(
     # uMUX (standard microwave multiplexer) systems
     # Uses Primary:False naming -> rogue_MicrowaveMuxBpEthGen2_<tag>.zip
-    "umux|https://github.com/slaclab/cryo-det|MicrowaveMuxBpEthGen2_v2.4.0|MicrowaveMuxBpEthGen2-0x02040000-20260414104316-ruckman-33885cfb.mcs|rogue_MicrowaveMuxBpEthGen2_v2.4.0.zip"
+    "umux|https://github.com/slaclab/cryo-det|MicrowaveMuxBpEthGen2_v2.5.0|MicrowaveMuxBpEthGen2-0x02050000-20260616105622-ruckman-af249f83.mcs|rogue_MicrowaveMuxBpEthGen2_v2.5.0.zip"
 
     # NO LONGER BEING DEVELOPED
     ## TKID (transition-edge sensor kinetic inductance detector) systems

--- a/python/pysmurf/client/base/base_class.py
+++ b/python/pysmurf/client/base/base_class.py
@@ -13,6 +13,8 @@
 # copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
+import atexit
+
 try:
     import pyrogue.interfaces
 except ModuleNotFoundError:
@@ -101,16 +103,18 @@ class SmurfBase:
         # connect to rogue servers
         if not offline:
             self._client = pyrogue.interfaces.VirtualClient(addr=self._server_addr, port=self._server_port)
-            # set the timeout to supress spam in logs. Retries forever anyway
-            # certain calls take long to complete
-            self._client.setTimeout(10000, True)  # ms
-            # but disable monitor thread to avoid issues on exit. Socket remains open
-            self._client.stop()
+            # Set a 30s timeout. And warn every 5s
+            self._client.setTimeout(5000, 30000)  # ms
+            # disable monitor thread that hangs on exit
+            self._client._monEnable = False
+            # ensure that client socket is closed
+            atexit.register(self._client.stop)
             if atca_monitor:
                 self._atca = pyrogue.interfaces.VirtualClient(addr=self._server_addr, port=self._atca_port)
                 if self._atca.root is None:
                     self.log(f"Could not connect to ATCA monitor at port {self._atca_port}.")
-                self._atca.stop()
+                self._atca._monEnable = False
+                atexit.register(self._atca.stop)
             else:
                 self._atca = _DummyClient("ATCA monitor client")
         else:


### PR DESCRIPTION
In rogue >=6.13, the way to specifiy the ZMQ client timeout changed.

Also ensures client stop method is called at exit.

Pending next release of rogue.