### PR TITLE
fix(docker/server): Update cryo-det to 2.5.1.

### DIFF
--- a/docker/server/definitions.sh
+++ b/docker/server/definitions.sh
@@ -29,7 +29,7 @@
 FW_SYSTEMS=(
     # uMUX (standard microwave multiplexer) systems
     # Uses Primary:False naming -> rogue_MicrowaveMuxBpEthGen2_<tag>.zip
-    "umux|https://github.com/slaclab/cryo-det|MicrowaveMuxBpEthGen2_v2.5.0|MicrowaveMuxBpEthGen2-0x02050000-20260616105622-ruckman-af249f83.mcs|rogue_MicrowaveMuxBpEthGen2_v2.5.0.zip"
+    "umux|https://github.com/slaclab/cryo-det|MicrowaveMuxBpEthGen2_v2.5.1|MicrowaveMuxBpEthGen2-0x02050000-20260616105622-ruckman-af249f83.mcs|rogue_MicrowaveMuxBpEthGen2_v2.5.1.zip"
 
     # NO LONGER BEING DEVELOPED
     ## TKID (transition-edge sensor kinetic inductance detector) systems


### PR DESCRIPTION
Restores the old behavior in `SerialEtaScan` when eta > 1 : don't turn off the channel.