### PR TITLE
Backport: isolate hardware log getters from a stalled atca_monitor (v4.0.x)

### DIFF
--- a/python/pysmurf/client/util/smurf_util.py
+++ b/python/pysmurf/client/util/smurf_util.py
@@ -3795,7 +3795,16 @@ class SmurfUtilMixin(SmurfBase):
         fmt=''
         counter=0
         for key, value in d.items():
-            columns.append(str(value()))
+            # Isolate each getter so one misbehaving read (e.g. a wedged or
+            # disconnected atca_monitor) can neither stall nor kill the
+            # hardware logging thread.  Substitute NaN and keep logging.
+            try:
+                col=str(value())
+            except Exception as e:
+                self.log('Hardware log getter %s failed: %s'%(key,e),
+                         self.LOG_ERROR)
+                col=str(float('nan'))
+            columns.append(col)
             names.append(key)
             fmt+='{0[%d]:<20}'%counter
             counter+=1


### PR DESCRIPTION
## Backport to the v4.0.x line

Base branch `v4.0.1-dev` was branched from the `v4.0.0` tag. This is the v4.0.x backport of the hardware-logging hardening in the main-line PR.

## Problem

The thermal test intermittently freezes: **no traceback, RF/full-band response looks fine, but data taking and the live temperature plots stop updating for the rest of the run** (and loopback is skipped if the freeze precedes it). It only reproduces when an AMC FRU asset tag is long enough to be truncated by the fixed-width BSI/FRU field (e.g. `30C03A01-176` → `30C03A01`); a short tag like `A01-176` passes.

## Root cause

`get_hardware_log_entry()` polls every atca_monitor temperature getter in a bare `for key, value in d.items(): columns.append(str(value()))` loop with **no exception isolation**. When a misbehaving atca_monitor makes a getter raise, the daemon hardware-logging thread dies, `hwlog.dat` stops growing, and the plots freeze. The underlying bad field originates firmware/atca-monitor side (over-length tag overrunning the 8-char BSI/FRU field in the external `slaclab/smurf-atca-monitor` server) — out of scope here; this makes pysmurf robust to it.

## Change

- **`smurf_util.py` (`get_hardware_log_entry`)** — isolate each getter; on failure log once at `LOG_ERROR` and substitute `NaN`, so the logging thread keeps running and continues logging the healthy sensors.

## Scope vs the main-line PR

The main-line fix also (a) sets a timeout on the atca `VirtualClient` and (b) hardens the `check_full_band_resp` AMC-type parse. Neither applies to v4.0.0:
- v4.0.0 reads atca values via `epics.caget`, which already carries pyepics' default timeout (there is no timeout-less `node.get()` path here).
- v4.0.0 has no `check_full_band_resp`/`amc_sn.split('-')[1]` code.

So this backport is scoped to the logger-isolation fix — the direct cause of the freeze.

## Verification

Validated the exact edited loop in isolation (no HW): a getter that raises `ConnectionError` is caught, substituted with `NaN`, and the remaining sensors still log — the thread survives. Byte-compiles cleanly; the edited lines are flake8-clean.