### PR TITLE
Convert to float when fallback on slow reader

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -1274,6 +1274,7 @@ class SmurfUtilMixin(SmurfBase):
                     'Fast Cython reader not available. Falling back on slow reader.',
                     self.LOG_ERROR
                 )
+                fast_reader = False  # will impact conversion later
             # Flag to indicate we are about the read the fist frame from the disk
             # The number of channel will be extracted from the first frame and the
             # data structures will be build based on that


### PR DESCRIPTION
If the cython reader is not installed, the code will fall back on the slow reader. Unfortunately, they don't do the conversion to float in the same place, and the condition was defeated in this special case.